### PR TITLE
fix: update to v4 actions 

### DIFF
--- a/.github/workflows/run-notebooks.yml
+++ b/.github/workflows/run-notebooks.yml
@@ -24,7 +24,7 @@ jobs:
         id: set-matrix
         run: python ./.github/workflows/utils/notebooks2scripts.py
       - name: Upload converted python script
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: converted_notebooks
           path: examples/notebooks/

--- a/.github/workflows/run-notebooks.yml
+++ b/.github/workflows/run-notebooks.yml
@@ -24,7 +24,7 @@ jobs:
         id: set-matrix
         run: python ./.github/workflows/utils/notebooks2scripts.py
       - name: Upload converted python script
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@v4
         with:
           name: converted_notebooks
           path: examples/notebooks/

--- a/.github/workflows/run-syne-tune.yml
+++ b/.github/workflows/run-syne-tune.yml
@@ -67,7 +67,7 @@ jobs:
         run: python -m pip install -e '.[${{ inputs.extras-require }}]'
       - name: Download artifact (must have been previously uploaded via actions/upload-artifact)
         if: ${{ inputs.download-artifact-path != '' }}
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: ${{ inputs.download-artifact-name }}
           path: ${{ inputs.download-artifact-path }}


### PR DESCRIPTION
Update to v4 actions:
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
