### PR TITLE
refactor: simplify searcher interface

### DIFF
--- a/syne_tune/optimizer/schedulers/asha.py
+++ b/syne_tune/optimizer/schedulers/asha.py
@@ -128,9 +128,9 @@ class AsynchronousSuccessiveHalving(TrialScheduler):
 
     def on_trial_result(self, trial: Trial, result: Dict[str, Any]) -> str:
         config = remove_constant_and_cast(trial.config, self.config_space)
-        observation = result[self.metric] * self.metric_multiplier
+        metric = result[self.metric] * self.metric_multiplier
         self.searcher.on_trial_result(
-            trial.trial_id, config, observation=observation, update=False
+            trial.trial_id, config, metric=metric, update=False
         )
         self._check_metrics_are_present(result)
         if result[self.time_attr] >= self.max_t:
@@ -149,9 +149,9 @@ class AsynchronousSuccessiveHalving(TrialScheduler):
     def on_trial_complete(self, trial: Trial, result: Dict[str, Any]):
 
         config = remove_constant_and_cast(trial.config, self.config_space)
-        observation = result[self.metric] * self.metric_multiplier
+        metric = result[self.metric] * self.metric_multiplier
         self.searcher.on_trial_result(
-            trial.trial_id, config, observation=observation, update=True
+            trial.trial_id, config, metric=metric, update=True
         )
 
         self._check_metrics_are_present(result)

--- a/syne_tune/optimizer/schedulers/searchers/searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/searcher.py
@@ -40,7 +40,7 @@ class BaseSearcher:
             self.points_to_evaluate = []
 
         if random_seed is None:
-            self.random_seed = np.random.randint(0, 2 ** 31 - 1)
+            self.random_seed = np.random.randint(0, 2**31 - 1)
         else:
             self.random_seed = random_seed
 

--- a/syne_tune/optimizer/schedulers/single_fidelity_scheduler.py
+++ b/syne_tune/optimizer/schedulers/single_fidelity_scheduler.py
@@ -100,9 +100,9 @@ class SingleFidelityScheduler(TrialScheduler):
         :return: Decision what to do with the trial
         """
         config = remove_constant_and_cast(trial.config, self.config_space)
-        observation = result[self.metric] * self.metric_multiplier
+        metric = result[self.metric] * self.metric_multiplier
         self.searcher.on_trial_result(
-            trial.trial_id, config, observation=observation, update=False
+            trial.trial_id, config, metric=metric, update=False
         )
         return SchedulerDecision.CONTINUE
 
@@ -117,9 +117,9 @@ class SingleFidelityScheduler(TrialScheduler):
         :param result: Result dictionary
         """
         config = remove_constant_and_cast(trial.config, self.config_space)
-        observation = result[self.metric] * self.metric_multiplier
+        metric = result[self.metric] * self.metric_multiplier
         self.searcher.on_trial_result(
-            trial.trial_id, config, observation=observation, update=True
+            trial.trial_id, config, metric=metric, update=True
         )
 
     def metadata(self) -> Dict[str, Any]:


### PR DESCRIPTION
- removes some boilerplate from BaseSearcher
- consistent naming
- handle random seeds
----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
