### PR TITLE
Blackbox repository to use HuggingFace as storage backend instead of S3

### DIFF
--- a/examples/training_scripts/nasbench201/nasbench201.py
+++ b/examples/training_scripts/nasbench201/nasbench201.py
@@ -40,8 +40,7 @@ def objective(config):
     dont_sleep = parse_bool(config["dont_sleep"])
 
     ts_start = time.time()
-    s3_root = config.get("blackbox_repo_s3_root")
-    blackbox = load_blackbox(BLACKBOX_NAME, s3_root=s3_root)[config["dataset_name"]]
+    blackbox = load_blackbox(BLACKBOX_NAME)[config["dataset_name"]]
     # We load metric values for all epochs required here
     essential_config = {k: config[k] for k in CONFIG_KEYS}
     fidelity_range = (1, config["epochs"])

--- a/syne_tune/blackbox_repository/conversion_scripts/generate_all_blackboxes.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/generate_all_blackboxes.py
@@ -1,0 +1,18 @@
+"""
+Generates all blackbox recipes locally and upload them to HuggingFace Hub.
+Intended to use for internal developers, you should set HF_TOKEN environment variable to get write access to the hub.
+"""
+from syne_tune.blackbox_repository.conversion_scripts.recipes import (
+    generate_blackbox_recipes,
+)
+
+if __name__ == "__main__":
+    # list all blackboxes available
+    for blackbox, recipe in generate_blackbox_recipes.items():
+        if not "yahpo" in blackbox:
+            continue
+        try:
+            recipe.generate(upload_on_hub=True)
+        except Exception as e:
+            print(f"Failed generating and uploading {blackbox}")
+            print(e)

--- a/syne_tune/blackbox_repository/conversion_scripts/generate_and_upload_all_blackboxes.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/generate_and_upload_all_blackboxes.py
@@ -7,10 +7,7 @@ from syne_tune.blackbox_repository.conversion_scripts.recipes import (
 )
 
 if __name__ == "__main__":
-    # list all blackboxes available
     for blackbox, recipe in generate_blackbox_recipes.items():
-        if not "yahpo" in blackbox:
-            continue
         try:
             recipe.generate(upload_on_hub=True)
         except Exception as e:

--- a/syne_tune/blackbox_repository/conversion_scripts/scripts/fcnet_import.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/scripts/fcnet_import.py
@@ -60,8 +60,6 @@ NUM_UNITS_1 = "hp_n_units_1"
 
 NUM_UNITS_2 = "hp_n_units_2"
 
-SHA256_HASH = "1bb685bbef55ad339c1f81100c66e1fb7755ab4237ee1ed2ff8e59fe05d6df96"
-
 CONFIGURATION_SPACE = {
     "hp_activation_fn_1": choice(["tanh", "relu"]),
     "hp_activation_fn_2": choice(["tanh", "relu"]),
@@ -226,7 +224,6 @@ class FCNETRecipe(BlackboxRecipe):
     def __init__(self):
         super(FCNETRecipe, self).__init__(
             name=BLACKBOX_NAME,
-            hash=SHA256_HASH,
             cite_reference="Tabular benchmarks for joint architecture and hyperparameter optimization. "
             "Klein, A. and Hutter, F. 2019.",
         )

--- a/syne_tune/blackbox_repository/conversion_scripts/scripts/icml2020_import.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/scripts/icml2020_import.py
@@ -25,9 +25,6 @@ from syne_tune.blackbox_repository.conversion_scripts.blackbox_recipe import (
 from syne_tune.blackbox_repository.conversion_scripts.utils import repository_path
 import syne_tune.config_space as sp
 
-SHA256_HASH_DEEPAR = "b282b369daedc2986b3e59646d5e0c6bc93ccb3b4fbec02980f47cd89a002605"
-SHA256_HASH_XGBOOST = "2f6ebb75b2a95614eb783c8d5874cb1dc9e1859e5081fa31e6e46fc9ba56774d"
-
 
 def download(blackbox: str):
     import urllib
@@ -131,7 +128,6 @@ class XGBoostRecipe(BlackboxRecipe):
     def __init__(self):
         super(XGBoostRecipe, self).__init__(
             name="icml-xgboost",
-            hash=SHA256_HASH_XGBOOST,
             cite_reference="A quantile-based approach for hyperparameter transfer learning."
             "Salinas, D., Shen, H., and Perrone, V. 2021.",
         )
@@ -144,7 +140,6 @@ class DeepARRecipe(BlackboxRecipe):
     def __init__(self):
         super(DeepARRecipe, self).__init__(
             name="icml-deepar",
-            hash=SHA256_HASH_DEEPAR,
             cite_reference="A quantile-based approach for hyperparameter transfer learning."
             "Salinas, D., Shen, H., and Perrone, V. 2021.",
         )

--- a/syne_tune/blackbox_repository/conversion_scripts/scripts/nasbench201_import.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/scripts/nasbench201_import.py
@@ -237,7 +237,11 @@ class NASBench201Recipe(BlackboxRecipe):
 
                     session = requests.Session()
 
-                    params = {"id": id, "confirm": "t"}
+                    print(
+                        "TODO fix me, right now this download does not work as google added a warning, "
+                        "file must be downloaded manually for now"
+                    )
+                    params = {"id": id, "confirm": True}
                     response = session.get(URL, params=params, stream=True)
 
                     save_response_content(response, destination)

--- a/syne_tune/blackbox_repository/conversion_scripts/scripts/nasbench201_import.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/scripts/nasbench201_import.py
@@ -43,8 +43,6 @@ METRIC_VALID_ERROR = "metric_valid_error"
 
 METRIC_ELAPSED_TIME = "metric_elapsed_time"
 
-SHA256_HASH = "8828c25ebccb0ba99eefed1b7f97ac4686dc1abb91f352ec9019338f2ae0f558"
-
 # This is time required for the given epoch, not time elapsed
 # since start of training
 METRIC_TIME_THIS_RESOURCE = "metric_runtime"
@@ -217,7 +215,6 @@ class NASBench201Recipe(BlackboxRecipe):
     def __init__(self):
         super(NASBench201Recipe, self).__init__(
             name="nasbench201",
-            hash=SHA256_HASH,
             cite_reference="NAS-Bench-201: Extending the scope of reproducible neural architecture search. "
             "Dong, X. and Yang, Y. 2020.",
         )
@@ -240,7 +237,7 @@ class NASBench201Recipe(BlackboxRecipe):
 
                     session = requests.Session()
 
-                    params = {"id": id, "confirm": True}
+                    params = {"id": id, "confirm": "t"}
                     response = session.get(URL, params=params, stream=True)
 
                     save_response_content(response, destination)

--- a/syne_tune/blackbox_repository/conversion_scripts/scripts/pd1_import.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/scripts/pd1_import.py
@@ -58,8 +58,6 @@ METRIC_ELAPSED_TIME = "metric_elapsed_time"
 
 RESOURCE_ATTR = "global_step"
 
-SHA256_HASH = "bd5b599179b1c5163d146a26dd2d559e5cb561f491ef48a22503e821651fd4d1"
-
 CONFIGURATION_SPACE = {
     "lr_initial_value": loguniform(1e-5, 10),
     "lr_power": uniform(0.1, 2.0),
@@ -136,7 +134,6 @@ class PD1Recipe(BlackboxRecipe):
     def __init__(self):
         super(PD1Recipe, self).__init__(
             name=BLACKBOX_NAME,
-            hash=SHA256_HASH,
             cite_reference="Pre-trained Gaussian processes for Bayesian optimization. "
             "Wang, Z. and Dahl G. and Swersky K. and Lee C. and Mariet Z. and Nado Z. and Gilmer J. and Snoek J. and "
             "Ghahramani Z. 2021.",

--- a/syne_tune/blackbox_repository/conversion_scripts/scripts/yahpo_import.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/scripts/yahpo_import.py
@@ -439,7 +439,7 @@ if __name__ == "__main__":
     # plot one learning-curve for sanity-check
     from syne_tune.blackbox_repository import load_blackbox
 
-    bb_dict = load_blackbox(f"yahpo-{scenario}", skip_if_present=False)
+    bb_dict = load_blackbox(f"yahpo-{scenario}")
     first_task = next(iter(bb_dict.keys()))
     b = bb_dict[first_task]
     configuration = {k: v.sample() for k, v in b.configuration_space.items()}

--- a/syne_tune/blackbox_repository/conversion_scripts/utils.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/utils.py
@@ -10,36 +10,12 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-from typing import Optional
 import os
-import logging
-import hashlib
-import pandas
-from functools import lru_cache
 from pathlib import Path
-
-from syne_tune.try_import import try_import_aws_message
-
-try:
-    import s3fs
-    import sagemaker
-    from botocore.exceptions import NoCredentialsError
-except ImportError:
-    print(try_import_aws_message())
-
-
-@lru_cache(maxsize=1)
-def s3_blackbox_folder(s3_root: Optional[str] = None):
-    if s3_root is None:
-        if "AWS_DEFAULT_REGION" not in os.environ:
-            # avoids error "Must setup local AWS configuration with a region supported by SageMaker."
-            # in case no region is explicitely configured
-            os.environ["AWS_DEFAULT_REGION"] = "us-west-2"
-        s3_root = sagemaker.Session().default_bucket()
-    return f"{s3_root}/blackbox-repository"
-
+from typing import Optional
 
 repository_path = Path("~/.blackbox-repository/").expanduser()
+repo_id = "synetune/blackbox-repository"
 
 
 def get_sub_directory_and_name(name: str):
@@ -61,28 +37,28 @@ def blackbox_local_path(name: str) -> Path:
     return Path(repository_path) / subdir / subname
 
 
-def blackbox_s3_path(name: str, s3_root: Optional[str] = None) -> Path:
-    subdir, subname = get_sub_directory_and_name(name)
-    return Path(s3_blackbox_folder(s3_root)) / subdir / subname
-
-
-def upload_blackbox(name: str, s3_root: Optional[str] = None):
+def upload_blackbox(name: str, custom_repo_id: Optional[str] = None):
     """
-    Uploads a blackbox locally present in repository_path to S3.
+    Uploads a blackbox locally present in repository_path to HuggingFace hub
     :param name: folder must be available in repository_path/name
+    :param custom_repo_id: hugging face hub where the blackbox should be addded
     """
-    try:
-        fs = s3fs.S3FileSystem()
-        local_folder = blackbox_local_path(name)
-        s3_folder = blackbox_s3_path(name, s3_root)
-        for src in local_folder.glob("*"):
-            tgt = f"s3://{s3_folder}/{src.name}"
-            logging.info(f"copy {src} to {tgt}")
-            fs.put(str(src), tgt)
-    except NoCredentialsError:
-        logging.warning(
-            "Unable to locate credentials. Blackbox won't be uploaded to S3."
-        )
+    from huggingface_hub import HfApi
+
+    if name.startswith("yahpo"):
+        _, subname = get_sub_directory_and_name(name)
+        path_in_repo = f"yahpo/{subname}"
+    else:
+        path_in_repo = name
+
+    HfApi().upload_folder(
+        folder_path=blackbox_local_path(name),
+        path_in_repo=path_in_repo,
+        repo_id=repo_id if not custom_repo_id else custom_repo_id,
+        repo_type="dataset",
+        commit_message=f"Upload blackbox {name}",
+        token=os.getenv("HF_TOKEN"),
+    )
 
 
 def download_file(source: str, destination: str):
@@ -94,39 +70,3 @@ def download_file(source: str, destination: str):
         with requests.get(source, stream=True) as r:
             with open(destination, "wb") as f:
                 shutil.copyfileobj(r.raw, f)
-
-
-def compute_hash_binary(filename):
-    h = hashlib.sha256()
-    b = bytearray(128 * 1024)
-    mv = memoryview(b)
-    with open(filename, "rb", buffering=0) as f:
-        for n in iter(lambda: f.readinto(mv), 0):
-            h.update(mv[:n])
-    return h.hexdigest().encode("utf-8")
-
-
-def compute_hash_benchmark(tgt_folder):
-    hashes = []
-    for fname in os.listdir(tgt_folder):
-        if fname.endswith(".parquet"):
-            # Parquet files are non-deterministic across hosts. Compute logical hash of the pandas dataframe.
-            df = pandas.read_parquet(Path(tgt_folder) / fname)
-            h = pandas.util.hash_pandas_object(df.round(decimals=10), index=False).sum()
-        else:
-            h = compute_hash_binary(Path(tgt_folder) / fname)
-        hashes.append(h)
-    aggregated_hash = hashlib.sha256()
-    [aggregated_hash.update(h) for h in hashes]
-    return aggregated_hash.hexdigest()
-
-
-def validate_hash(tgt_folder, original_hash):
-    """
-    Computes hash of the files in tgt_folder and validates it with the original hash
-    :param tgt_folder: target folder that contains the files of the original benchmark
-    :param original_hash: original sha256 hash
-    :return:
-    """
-    current_hash = compute_hash_benchmark(tgt_folder)
-    return original_hash == current_hash

--- a/syne_tune/blackbox_repository/repository.py
+++ b/syne_tune/blackbox_repository/repository.py
@@ -116,7 +116,6 @@ def load_blackbox(
             yahpo_kwargs = dict()
         return instantiate_yahpo(name, **yahpo_kwargs)
     elif name.startswith("pd1"):
-        print(blackbox_path)
         return deserialize_pd1(blackbox_path)
     elif (blackbox_path / "hyperparameters.parquet").exists():
         return deserialize_tabular(blackbox_path)

--- a/syne_tune/blackbox_repository/repository.py
+++ b/syne_tune/blackbox_repository/repository.py
@@ -11,16 +11,9 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 import logging
-from pathlib import Path
 from typing import List, Union, Dict, Optional
 
-from syne_tune.try_import import try_import_aws_message, try_import_yahpo_message
-
-try:
-    import s3fs as s3fs
-    from botocore.exceptions import NoCredentialsError
-except ImportError:
-    print(try_import_aws_message())
+from huggingface_hub import snapshot_download
 
 from syne_tune.blackbox_repository.blackbox import Blackbox
 from syne_tune.blackbox_repository.blackbox_offline import (
@@ -33,21 +26,12 @@ from syne_tune.blackbox_repository.conversion_scripts.scripts.pd1_import import 
     deserialize as deserialize_pd1,
 )
 
-try:
-    from syne_tune.blackbox_repository.conversion_scripts.scripts.yahpo_import import (
-        instantiate_yahpo,
-    )
-except ImportError:
-    print(try_import_yahpo_message())
-
-# where the blackbox repository is stored on s3
 from syne_tune.blackbox_repository.conversion_scripts.recipes import (
     generate_blackbox_recipes,
 )
 from syne_tune.blackbox_repository.conversion_scripts.utils import (
-    validate_hash,
-    blackbox_local_path,
-    blackbox_s3_path,
+    repository_path,
+    repo_id,
 )
 
 logger = logging.getLogger(__name__)
@@ -62,11 +46,11 @@ def blackbox_list() -> List[str]:
 
 def load_blackbox(
     name: str,
-    skip_if_present: bool = True,
-    s3_root: Optional[str] = None,
-    generate_if_not_found: bool = True,
+    custom_repo_id: Optional[str] = None,
     yahpo_kwargs: Optional[dict] = None,
-    ignore_hash: bool = True,  # TODO: Switch back to ``False`` once hash computation fixed
+    local_files_only: bool = False,
+    force_download: bool = False,
+    **snapshot_download_kwargs,
 ) -> Union[Dict[str, Blackbox], Blackbox]:
     """
     :param name: name of a blackbox present in the repository, see
@@ -92,87 +76,52 @@ def load_blackbox(
         * "yahpo-*": Number of different benchmarks from YAHPO Gym. Note that these
           blackboxes come with surrogates already, so no need to wrap them into
           :class:`SurrogateBlackbox`
-
-    :param skip_if_present: skip the download if the file locally exists
-    :param s3_root: S3 root directory for blackbox repository. Defaults to
-        S3 bucket name of SageMaker session
-    :param generate_if_not_found: If the blackbox file is not present locally
-        or on S3, should it be generated using its conversion script?
+    :param custom_repo_id: custom hugging face repoid to use, default to Syne Tune hub
     :param yahpo_kwargs: For a YAHPO blackbox (``name == "yahpo-*"``), these are
         additional arguments to ``instantiate_yahpo``
-    :param ignore_hash: do not check if hash of currently stored files matches the
-        pre-computed hash. Be careful with this option. If hashes do not match, results
-        might not be reproducible.
+    :param local_files_only: whether to use local files with no internet check on the Hub
+    :param force_download: forces files to be downloaded
+    :param snapshot_download_kwargs: keyword arguments for `snapshot_download` (other than local_files_only and force_download)
     :return: blackbox with the given name, download it if not present.
     """
-    tgt_folder = blackbox_local_path(name)
+    assert (
+        name in blackbox_list()
+    ), f"Got {name} but only the following blackboxes are supported {blackbox_list()}."
 
-    expected_hash = generate_blackbox_recipes[name].hash
-
-    if check_blackbox_local_files(tgt_folder) and skip_if_present:
-        if (
-            not ignore_hash
-            and expected_hash is not None
-            and not validate_hash(tgt_folder, expected_hash)
-        ):
-            logger.warning(
-                f"Files seem to be corrupted (hash mismatch), regenerating it locally and persisting it on S3."
-            )
-            generate_blackbox_recipes[name].generate(s3_root=s3_root)
-            if not validate_hash(tgt_folder, expected_hash):
-                Exception(
-                    f"The hash of the files do not match the stored hash after regenerations. "
-                    f"Consider updating the hash and sending a pull-request to change it or set the option ``ignore_hash`` to True."
-                )
-        logger.info(
-            f"Skipping download of {name} as {tgt_folder} already exists, change skip_if_present to redownload"
-        )
+    # download blackbox if not present, we use allow_patterns to download only the files wanted
+    if not name.startswith("yahpo"):
+        allow_patterns = f"{name}/*"
     else:
-        logger.info("Local files not found, attempting to copy from S3.")
-        tgt_folder.mkdir(exist_ok=True, parents=True)
-        try:
-            s3_folder = blackbox_s3_path(name=name, s3_root=s3_root)
-            fs = s3fs.S3FileSystem()
-            data_on_s3 = fs.exists(f"{s3_folder}/metadata.json")
-        except NoCredentialsError:
-            data_on_s3 = False
-        if data_on_s3:
-            logger.info("found blackbox on S3, copying it locally")
-            # download files from s3 to repository_path
-            for src in fs.glob(f"{s3_folder}/*"):
-                tgt = tgt_folder / Path(src).name
-                logger.info(f"copying {src} to {tgt}")
-                fs.get(src, str(tgt))
+        allow_patterns = f"yahpo/*"
 
-            if (
-                not ignore_hash
-                and expected_hash is not None
-                and not validate_hash(tgt_folder, expected_hash)
-            ):
-                logger.warning(
-                    f"Files seem to be corrupted (hash mismatch), regenerating it locally and overwrite files on S3."
-                )
-                generate_blackbox_recipes[name].generate(s3_root=s3_root)
-        else:
-            assert generate_if_not_found, (
-                "Blackbox files do not exist locally or on S3. If you have "
-                + f"write permissions to {s3_folder}, you can set "
-                + "generate_if_not_found=True in order to generate and persist them"
-            )
-            logger.info(
-                "Did not find blackbox files locally nor on S3, regenerating it locally and persisting it on S3."
-            )
-            generate_blackbox_recipes[name].generate(s3_root=s3_root)
+    snapshot_download(
+        repo_id=custom_repo_id if custom_repo_id else repo_id,
+        repo_type="dataset",
+        # for now we use allow_pattern for lack of a better option to specify explicitly the desired blackbox directory
+        allow_patterns=allow_patterns,
+        local_dir=repository_path,
+        force_download=force_download,
+        local_files_only=local_files_only,
+        **snapshot_download_kwargs,
+    )
+
+    # TODO avoid switch case of PD1
+    blackbox_path = repository_path / name
     if name.startswith("yahpo"):
+        from syne_tune.blackbox_repository.conversion_scripts.scripts.yahpo_import import (
+            instantiate_yahpo,
+        )
+
         if yahpo_kwargs is None:
             yahpo_kwargs = dict()
         return instantiate_yahpo(name, **yahpo_kwargs)
     elif name.startswith("pd1"):
-        return deserialize_pd1(tgt_folder)
-    elif (tgt_folder / "hyperparameters.parquet").exists():
-        return deserialize_tabular(tgt_folder)
+        print(blackbox_path)
+        return deserialize_pd1(blackbox_path)
+    elif (blackbox_path / "hyperparameters.parquet").exists():
+        return deserialize_tabular(blackbox_path)
     else:
-        return deserialize_offline(tgt_folder)
+        return deserialize_offline(blackbox_path)
 
 
 def check_blackbox_local_files(tgt_folder) -> bool:

--- a/syne_tune/blackbox_repository/requirements.txt
+++ b/syne_tune/blackbox_repository/requirements.txt
@@ -1,7 +1,10 @@
 numpy>=1.16.0, <1.27.0
 pandas
-fastparquet
-s3fs
+
+# required for surrogates
 scikit-learn
 xgboost
-h5py # note: only needed for fcnet
+
+# required to load datasets
+fastparquet
+h5py # note: only needed for fcnet for high compression

--- a/syne_tune/blackbox_repository/requirements.txt
+++ b/syne_tune/blackbox_repository/requirements.txt
@@ -8,3 +8,6 @@ xgboost
 # required to load datasets
 fastparquet
 h5py # note: only needed for fcnet for high compression
+
+# required to download datasets
+huggingface_hub


### PR DESCRIPTION
Because the options of HF hub are different than what was supported in BB repository, the options now looks a bit different but I did my best to maintain option parity when possible.
The hash is not needed anymore since HF hub supports it.

I have noted an issue with LCBench data as an error is thrown now with a pandas update. I have sent an email to the authors and hotfixed the blackbox import code so that it can run with newer pandas code.