### PR TITLE
refactor: median stopping rule

### DIFF
--- a/benchmarking/nursery/benchmark_automl/baselines.py
+++ b/benchmarking/nursery/benchmark_automl/baselines.py
@@ -7,7 +7,7 @@ from syne_tune.blackbox_repository.simulated_tabular_backend import (
 from syne_tune.optimizer.baselines import ZeroShotTransfer
 from syne_tune.optimizer.schedulers.hyperband import HyperbandScheduler
 from syne_tune.optimizer.schedulers.fifo import FIFOScheduler
-from syne_tune.optimizer.schedulers.median_stopping_rule import MedianStoppingRule
+from syne_tune.optimizer.schedulers.legacy_median_stopping_rule import LegacyMedianStoppingRule
 from syne_tune.optimizer.schedulers.transfer_learning import RUSHScheduler
 from syne_tune.optimizer.schedulers.transfer_learning.bounding_box import BoundingBox
 from syne_tune.optimizer.schedulers.searchers.regularized_evolution import (
@@ -79,7 +79,7 @@ methods = {
         random_seed=method_arguments.random_seed,
         **_max_resource_attr_or_max_t(method_arguments),
     ),
-    Methods.MSR: lambda method_arguments: MedianStoppingRule(
+    Methods.MSR: lambda method_arguments: LegacyMedianStoppingRule(
         scheduler=FIFOScheduler(
             config_space=method_arguments.config_space,
             searcher="random",

--- a/benchmarking/nursery/benchmark_automl/baselines.py
+++ b/benchmarking/nursery/benchmark_automl/baselines.py
@@ -7,7 +7,9 @@ from syne_tune.blackbox_repository.simulated_tabular_backend import (
 from syne_tune.optimizer.baselines import ZeroShotTransfer
 from syne_tune.optimizer.schedulers.hyperband import HyperbandScheduler
 from syne_tune.optimizer.schedulers.fifo import FIFOScheduler
-from syne_tune.optimizer.schedulers.legacy_median_stopping_rule import LegacyMedianStoppingRule
+from syne_tune.optimizer.schedulers.legacy_median_stopping_rule import (
+    LegacyMedianStoppingRule,
+)
 from syne_tune.optimizer.schedulers.transfer_learning import RUSHScheduler
 from syne_tune.optimizer.schedulers.transfer_learning.bounding_box import BoundingBox
 from syne_tune.optimizer.schedulers.searchers.regularized_evolution import (

--- a/syne_tune/optimizer/schedulers/__init__.py
+++ b/syne_tune/optimizer/schedulers/__init__.py
@@ -2,7 +2,9 @@ import logging
 
 from syne_tune.optimizer.schedulers.fifo import FIFOScheduler
 from syne_tune.optimizer.schedulers.hyperband import HyperbandScheduler
-from syne_tune.optimizer.schedulers.legacy_median_stopping_rule import LegacyMedianStoppingRule
+from syne_tune.optimizer.schedulers.legacy_median_stopping_rule import (
+    LegacyMedianStoppingRule,
+)
 from syne_tune.optimizer.schedulers.pbt import PopulationBasedTraining
 
 __all__ = [

--- a/syne_tune/optimizer/schedulers/__init__.py
+++ b/syne_tune/optimizer/schedulers/__init__.py
@@ -2,13 +2,13 @@ import logging
 
 from syne_tune.optimizer.schedulers.fifo import FIFOScheduler
 from syne_tune.optimizer.schedulers.hyperband import HyperbandScheduler
-from syne_tune.optimizer.schedulers.median_stopping_rule import MedianStoppingRule
+from syne_tune.optimizer.schedulers.legacy_median_stopping_rule import LegacyMedianStoppingRule
 from syne_tune.optimizer.schedulers.pbt import PopulationBasedTraining
 
 __all__ = [
     "FIFOScheduler",
     "HyperbandScheduler",
-    "MedianStoppingRule",
+    "LegacyMedianStoppingRule",
     "PopulationBasedTraining",
 ]
 

--- a/syne_tune/optimizer/schedulers/legacy_median_stopping_rule.py
+++ b/syne_tune/optimizer/schedulers/legacy_median_stopping_rule.py
@@ -58,7 +58,9 @@ class LegacyMedianStoppingRule(LegacyTrialScheduler):
         grace_population: int = 5,
         rank_cutoff: float = 0.5,
     ):
-        super(LegacyMedianStoppingRule, self).__init__(config_space=scheduler.config_space)
+        super(LegacyMedianStoppingRule, self).__init__(
+            config_space=scheduler.config_space
+        )
         if metric is None and hasattr(scheduler, "metric"):
             metric = getattr(scheduler, "metric")
         self.metric = metric

--- a/syne_tune/optimizer/schedulers/median_stopping_rule.py
+++ b/syne_tune/optimizer/schedulers/median_stopping_rule.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-from typing import Optional, Dict, List, Any
+from typing import Optional, Dict, Any
 
 import numpy as np
 
@@ -10,8 +10,6 @@ from syne_tune.optimizer.scheduler import (
     SchedulerDecision,
     TrialSuggestion,
 )
-from syne_tune.config_space import config_space_to_json_dict
-from syne_tune.util import dump_json_with_numpy
 
 
 logger = logging.getLogger(__name__)

--- a/syne_tune/optimizer/schedulers/median_stopping_rule.py
+++ b/syne_tune/optimizer/schedulers/median_stopping_rule.py
@@ -77,10 +77,8 @@ class MedianStoppingRule(TrialScheduler):
 
         self.metric_multiplier = 1 if do_minimize else -1
 
-
         if running_average:
             self.trial_to_results = defaultdict(list)
-
 
     def suggest(self) -> Optional[TrialSuggestion]:
         return self.scheduler.suggest()
@@ -129,7 +127,6 @@ class MedianStoppingRule(TrialScheduler):
             return True
         return False
 
-    
     def metadata(self) -> Dict[str, Any]:
         """
         :return: Metadata for the scheduler

--- a/tst/schedulers/test_legacy_schedulers_api.py
+++ b/tst/schedulers/test_legacy_schedulers_api.py
@@ -47,7 +47,7 @@ from syne_tune.optimizer.schedulers.searchers.conformal.legacy_surrogate_searche
 from syne_tune.optimizer.scheduler import SchedulerDecision
 from syne_tune.optimizer.schedulers import (
     FIFOScheduler,
-    MedianStoppingRule,
+    LegacyMedianStoppingRule,
     HyperbandScheduler,
     PopulationBasedTraining,
     RayTuneScheduler,
@@ -296,7 +296,7 @@ list_schedulers_to_test = [
         metrics=[metric1, metric2],
         mode=mode,
     ),
-    MedianStoppingRule(
+    LegacyMedianStoppingRule(
         scheduler=FIFOScheduler(
             config_space, searcher="random", metric=metric1, mode=mode
         ),

--- a/tst/schedulers/test_schedulers_api.py
+++ b/tst/schedulers/test_schedulers_api.py
@@ -103,7 +103,9 @@ list_schedulers_to_test = [
     ),
     MedianStoppingRule(
         scheduler=SingleObjectiveScheduler(
-            config_space, searcher="random_search", metric=metric1,
+            config_space,
+            searcher="random_search",
+            metric=metric1,
         ),
         resource_attr=resource_attr,
         metric=metric1,

--- a/tst/schedulers/test_schedulers_api.py
+++ b/tst/schedulers/test_schedulers_api.py
@@ -110,7 +110,7 @@ list_schedulers_to_test = [
         ),
         resource_attr=resource_attr,
         metric=metric1,
-        random_seed=random_seed
+        random_seed=random_seed,
     ),
     AsynchronousSuccessiveHalving(
         config_space=config_space,

--- a/tst/schedulers/test_schedulers_api.py
+++ b/tst/schedulers/test_schedulers_api.py
@@ -18,6 +18,7 @@ from syne_tune.optimizer.schedulers.single_objective_scheduler import (
 )
 
 from syne_tune.config_space import randint, uniform, choice
+from syne_tune.optimizer.schedulers.median_stopping_rule import MedianStoppingRule
 
 config_space = {
     "steps": 100,
@@ -99,6 +100,13 @@ list_schedulers_to_test = [
         metrics=[metric1, metric2],
         do_minimize=False,
         random_seed=random_seed,
+    ),
+    MedianStoppingRule(
+        scheduler=SingleObjectiveScheduler(
+            config_space, searcher="random_search", metric=metric1,
+        ),
+        resource_attr=resource_attr,
+        metric=metric1,
     ),
 ]
 

--- a/tst/test_median_stopping_rule.py
+++ b/tst/test_median_stopping_rule.py
@@ -1,8 +1,4 @@
 from datetime import datetime
-from functools import partial
-
-import pytest
-import numpy as np
 
 from syne_tune.backend.trial_status import Trial
 from syne_tune.optimizer.scheduler import SchedulerDecision

--- a/tst/test_median_stopping_rule.py
+++ b/tst/test_median_stopping_rule.py
@@ -1,0 +1,62 @@
+from datetime import datetime
+from functools import partial
+
+import pytest
+import numpy as np
+
+from syne_tune.backend.trial_status import Trial
+from syne_tune.optimizer.scheduler import SchedulerDecision
+from syne_tune.optimizer.schedulers.median_stopping_rule import MedianStoppingRule
+from syne_tune.config_space import randint
+
+from syne_tune.optimizer.schedulers.single_objective_scheduler import (
+    SingleObjectiveScheduler,
+)
+
+max_steps = 10
+
+config_space = {
+    "steps": max_steps,
+    "width": randint(0, 20),
+}
+time_attr = "step"
+metric = "mean_loss"
+
+
+def make_trial(trial_id: int):
+    return Trial(
+        trial_id=trial_id,
+        config={"steps": 0, "width": trial_id},
+        creation_time=datetime.now(),
+    )
+
+
+def test_median_stopping_rule():
+    random_seed = 42
+    scheduler = MedianStoppingRule(
+        scheduler = SingleObjectiveScheduler(
+            config_space,
+            searcher="random_search",
+            metric=metric,
+        ),
+        resource_attr = 'step',
+        metric = metric,
+        random_seed=random_seed,
+        grace_population=1,
+    )
+
+    trial1 = make_trial(trial_id=0)
+    trial2 = make_trial(trial_id=1)
+    trial3 = make_trial(trial_id=2)
+
+    scheduler.on_trial_add(trial=trial1)
+    scheduler.on_trial_add(trial=trial2)
+    scheduler.on_trial_add(trial=trial3)
+
+    make_metric = lambda x: {time_attr: 1, metric: x}
+    decision1 = scheduler.on_trial_result(trial1, make_metric(2.0))
+    decision2 = scheduler.on_trial_result(trial2, make_metric(1.0))
+    decision3 = scheduler.on_trial_result(trial3, make_metric(5.0))
+    assert decision1 == SchedulerDecision.CONTINUE
+    assert decision2 == SchedulerDecision.CONTINUE
+    assert decision3 == SchedulerDecision.STOP

--- a/tst/test_median_stopping_rule.py
+++ b/tst/test_median_stopping_rule.py
@@ -34,13 +34,13 @@ def make_trial(trial_id: int):
 def test_median_stopping_rule():
     random_seed = 42
     scheduler = MedianStoppingRule(
-        scheduler = SingleObjectiveScheduler(
+        scheduler=SingleObjectiveScheduler(
             config_space,
             searcher="random_search",
             metric=metric,
         ),
-        resource_attr = 'step',
-        metric = metric,
+        resource_attr="step",
+        metric=metric,
         random_seed=random_seed,
         grace_population=1,
     )


### PR DESCRIPTION
- Uses new scheduler interface for median stopping rule #879 
- Deprecates old scheduler
- Adds additional unit test

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
