### PR TITLE
fix: trial id in surrogate searcher

### DIFF
--- a/syne_tune/optimizer/schedulers/searchers/conformal/surrogate_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/conformal/surrogate_searcher.py
@@ -62,23 +62,20 @@ class SurrogateSearcher(SingleObjectiveBaseSearcher):
         self.random_state = np.random.RandomState(self.random_seed)
 
     def suggest(self, **kwargs) -> Optional[Dict[str, Any]]:
-        trial_id = len(self.trial_configs)
-        logger.debug(f"get_config trial {trial_id}, {self.num_results()} results")
         config = self._next_points_to_evaluate()
 
         if config is None:
             if self.should_update():
-                logger.debug(f"trial {trial_id}: fit model")
+                logger.debug(f"fit model")
                 with catchtime(f"fit model with {self.num_results()} observations"):
                     self.fit_model()
                 self.index_last_result_fit = self.num_results()
             if self.surrogate_model is not None:
-                logger.debug(f"trial {trial_id}: sample from model")
+                logger.debug(f"sample from model")
                 config = self.surrogate_model.suggest()
             else:
-                logger.debug(f"trial {trial_id}: sample at random")
+                logger.debug(f"sample at random")
                 config = self.sample_random()
-        self.trial_configs[trial_id] = config
         return config
 
     def should_update(self) -> bool:
@@ -126,7 +123,7 @@ class SurrogateSearcher(SingleObjectiveBaseSearcher):
         metric: float,
         resource_level: int = None,
     ):
-
+        self.trial_configs[trial_id] = config
         self.trial_results[trial_id].append(metric)
 
     def on_trial_result(
@@ -136,6 +133,7 @@ class SurrogateSearcher(SingleObjectiveBaseSearcher):
         metric: float,
         resource_level: int = None,
     ):
+        self.trial_configs[trial_id] = config
         self.trial_results[trial_id].append(metric)
 
     def sample_random(self) -> Dict:


### PR DESCRIPTION
We shouldn't set a trial-id in the suggest function. Instead we record configs  in `on_trial_complete` / `on_trial_result` directly to avoid miss match. 

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
