### PR TITLE
fix: constrain sklearn < 1.6

### DIFF
--- a/requirements-sklearn.txt
+++ b/requirements-sklearn.txt
@@ -1,1 +1,1 @@
-scikit-learn
+scikit-learn==1.5.2

--- a/requirements-sklearn.txt
+++ b/requirements-sklearn.txt
@@ -1,1 +1,1 @@
-scikit-learn==1.5.2
+scikit-learn<1.6


### PR DESCRIPTION
Current CI fails because of https://github.com/scikit-learn/scikit-learn/issues/30450
Constrain to version number temporarily until this will be fixed.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
