### PR TITLE
fix: change seed for base searcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,32 +9,21 @@
 
 ![Syne Tune](docs/source/synetune.gif)
 
-**[Documentation](https://syne-tune.readthedocs.io/en/latest/index.html)** | **[Tutorials](https://syne-tune.readthedocs.io/en/latest/tutorials/basics/README.html)** | **[API Reference](https://syne-tune.readthedocs.io/en/latest/_apidoc/modules.html#)** | **[PyPI](https://pypi.org/project/syne-tune)** | **[Latest Blog Post](https://aws.amazon.com/blogs/machine-learning/hyperparameter-optimization-for-fine-tuning-pre-trained-transformer-models-from-hugging-face/)** | **[Discord](https://discord.gg/vzYkjZjs)** 
+**[Documentation](https://syne-tune.readthedocs.io/en/latest/index.html)** | **[Blackboxes](https://github.com/syne-tune/syne-tune/blob/main/syne_tune/blackbox_repository/README.md)** | **[Benchmarking](https://github.com/syne-tune/syne-tune/blob/main/benchmarking/README.md)** | **[API Reference](https://syne-tune.readthedocs.io/en/latest/_apidoc/modules.html#)** | **[PyPI](https://pypi.org/project/syne-tune)** | **[Latest Blog Post](https://aws.amazon.com/blogs/machine-learning/hyperparameter-optimization-for-fine-tuning-pre-trained-transformer-models-from-hugging-face/)** | **[Discord](https://discord.gg/vzYkjZjs)** 
 
-Syne Tune provides state-of-the-art algorithms for hyperparameter optimization (HPO) with the following key features:
-* **Lightweight and platform-agnostic**: Syne Tune is designed to work with
-  different execution backends, so you are not locked into a particular
-  distributed system architecture. Syne Tune runs with minimal dependencies.
-* **Wide coverage of different HPO methods**: Syne Tune supports more than 20 different optimization methods across [multi-fidelity HPO](https://syne-tune.readthedocs.io/en/latest/tutorials/multifidelity/README.html), [constrained HPO](https://syne-tune.readthedocs.io/en/latest/tutorials/basics/basics_outlook.html#further-topics), [multi-objective HPO](https://syne-tune.readthedocs.io/en/latest/getting_started.html#supported-multi-objective-optimization-methods), [transfer learning](https://syne-tune.readthedocs.io/en/latest/tutorials/transfer_learning/transfer_learning.html), [cost-aware HPO](https://syne-tune.readthedocs.io/en/latest/_apidoc/syne_tune.optimizer.schedulers.searchers.cost_aware.html), and [population-based training](https://syne-tune.readthedocs.io/en/latest/_apidoc/syne_tune.optimizer.schedulers.pbt.html).
-* **Simple, modular design**: Rather than wrapping other HPO
-  frameworks, Syne Tune provides simple APIs and scheduler templates, which can
-  easily be [extended to your specific needs](https://syne-tune.readthedocs.io/en/latest/tutorials/developer/README.html).
-  Studying the code will allow you to understand what the different algorithms
-  are doing, and how they differ from each other.
-* **Industry-strength Bayesian optimization**: Syne Tune has comprehensive support
-  for [Gaussian Process-based Bayesian optimization](https://syne-tune.readthedocs.io/en/latest/tutorials/basics/basics_bayesopt.html).
-  The same code powers modalities such as multi-fidelity HPO, constrained HPO, and
-  cost-aware HPO, and has been tried and tested in production for several years.
-* **Support for distributed workloads**: Syne Tune lets you move fast, thanks to the parallel compute resources AWS SageMaker offers. Syne Tune allows ML/AI practitioners to easily set up and run studies with many [experiments running in parallel](https://syne-tune.readthedocs.io/en/latest/tutorials/experimentation/README.html). Run on different compute environments (locally, AWS, simulation) by changing just one line of code.
-* **Out-of-the-box tabulated benchmarks:** Tabulated benchmarks let you simulate results in seconds while preserving the real dynamics of asynchronous or synchronous HPO with any number of workers.
+Syne Tune is a library for large-scale hyperparameter optimization (HPO) with the following key features:
 
+- State-of-the-art HPO methods for multi-fidelity optimization, multi-objective optimization, transfer learning, and population-based training.
 
-Syne Tune is developed in collaboration with the team behind the [Automatic Model Tuning](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning.html) service.
+- Simple, modular design that lets you easily implement your own HPO searcher or scheduler.
 
+- Tooling that lets you run [large-scale experimentation](https://github.com/syne-tune/syne-tune/blob/main/benchmarking/README.md) either locally or on SLURM clusters.
+
+- Extensive [collection of blackboxes](https://github.com/syne-tune/syne-tune/blob/main/syne_tune/blackbox_repository/README.md) including surrogate and tabular benchmarks for efficient HPO simulation.
 
 ## Installing
 
-To install Syne Tune from pip, you can simply do:
+To install Syne Tune from pip:
 
 ```bash
 pip install 'syne-tune[basic]'
@@ -45,23 +34,37 @@ or to install the latest version from source:
 ```bash
 git clone https://github.com/awslabs/syne-tune.git
 cd syne-tune
-python3 -m venv st_venv
-. st_venv/bin/activate
-pip install --upgrade pip
 pip install -e '.[basic]'
 ```
-
-This installs everything in a virtual environment `st_venv`. Remember to activate
-this environment before working with Syne Tune. We also recommend building the
-virtual environment from scratch now and then, in particular when you pull a new
-release, as dependencies may have changed.
 
 See our [change log](CHANGELOG.md) to see what changed in the latest version. 
 
 ## Getting started
 
-To enable tuning, you have to report metrics from a training script so that they can be communicated later to Syne Tune,
-this can be accomplished by just calling `report(epoch=epoch, loss=loss)` as shown in the example below:
+Syne Tune assumes some python script that given hyperparameter as input arguments trains and validates a machine learning model that
+somewhat follows this pattern:
+
+```python
+from argparse import ArgumentParser
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser.add_argument('--epochs', type=int)
+    parser.add_argument('--hyperparameter1', type=float)
+    parser.add_argument('--hyperparameter3', type=float)
+    args, _ = parser.parse_known_args()
+    # instantiate your machine learning model
+    for epoch in range(args.epochs):  # training loop
+        # train for some steps or epoch
+        ...
+        # validate your model on some hold-out validation data
+```
+
+### Step 1: Adapt your training script
+
+First, to enable tuning of your training script, you need to report metrics so they can be communicated to Syne Tune.
+For example, in the script above, we assume you're tuning two hyperparameters — `height` and `width` — to minimize a loss function.
+To report the loss back to Syne Tune after each epoch, simply add `report(epoch=epoch, loss=loss)` inside your training loop:
 
 ```python
 # train_height_simple.py
@@ -87,7 +90,11 @@ if __name__ == '__main__':
         report(epoch=step + 1, mean_loss=dummy_score)
 ```
 
-Once you have a training script reporting a metric, you can launch a tuning as follows:
+### Step 2: Define a launching script
+
+Once the training script is prepared, we first define the search space and then start the tuning process.
+In this example, we launch [ASHA] for a total of 30 seconds using four workers.
+Each worker spawns a separate Python process to evaluate a hyperparameter configuration, meaning that four configurations are trained in parallel.
 
 ```python
 # launch_height_simple.py
@@ -108,178 +115,32 @@ tuner = Tuner(
     scheduler=ASHA(
         config_space,
         metric='mean_loss',
-        resource_attr='epoch',
-        max_resource_attr="epochs",
-        search_options={'debug_log': False},
+        time_attr='epoch',
     ),
-    stop_criterion=StoppingCriterion(max_wallclock_time=30),
+    stop_criterion=StoppingCriterion(max_wallclock_time=30), # total runtime in seconds
     n_workers=4,  # how many trials are evaluated in parallel
 )
 tuner.run()
 ```
 
-The above example runs ASHA with 4 asynchronous workers on a local machine.
+### Step 3: Plot the results
 
-## Experimentation with Syne Tune
+Next, we can plot the results as follows. Replace `TUNER_NAME` with the name of the tuning job 
+used earlier — this is shown at the beginning of the logs.
 
-If you plan to use advanced features of Syne Tune, such as different execution
-backends or running experiments remotely, writing launcher scripts like
-`examples/launch_height_simple.py` can become tedious. Syne Tune provides an
-advanced experimentation framework, which you can learn about in
-[this tutorial](https://syne-tune.readthedocs.io/en/latest/tutorials/experimentation/README.html)
-or also in
-[this one](https://syne-tune.readthedocs.io/en/latest/tutorials/odsc_tutorial/README.html).
+```python
+import matplotlib.pyplot as plt
+from syne_tune.experiments import load_experiment
 
-## Supported HPO methods
+e = load_experiment('TUNER_NAME')  # name of the tuning run which is printed at the beginning of the run
+e.plot_trials_over_time(metric_to_plot='mean_loss')
+plt.show()
+```
 
-The following hyperparameter optimization (HPO) methods are available in Syne Tune:
 
-Method | Reference | Searcher | Asynchronous? | Multi-fidelity? | Transfer? 
-:--- | :---: | :---: | :---: | :---: | :---: 
-Grid Search |  | deterministic | yes | no | no 
-Random Search | Bergstra, et al. (2011) | random | yes | no | no 
-Bayesian Optimization | Snoek, et al. (2012) | model-based | yes | no | no 
-BORE | Tiao, et al. (2021) | model-based | yes | no | no 
-CQR | Salinas, et al. (2023) | model-based | yes | no | no 
-MedianStoppingRule | Golovin, et al. (2017) | any | yes | yes | no 
-SyncHyperband | Li, et al. (2018) | random | no | yes | no 
-SyncBOHB | Falkner, et al. (2018) | model-based | no | yes | no 
-SyncMOBSTER | Klein, et al. (2020) | model-based | no | yes | no 
-ASHA | Li, et al. (2019) | random | yes | yes | no 
-BOHB | Falkner, et al. (2018) | model-based | yes | yes | no 
-MOBSTER | Klein, et al. (2020) | model-based | yes | yes | no 
-DEHB | Awad, et al. (2021) | evolutionary | no | yes | no 
-HyperTune | Li, et al. (2022) | model-based | yes | yes | no
-DyHPO<sup>*</sup> | Wistuba, et al. (2022) | model-based | yes | yes | no
-ASHABORE | Tiao, et al. (2021) | model-based | yes | yes | no
-ASHACQR | Salinas, et al. (2023) | model-based | yes | yes | no 
-PASHA | Bohdal, et al. (2022)| random or model-based | yes | yes | no 
-REA | Real, et al. (2019) | evolutionary | yes | no | no 
-KDE | Falkner, et al. (2018) | model-based | yes | no | no 
-PBT | Jaderberg, et al. (2017) | evolutionary | no | yes | no 
-ZeroShotTransfer | Wistuba, et al. (2015) | deterministic | yes | no | yes 
-ASHA-CTS | Salinas, et al. (2021)| random | yes | yes | yes 
-RUSH | Zappella, et al. (2021)| random | yes | yes | yes 
-BoundingBox | Perrone, et al. (2019) | any | yes | yes | yes
+## Benchmarking
 
-<sup>*</sup>: We implement the model-based scheduling logic of DyHPO, but use
-the same Gaussian process surrogate models as MOBSTER and HyperTune. The original
-source code for the paper is [here](https://github.com/releaunifreiburg/DyHPO/tree/main).
-
-The searchers fall into four broad categories, **deterministic**, **random**, **evolutionary** and **model-based**. The random searchers sample candidate hyperparameter configurations uniformly at random, while the model-based searchers sample them non-uniformly at random, according to a model (e.g., Gaussian process, density ration estimator, etc.) and an acquisition function. The evolutionary searchers make use of an evolutionary algorithm.
-
-Syne Tune also supports [BoTorch](https://github.com/awslabs/syne-tune/blob/main/syne_tune/optimizer/schedulers/searchers/botorch/botorch_searcher.py) searchers.
-
-## Supported multi-objective optimization methods
-
-Method |          Reference          |   Searcher   | Asynchronous? | Multi-fidelity? | Transfer?
-:--- |:---------------------------:|:------------:| :---: | :---: | :---: 
-Constrained Bayesian Optimization |   Gardner, et al. (2014)    | model-based  | yes | no | no
-MOASHA |  Schmucker, et al. (2021)   |    random    | yes | yes | no
-NSGA-2 |     Deb, et al. (2002)      | evolutionary | no | no | no
-Multi Objective Multi Surrogate (MSMOS) | Guerrero-Viu, et al. (2021) | model-based  | no | no | no
-MSMOS with random scalarization |    Paria, et al. (2018)     | model-based  | no | no | no
-
-HPO methods listed can be used in a multi-objective setting by scalarization or non-dominated sorting. See [multiobjective_priority.py](syne_tune/optimizer/schedulers/multiobjective/multiobjective_priority.py) for details.
-
-## Examples
-
-You will find many examples in the [examples/](examples/) folder illustrating
-different functionalities provided by Syne Tune. For example:
-* [launch_height_baselines.py](examples/launch_height_baselines.py):
-  launches HPO locally, tuning a simple script 
-  [train_height_example.py](examples/training_scripts/height_example/train_height.py) for several baselines  
-* [launch_height_moasha.py](examples/launch_height_moasha.py):
-  shows how to tune a script reporting multiple-objectives with multiobjective Asynchronous Hyperband (MOASHA)
-* [launch_height_standalone_scheduler.py](examples/launch_height_standalone_scheduler.py):
-  launches HPO locally with a custom scheduler that cuts any trial that is not
-  in the top 80%
-* [launch_height_sagemaker_remotely.py](examples/launch_height_sagemaker_remotely.py):
-  launches the HPO loop on SageMaker rather than a local machine, trial can be executed either
-  the remote machine or distributed again as separate SageMaker training jobs. See 
-  [launch_height_sagemaker_remote_launcher.py](examples/launch_height_sagemaker_remote_launcher.py)
-  for remote launching with the help of RemoteTuner also discussed in one of the FAQs.
-* [launch_height_sagemaker.py](examples/launch_height_sagemaker.py):
-  launches HPO on SageMaker to tune a SageMaker Pytorch estimator
-* [launch_bayesopt_constrained.py](examples/launch_bayesopt_constrained.py):
-  launches Bayesian constrained hyperparameter optimization
-* [launch_height_sagemaker_custom_image.py](examples/launch_height_sagemaker_custom_image.py):
-  launches HPO on SageMaker to tune an entry point with a custom docker image
-* [launch_plot_results.py](examples/launch_plot_results.py): shows how to plot
-  results of a HPO experiment
-* [launch_tensorboard_example.py](examples/launch_tensorboard_example.py):
-  shows how results can be visualized on the fly with TensorBoard
-* [launch_nasbench201_simulated.py](examples/launch_nasbench201_simulated.py):
-  demonstrates simulation of experiments on a tabulated benchmark
-* [launch_fashionmnist.py](examples/launch_fashionmnist.py):
-  launches HPO locally tuning a multi-layer perceptron on Fashion MNIST. This
-  employs an easy-to-use benchmark convention
-* [launch_huggingface_classification.py](examples/launch_huggingface_classification.py):
-  launches HPO on SageMaker to tune a SageMaker Hugging Face estimator for sentiment classification
-* [launch_tuning_gluonts.py](examples/launch_tuning_gluonts.py):
-  launches HPO locally to tune a gluon-ts time series forecasting algorithm
-* [launch_rl_tuning.py](examples/launch_rl_tuning.py):
-  launches HPO locally to tune a RL algorithm on the cartpole environment
-* [launch_height_ray.py](examples/launch_height_ray.py):
-  launches HPO locally with [Ray Tune](https://docs.ray.io/en/master/tune/index.html)
-  scheduler
-
-## Examples for Experimentation and Benchmarking
-
-You will find many examples for experimentation and benchmarking in
-[benchmarking/examples/](benchmarking/examples/) and in
-[benchmarking/nursery/](benchmarking/nursery/).
-
-## FAQ and Tutorials
-
-You can check our [FAQ](https://syne-tune.readthedocs.io/en/latest/faq.html), to
-learn more about Syne Tune functionalities.
-
-* [Why should I use Syne Tune?](https://syne-tune.readthedocs.io/en/latest/faq.html#why-should-i-use-syne-tune)
-* [What are the different installations options supported?](https://syne-tune.readthedocs.io/en/latest/faq.html#what-are-the-different-installations-options-supported)
-* [How can I run on AWS and SageMaker?](https://syne-tune.readthedocs.io/en/latest/faq.html#how-can-i-run-on-aws-and-sagemaker)
-* [What are the metrics reported by default when calling the `Reporter`?](https://syne-tune.readthedocs.io/en/latest/faq.html#what-are-the-metrics-reported-by-default-when-calling-the-reporter)
-* [How can I utilize multiple GPUs?](https://syne-tune.readthedocs.io/en/latest/faq.html#how-can-i-utilize-multiple-gpus)
-* [What is the default mode when performing optimization?](https://syne-tune.readthedocs.io/en/latest/faq.html#what-is-the-default-mode-when-performing-optimization)
-* [How are trials evaluated on a local machine?](https://syne-tune.readthedocs.io/en/latest/faq.html#how-are-trials-evaluated-on-a-local-machine)
-* [Where can I find the output of the tuning?](https://syne-tune.readthedocs.io/en/latest/faq.html#where-can-i-find-the-output-of-the-tuning)
-* [How can I change the default output folder where tuning results are stored?](https://syne-tune.readthedocs.io/en/latest/faq.html#how-can-i-change-the-default-output-folder-where-tuning-results-are-stored)
-* [What does the output of the tuning contain?](https://syne-tune.readthedocs.io/en/latest/faq.html#what-does-the-output-of-the-tuning-contain)
-* [How can I enable trial checkpointing?](https://syne-tune.readthedocs.io/en/latest/faq.html#how-can-i-enable-trial-checkpointing)
-* [How can I retrieve the best checkpoint obtained after tuning?](https://syne-tune.readthedocs.io/en/latest/faq.html#how-can-i-retrieve-the-best-checkpoint-obtained-after-tuning)
-* [Which schedulers make use of checkpointing?](https://syne-tune.readthedocs.io/en/latest/faq.html#which-schedulers-make-use-of-checkpointing)
-* [Is the tuner checkpointed?](https://syne-tune.readthedocs.io/en/latest/faq.html#is-the-tuner-checkpointed)
-* [Where can I find the output of my trials?](https://syne-tune.readthedocs.io/en/latest/faq.html#where-can-i-find-the-output-of-my-trials)
-* [How can I plot the results of a tuning?](https://syne-tune.readthedocs.io/en/latest/faq.html#how-can-i-plot-the-results-of-a-tuning)
-* [How can I specify additional tuning metadata?](https://syne-tune.readthedocs.io/en/latest/faq.html#how-can-i-specify-additional-tuning-metadata)
-* [How do I append additional information to the results which are stored?](https://syne-tune.readthedocs.io/en/latest/faq.html#how-do-i-append-additional-information-to-the-results-which-are-stored) 
-* [I don’t want to wait, how can I launch the tuning on a remote machine?](https://syne-tune.readthedocs.io/en/latest/faq.html#i-dont-want-to-wait-how-can-i-launch-the-tuning-on-a-remote-machine)
-* [How can I run many experiments in parallel?](https://syne-tune.readthedocs.io/en/latest/faq.html#how-can-i-run-many-experiments-in-parallel)
-* [How can I access results after tuning remotely?](https://syne-tune.readthedocs.io/en/latest/faq.html#how-can-i-access-results-after-tuning-remotely)
-* [How can I specify dependencies to remote launcher or when using the SageMaker backend?](https://syne-tune.readthedocs.io/en/latest/faq.html#how-can-i-specify-dependencies-to-remote-launcher-or-when-using-the-sagemaker-backend)
-* [How can I benchmark different methods?](https://syne-tune.readthedocs.io/en/latest/faq.html#how-can-i-benchmark-different-methods)
-* [What different schedulers do you support? What are the main differences between them?](https://syne-tune.readthedocs.io/en/latest/faq.html#what-different-schedulers-do-you-support-what-are-the-main-differences-between-them)
-* [How do I define the configuration space?](https://syne-tune.readthedocs.io/en/latest/faq.html#how-do-i-define-the-configuration-space) 
-* [How do I set arguments of multi-fidelity schedulers?](https://syne-tune.readthedocs.io/en/latest/faq.html#how-do-i-set-arguments-of-multi-fidelity-schedulers)
-* [How can I visualize the progress of my tuning experiment with Tensorboard?](https://syne-tune.readthedocs.io/en/latest/faq.html#how-can-i-visualize-the-progress-of-my-tuning-experiment-with-tensorboard)
-* [How can I add a new scheduler?](https://syne-tune.readthedocs.io/en/latest/faq.html#how-can-i-add-a-new-scheduler)
-* [How can I add a new tabular or surrogate benchmark?](https://syne-tune.readthedocs.io/en/latest/faq.html#how-can-i-add-a-new-tabular-or-surrogate-benchmark)
-* [How can I reduce delays in starting trials with the SageMaker backend?](https://syne-tune.readthedocs.io/en/latest/faq.html#how-can-i-reduce-delays-in-starting-trials-with-the-sageMaker-backend)
-* [How can I pass lists or dictionaries to the training script?](https://syne-tune.readthedocs.io/en/latest/faq.html#how-can-i-pass-lists-or-dictionaries-to-the-training-script)
-* [How can I write extra results for an experiment?](https://syne-tune.readthedocs.io/en/latest/faq.html#how-can-i-write-extra-results-for-an-experiment)
-
-Do you want to know more? Here are a number of tutorials.
-* [Basics of Syne Tune](https://syne-tune.readthedocs.io/en/latest/tutorials/basics/README.html)
-* [Choosing a Configuration Space](https://syne-tune.readthedocs.io/en/latest/search_space.html)
-* [Using the Built-in Schedulers](https://syne-tune.readthedocs.io/en/latest/schedulers.html)
-* [Multi-Fidelity Hyperparameter Optimization](https://syne-tune.readthedocs.io/en/latest/tutorials/multifidelity/README.html)
-* [Benchmarking in Syne Tune](https://syne-tune.readthedocs.io/en/latest/tutorials/benchmarking/README.html)
-* [Visualization of Results](https://syne-tune.readthedocs.io/en/latest/tutorials/visualization/README.html)
-* [Rapid Experimentation with Syne Tune](https://syne-tune.readthedocs.io/en/latest/tutorials/experimentation/README.html)
-* [How to Contribute a New Scheduler](https://syne-tune.readthedocs.io/en/latest/tutorials/developer/README.html)
-* [PASHA: Efficient HPO and NAS with Progressive Resource Allocation](https://syne-tune.readthedocs.io/en/latest/tutorials/pasha/pasha.html)
-* [Using Syne Tune for Transfer Learning](https://syne-tune.readthedocs.io/en/latest/tutorials/transfer_learning/transfer_learning.html)
-* [Distributed Hyperparameter Tuning: Finding the Right Model can be Fast and Fun](https://syne-tune.readthedocs.io/en/latest/tutorials/odsc_tutorial/README.html)
+Checkout this tutorial to run large-scale [benchmarking](benchmarking/nursery/) with Syne Tune.
 
 ## Blog Posts
 
@@ -292,7 +153,7 @@ Do you want to know more? Here are a number of tutorials.
 * [Martin Wistuba: Hyperparameter Optimization for the Impatient (PyData 2023)](https://www.youtube.com/watch?v=onX6fXzp9Yk)
 * [David Salinas: Syne Tune: A Library for Large-Scale Hyperparameter Tuning and Reproducible Research (AutoML Seminar)](https://youtu.be/DlM-__TTa3U?feature=shared)
   
-## Security
+## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
 

--- a/syne_tune/optimizer/schedulers/searchers/last_value_multi_fidelity_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/last_value_multi_fidelity_searcher.py
@@ -122,7 +122,7 @@ class LastValueMultiFidelitySearcher(SingleObjectiveBaseSearcher):
         configs, metrics = self.make_input_target()
         self.searcher = self.searcher_cls(
             config_space=self.config_space,
-            random_seed=self.random_seed,
+            random_seed=self.random_seed + self.random_state.randint(0, 2**32 - 1),
             points_to_evaluate=None,
             **self.searcher_kwargs,
         )

--- a/syne_tune/optimizer/schedulers/searchers/last_value_multi_fidelity_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/last_value_multi_fidelity_searcher.py
@@ -122,7 +122,7 @@ class LastValueMultiFidelitySearcher(SingleObjectiveBaseSearcher):
         configs, metrics = self.make_input_target()
         self.searcher = self.searcher(
             config_space=self.config_space,
-            # TODO BaseSearcher expects a int for random_seed, so we cannot pass a random state, we could change to pass both 
+            # TODO BaseSearcher expects a int for random_seed, so we cannot pass a random state, we could change to pass both
             random_seed=self.random_seed + self.random_state.randint(0, 2**32 - 1),
             points_to_evaluate=None,
             **self.searcher_kwargs,


### PR DESCRIPTION
Samples a different random seed every time a new BaseSearcher gets initialized to avoid resampling of random configurations.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
