### PR TITLE
fix: import syne-tune's ask-tell scheduler

### DIFF
--- a/examples/launch_ask_tell_scheduler.py
+++ b/examples/launch_ask_tell_scheduler.py
@@ -18,74 +18,18 @@ Once done, user feeds the result into the Scheduler which uses the data to sugge
 
 
 In some cases, experiments needed for function evaluations can be very complex and require extra orchestration
-(example vary from setting up jobs on non-aws clusters to runnig physical lab experiments) in which case this
+(example vary from setting up jobs on non-aws clusters to running physical lab experiments) in which case this
 interface provides all the necessary flexibility
 """
-from typing import Dict
-import datetime
 import logging
 
 import dill
 import numpy as np
 
-from syne_tune.backend.trial_status import Trial, Status, TrialResult
+from syne_tune.backend.trial_status import TrialResult
 from syne_tune.config_space import uniform
 from syne_tune.optimizer.baselines import RandomSearch, BayesianOptimization
-from syne_tune.optimizer.scheduler import TrialScheduler
-
-
-class AskTellScheduler:
-    bscheduler: TrialScheduler
-    trial_counter: int
-    completed_experiments: Dict[int, TrialResult]
-
-    def __init__(self, base_scheduler: TrialScheduler):
-        self.bscheduler = base_scheduler
-        self.trial_counter = 0
-        self.completed_experiments = {}
-
-    def ask(self) -> Trial:
-        """
-        Ask the scheduler for new trial to run
-        :return: Trial to run
-        """
-        trial_suggestion = self.bscheduler.suggest(self.trial_counter)
-        trial = Trial(
-            trial_id=self.trial_counter,
-            config=trial_suggestion.config,
-            creation_time=datetime.datetime.now(),
-        )
-        self.trial_counter += 1
-        return trial
-
-    def tell(self, trial: Trial, experiment_result: Dict[str, float]):
-        """
-        Feed experiment results back to the Scheduler
-
-        :param trial: Trial that was run
-        :param experiment_result: {metric: value} dictionary with experiment results
-        """
-        trial_result = trial.add_results(
-            metrics=experiment_result,
-            status=Status.completed,
-            training_end_time=datetime.datetime.now(),
-        )
-        self.bscheduler.on_trial_complete(trial=trial, result=experiment_result)
-        self.completed_experiments[trial_result.trial_id] = trial_result
-
-    def best_trial(self, metric: str) -> TrialResult:
-        """
-        Return the best trial according to the provided metric
-        """
-        if self.bscheduler.mode == "max":
-            sign = 1.0
-        else:
-            sign = -1.0
-
-        return max(
-            [value for key, value in self.completed_experiments.items()],
-            key=lambda trial: sign * trial.metrics[metric],
-        )
+from syne_tune.optimizer.schedulers.ask_tell_scheduler import AskTellScheduler
 
 
 def target_function(x, noise: bool = True):

--- a/examples/launch_ask_tell_scheduler_hyperband.py
+++ b/examples/launch_ask_tell_scheduler_hyperband.py
@@ -19,7 +19,7 @@ Once done, user feeds the result into the Scheduler which uses the data to sugge
 
 
 In some cases, experiments needed for function evaluations can be very complex and require extra orchestration
-(example vary from setting up jobs on non-aws clusters to runnig physical lab experiments) in which case this
+(example vary from setting up jobs on non-aws clusters to running physical lab experiments) in which case this
 interface provides all the necessary flexibility
 
 This is an extension of launch_ask_tell_scheduler.py to run multi-fidelity methods such as Hyperband
@@ -30,7 +30,7 @@ from typing import Tuple
 
 import numpy as np
 
-from examples.launch_ask_tell_scheduler import AskTellScheduler
+from syne_tune.optimizer.schedulers.ask_tell_scheduler import AskTellScheduler
 from syne_tune.backend.trial_status import Trial, TrialResult
 from syne_tune.config_space import uniform
 from syne_tune.optimizer.baselines import ASHA


### PR DESCRIPTION
Adapts the example files for ask-tell interface to load Syne-Tune's ask-tell scheduler. 

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
