### PR TITLE
refactor: make SingleFidelityScheduler compatible with tuner

### DIFF
--- a/syne_tune/optimizer/schedulers/single_fidelity_scheduler.py
+++ b/syne_tune/optimizer/schedulers/single_fidelity_scheduler.py
@@ -132,3 +132,9 @@ class SingleFidelityScheduler(TrialScheduler):
         )
         metadata["config_space"] = config_space_json
         return metadata
+
+    def metric_names(self) -> List[str]:
+        return self.metrics
+
+    def metric_mode(self) -> str:
+        return "min" if self.do_minimize else "max"

--- a/syne_tune/tuner.py
+++ b/syne_tune/tuner.py
@@ -493,7 +493,11 @@ class Tuner:
             not suggest a new configuration (this can happen if its configuration
             space is exhausted)
         """
-        suggestion = self.scheduler.suggest(trial_id=self.trial_backend.new_trial_id())
+
+        if isinstance(self.scheduler, TrialScheduler):
+            suggestion = self.scheduler.suggest()
+        else:
+            suggestion = self.scheduler.suggest(self.trial_backend.new_trial_id())
         if suggestion is None:
             logger.info("Searcher ran out of candidates, tuning job is stopping.")
             raise StopIteration

--- a/syne_tune/tuner.py
+++ b/syne_tune/tuner.py
@@ -497,7 +497,9 @@ class Tuner:
         if isinstance(self.scheduler, TrialScheduler):
             suggestion = self.scheduler.suggest()
         else:
-            logger.warning(f"Scheduler {type(self.scheduler).__name__} is deprecated and will be removed in the next release!")
+            logger.warning(
+                f"Scheduler {type(self.scheduler).__name__} is deprecated and will be removed in the next release!"
+            )
             suggestion = self.scheduler.suggest(self.trial_backend.new_trial_id())
         if suggestion is None:
             logger.info("Searcher ran out of candidates, tuning job is stopping.")

--- a/syne_tune/tuner.py
+++ b/syne_tune/tuner.py
@@ -497,6 +497,7 @@ class Tuner:
         if isinstance(self.scheduler, TrialScheduler):
             suggestion = self.scheduler.suggest()
         else:
+            logger.warning(f"Scheduler {type(self.scheduler).__name__} is deprecated and will be removed in the next release!")
             suggestion = self.scheduler.suggest(self.trial_backend.new_trial_id())
         if suggestion is None:
             logger.info("Searcher ran out of candidates, tuning job is stopping.")


### PR DESCRIPTION
Makes the `SingleFidelityScheduler` compatible with `Tuner`, and allows to use `Tuner` both with new and legacy schedulers.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
