### PR TITLE
reformat: unify scheduler argument naming

### DIFF
--- a/docs/source/tutorials/developer/new_searcher.rst
+++ b/docs/source/tutorials/developer/new_searcher.rst
@@ -48,7 +48,7 @@ generic scheduler is calling it.
 The
 :func:`~syne_tune.optimizer.schedulers.searchers.searcher_factory.searcher_factory`
 code should be straightforward to understand and extend. Pick a name for your
-new searcher and set ``searcher_cls`` and ``supported_schedulers`` (the latter
+new searcher and set ``searcher`` and ``supported_schedulers`` (the latter
 can be left to ``None`` if your searcher works with all generic schedulers). The
 constructor of your searcher needs to have the signature
 

--- a/syne_tune/optimizer/schedulers/asha.py
+++ b/syne_tune/optimizer/schedulers/asha.py
@@ -95,7 +95,7 @@ class AsynchronousSuccessiveHalving(TrialScheduler):
                 searcher_kwargs = {}
 
             self.searcher = LastValueMultiFidelitySearcher(
-                searcher_cls=searcher,
+                searcher=searcher,
                 config_space=config_space,
                 random_seed=random_seed,
                 **searcher_kwargs,

--- a/syne_tune/optimizer/schedulers/searchers/last_value_multi_fidelity_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/last_value_multi_fidelity_searcher.py
@@ -12,7 +12,7 @@ from syne_tune.optimizer.schedulers.searchers.single_objective_searcher import (
 )
 from syne_tune.optimizer.schedulers.searchers.utils import make_hyperparameter_ranges
 from syne_tune.util import catchtime
-from syne_tune.optimizer.schedulers.searchers.searcher_factory import searcher_cls_dict
+from syne_tune.optimizer.schedulers.searchers.searcher_factory import searcher_dict
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +26,7 @@ class LastValueMultiFidelitySearcher(SingleObjectiveBaseSearcher):
         num_init_random_draws: int = 5,
         update_frequency: int = 1,
         max_fit_samples: int = None,
-        searcher_cls: Optional[Union[str, SingleObjectiveBaseSearcher]] = "kde",
+        searcher: Optional[Union[str, SingleObjectiveBaseSearcher]] = "kde",
         searcher_kwargs: dict[str, Any] = None,
     ):
         """
@@ -68,11 +68,11 @@ class LastValueMultiFidelitySearcher(SingleObjectiveBaseSearcher):
             )  # this is handled by the SurrogateSearcher class
             self.searcher_kwargs = searcher_kwargs
 
-        if isinstance(searcher_cls, str):
-            assert searcher_cls in searcher_cls_dict
-            self.searcher_cls = searcher_cls_dict.get(searcher_cls)
+        if isinstance(searcher, str):
+            assert searcher in searcher_dict
+            self.searcher = searcher_dict.get(searcher)
         else:
-            self.searcher_cls = searcher_cls
+            self.searcher = searcher
         self.searcher = None
 
     def suggest(self, **kwargs) -> Optional[Dict[str, Any]]:
@@ -120,7 +120,7 @@ class LastValueMultiFidelitySearcher(SingleObjectiveBaseSearcher):
 
     def fit_model(self):
         configs, metrics = self.make_input_target()
-        self.searcher = self.searcher_cls(
+        self.searcher = self.searcher(
             config_space=self.config_space,
             random_seed=self.random_seed,
             points_to_evaluate=None,

--- a/syne_tune/optimizer/schedulers/searchers/legacy_searcher_factory.py
+++ b/syne_tune/optimizer/schedulers/searchers/legacy_searcher_factory.py
@@ -62,9 +62,9 @@ def legacy_searcher_factory(searcher_name: str, **kwargs) -> LegacyBaseSearcher:
     scheduler = kwargs.get("scheduler")
     model = kwargs.get("model", "gp_multitask")
     if searcher_name == "random":
-        searcher_cls = LegacyRandomSearcher
+        searcher = LegacyRandomSearcher
     elif searcher_name == "grid":
-        searcher_cls = GridSearcher
+        searcher = GridSearcher
     elif searcher_name == "kde":
         try:
             from syne_tune.optimizer.schedulers.searchers.kde.legacy_kde_searcher import (
@@ -77,10 +77,10 @@ def legacy_searcher_factory(searcher_name: str, **kwargs) -> LegacyBaseSearcher:
             raise
 
         if scheduler == "fifo":
-            searcher_cls = LegacyKernelDensityEstimator
+            searcher = LegacyKernelDensityEstimator
         else:
             supported_schedulers = _OUR_MULTIFIDELITY_SCHEDULERS
-            searcher_cls = LegacyMultiFidelityKernelDensityEstimator
+            searcher = LegacyMultiFidelityKernelDensityEstimator
     elif searcher_name == "cqr":
         try:
             from syne_tune.optimizer.schedulers.searchers.conformal.legacy_surrogate_searcher import (
@@ -88,7 +88,7 @@ def legacy_searcher_factory(searcher_name: str, **kwargs) -> LegacyBaseSearcher:
             )
         except ImportError:
             raise
-        searcher_cls = LegacySurrogateSearcher
+        searcher = LegacySurrogateSearcher
     elif searcher_name == "botorch":
         try:
             from syne_tune.optimizer.schedulers.searchers.botorch import (
@@ -97,7 +97,7 @@ def legacy_searcher_factory(searcher_name: str, **kwargs) -> LegacyBaseSearcher:
         except ImportError:
             raise
 
-        searcher_cls = BoTorchSearcher
+        searcher = BoTorchSearcher
         supported_schedulers = {"fifo"}
     else:
         gp_searchers = {
@@ -133,7 +133,7 @@ def legacy_searcher_factory(searcher_name: str, **kwargs) -> LegacyBaseSearcher:
 
         if searcher_name == "bayesopt":
             if scheduler == "fifo":
-                searcher_cls = GPFIFOSearcher
+                searcher = GPFIFOSearcher
             else:
                 supported_schedulers = _OUR_MULTIFIDELITY_SCHEDULERS
                 if (
@@ -147,22 +147,22 @@ def legacy_searcher_factory(searcher_name: str, **kwargs) -> LegacyBaseSearcher:
                         "obtained with model = gp_expdecay, but computations "
                         "are faster then."
                     )
-                searcher_cls = GPMultiFidelitySearcher
+                searcher = GPMultiFidelitySearcher
         elif searcher_name == "legacy_hypertune":
             supported_schedulers = _OUR_MULTIFIDELITY_SCHEDULERS
-            searcher_cls = HyperTuneSearcher
+            searcher = HyperTuneSearcher
         elif searcher_name == "bayesopt_constrained":
             supported_schedulers = {"fifo"}
-            searcher_cls = ConstrainedGPFIFOSearcher
+            searcher = ConstrainedGPFIFOSearcher
         elif searcher_name == "legacy_dyhpo":
             supported_schedulers = {"hyperband_dyhpo", "hyperband_legacy_dyhpo"}
-            searcher_cls = DynamicHPOSearcher
+            searcher = DynamicHPOSearcher
         else:  # bayesopt_cost
             if scheduler == "fifo":
-                searcher_cls = CostAwareGPFIFOSearcher
+                searcher = CostAwareGPFIFOSearcher
             else:
                 supported_schedulers = _OUR_MULTIFIDELITY_SCHEDULERS
-                searcher_cls = CostAwareGPMultiFidelitySearcher
+                searcher = CostAwareGPMultiFidelitySearcher
 
     if supported_schedulers is not None:
         assert scheduler is not None, "Scheduler must set search_options['scheduler']"
@@ -170,5 +170,5 @@ def legacy_searcher_factory(searcher_name: str, **kwargs) -> LegacyBaseSearcher:
             f"Searcher '{searcher_name}' only works with schedulers "
             + f"{supported_schedulers} (not with '{scheduler}')"
         )
-    searcher = searcher_cls(**kwargs)
+    searcher = searcher(**kwargs)
     return searcher

--- a/syne_tune/optimizer/schedulers/searchers/legacy_searcher_factory.py
+++ b/syne_tune/optimizer/schedulers/searchers/legacy_searcher_factory.py
@@ -62,9 +62,9 @@ def legacy_searcher_factory(searcher_name: str, **kwargs) -> LegacyBaseSearcher:
     scheduler = kwargs.get("scheduler")
     model = kwargs.get("model", "gp_multitask")
     if searcher_name == "random":
-        searcher = LegacyRandomSearcher
+        searcher_cls = LegacyRandomSearcher
     elif searcher_name == "grid":
-        searcher = GridSearcher
+        searcher_cls = GridSearcher
     elif searcher_name == "kde":
         try:
             from syne_tune.optimizer.schedulers.searchers.kde.legacy_kde_searcher import (
@@ -77,10 +77,10 @@ def legacy_searcher_factory(searcher_name: str, **kwargs) -> LegacyBaseSearcher:
             raise
 
         if scheduler == "fifo":
-            searcher = LegacyKernelDensityEstimator
+            searcher_cls = LegacyKernelDensityEstimator
         else:
             supported_schedulers = _OUR_MULTIFIDELITY_SCHEDULERS
-            searcher = LegacyMultiFidelityKernelDensityEstimator
+            searcher_cls = LegacyMultiFidelityKernelDensityEstimator
     elif searcher_name == "cqr":
         try:
             from syne_tune.optimizer.schedulers.searchers.conformal.legacy_surrogate_searcher import (
@@ -88,7 +88,7 @@ def legacy_searcher_factory(searcher_name: str, **kwargs) -> LegacyBaseSearcher:
             )
         except ImportError:
             raise
-        searcher = LegacySurrogateSearcher
+        searcher_cls = LegacySurrogateSearcher
     elif searcher_name == "botorch":
         try:
             from syne_tune.optimizer.schedulers.searchers.botorch import (
@@ -97,7 +97,7 @@ def legacy_searcher_factory(searcher_name: str, **kwargs) -> LegacyBaseSearcher:
         except ImportError:
             raise
 
-        searcher = BoTorchSearcher
+        searcher_cls = BoTorchSearcher
         supported_schedulers = {"fifo"}
     else:
         gp_searchers = {
@@ -133,7 +133,7 @@ def legacy_searcher_factory(searcher_name: str, **kwargs) -> LegacyBaseSearcher:
 
         if searcher_name == "bayesopt":
             if scheduler == "fifo":
-                searcher = GPFIFOSearcher
+                searcher_cls = GPFIFOSearcher
             else:
                 supported_schedulers = _OUR_MULTIFIDELITY_SCHEDULERS
                 if (
@@ -147,22 +147,22 @@ def legacy_searcher_factory(searcher_name: str, **kwargs) -> LegacyBaseSearcher:
                         "obtained with model = gp_expdecay, but computations "
                         "are faster then."
                     )
-                searcher = GPMultiFidelitySearcher
+                searcher_cls = GPMultiFidelitySearcher
         elif searcher_name == "legacy_hypertune":
             supported_schedulers = _OUR_MULTIFIDELITY_SCHEDULERS
-            searcher = HyperTuneSearcher
+            searcher_cls = HyperTuneSearcher
         elif searcher_name == "bayesopt_constrained":
             supported_schedulers = {"fifo"}
-            searcher = ConstrainedGPFIFOSearcher
+            searcher_cls = ConstrainedGPFIFOSearcher
         elif searcher_name == "legacy_dyhpo":
             supported_schedulers = {"hyperband_dyhpo", "hyperband_legacy_dyhpo"}
-            searcher = DynamicHPOSearcher
+            searcher_cls = DynamicHPOSearcher
         else:  # bayesopt_cost
             if scheduler == "fifo":
-                searcher = CostAwareGPFIFOSearcher
+                searcher_cls = CostAwareGPFIFOSearcher
             else:
                 supported_schedulers = _OUR_MULTIFIDELITY_SCHEDULERS
-                searcher = CostAwareGPMultiFidelitySearcher
+                searcher_cls = CostAwareGPMultiFidelitySearcher
 
     if supported_schedulers is not None:
         assert scheduler is not None, "Scheduler must set search_options['scheduler']"
@@ -170,5 +170,5 @@ def legacy_searcher_factory(searcher_name: str, **kwargs) -> LegacyBaseSearcher:
             f"Searcher '{searcher_name}' only works with schedulers "
             + f"{supported_schedulers} (not with '{scheduler}')"
         )
-    searcher = searcher(**kwargs)
+    searcher = searcher_cls(**kwargs)
     return searcher

--- a/syne_tune/optimizer/schedulers/searchers/multi_fidelity_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/multi_fidelity_searcher.py
@@ -7,7 +7,7 @@ from syne_tune.optimizer.schedulers.searchers.searcher import BaseSearcher
 from syne_tune.optimizer.schedulers.searchers.single_objective_searcher import (
     SingleObjectiveBaseSearcher,
 )
-from syne_tune.optimizer.schedulers.searchers.searcher_factory import searcher_cls_dict
+from syne_tune.optimizer.schedulers.searchers.searcher_factory import searcher_dict
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ class IndependentMultiFidelitySearcher(BaseSearcher):
     | Proceedings of the 35th International Conference on Machine Learning
 
     :param config_space: Configuration space
-    :param searcher_cls: Searcher to sample configurations on each rung level.
+    :param searcher: Searcher to sample configurations on each rung level.
     :param points_to_evaluate: List of configurations to be evaluated
         initially (in that order).
     :param random_seed: Seed used to initialize the random number generators.
@@ -31,7 +31,7 @@ class IndependentMultiFidelitySearcher(BaseSearcher):
     def __init__(
         self,
         config_space: Dict[str, Any],
-        searcher_cls: Optional[Union[str, SingleObjectiveBaseSearcher]] = "kde",
+        searcher: Optional[Union[str, SingleObjectiveBaseSearcher]] = "kde",
         points_to_evaluate: Optional[List[dict]] = None,
         random_seed: Optional[int] = None,
         searcher_kwargs: dict[str, Any] = None,
@@ -47,14 +47,14 @@ class IndependentMultiFidelitySearcher(BaseSearcher):
         else:
             self.searcher_kwargs = searcher_kwargs
 
-        if isinstance(searcher_cls, str):
-            assert searcher_cls in searcher_cls_dict
-            self.searcher_cls = searcher_cls_dict.get(searcher_cls)
+        if isinstance(searcher, str):
+            assert searcher in searcher_dict
+            self.searcher = searcher_dict.get(searcher)
         else:
-            self.searcher_cls = searcher_cls
+            self.searcher = searcher
 
         self.searchers = defaultdict(
-            lambda: self.searcher_cls(
+            lambda: self.searcher(
                 config_space=self.config_space,
                 random_seed=self.random_seed,
                 **self.searcher_kwargs,

--- a/syne_tune/optimizer/schedulers/searchers/searcher_factory.py
+++ b/syne_tune/optimizer/schedulers/searchers/searcher_factory.py
@@ -30,6 +30,4 @@ def searcher_factory(
     assert (
         searcher_name in searcher_dict
     ), f"Searcher name must be one of {list(searcher_dict.keys())}, got {searcher_name}"
-    return searcher_dict[searcher_name](
-        config_space=config_space, **searcher_kwargs
-    )
+    return searcher_dict[searcher_name](config_space=config_space, **searcher_kwargs)

--- a/syne_tune/optimizer/schedulers/searchers/searcher_factory.py
+++ b/syne_tune/optimizer/schedulers/searchers/searcher_factory.py
@@ -14,7 +14,7 @@ from syne_tune.optimizer.schedulers.searchers.conformal.conformal_quantile_regre
     ConformalQuantileRegression,
 )
 
-searcher_cls_dict = {
+searcher_dict = {
     "random_search": RandomSearcher,
     "bore": Bore,
     "kde": KernelDensityEstimator,
@@ -28,8 +28,8 @@ def searcher_factory(
     searcher_name: str, config_space: Dict[str, Any], **searcher_kwargs
 ) -> BaseSearcher:
     assert (
-        searcher_name in searcher_cls_dict
-    ), f"Searcher name must be one of {list(searcher_cls_dict.keys())}, got {searcher_name}"
-    return searcher_cls_dict[searcher_name](
+        searcher_name in searcher_dict
+    ), f"Searcher name must be one of {list(searcher_dict.keys())}, got {searcher_name}"
+    return searcher_dict[searcher_name](
         config_space=config_space, **searcher_kwargs
     )

--- a/tst/schedulers/test_multi_fidelity_searcher.py
+++ b/tst/schedulers/test_multi_fidelity_searcher.py
@@ -5,12 +5,12 @@ from syne_tune.optimizer.schedulers.searchers.multi_fidelity_searcher import (
     IndependentMultiFidelitySearcher,
 )
 from syne_tune.config_space import choice
-from syne_tune.optimizer.schedulers.searchers.searcher_factory import searcher_cls_dict
+from syne_tune.optimizer.schedulers.searchers.searcher_factory import searcher_dict
 from syne_tune.optimizer.schedulers.searchers.utils import make_hyperparameter_ranges
 
 
-@pytest.mark.parametrize("searcher_cls", searcher_cls_dict)
-def test_independent_multi_fidelity_searcher(searcher_cls):
+@pytest.mark.parametrize("searcher", searcher_dict)
+def test_independent_multi_fidelity_searcher(searcher):
     random_seed = 31415927
     resource_levels = [3] * 20 + [1] * 25 + [9] * 9
     random_state = np.random.RandomState(random_seed)
@@ -24,7 +24,7 @@ def test_independent_multi_fidelity_searcher(searcher_cls):
     searcher = IndependentMultiFidelitySearcher(
         config_space=config_space,
         points_to_evaluate=[],
-        searcher_cls=searcher_cls,
+        searcher=searcher,
     )
     # Sample data at random (except for ``resource_levels``)
     hp_ranges = make_hyperparameter_ranges(config_space)


### PR DESCRIPTION
Unified naming from `searcher_cls` ->`searcher` and `searcher_cls_dict `-> `searcher_dict`

Closes #941.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
