### PR TITLE
Fix: remove typing import

### DIFF
--- a/benchmarking/baselines.py
+++ b/benchmarking/baselines.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional, List
+from typing import Optional
 
 from syne_tune.blackbox_repository.simulated_tabular_backend import (
     BlackboxRepositoryBackend,
@@ -18,7 +18,7 @@ class MethodArguments:
     mode: str
     random_seed: int
     resource_attr: str
-    points_to_evaluate: List[dict]
+    points_to_evaluate: list[dict]
     max_t: Optional[int] = None
     max_resource_attr: Optional[str] = None
     use_surrogates: bool = False

--- a/benchmarking/benchmarks.py
+++ b/benchmarking/benchmarks.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional, List, Dict
+from typing import Optional
 
 from syne_tune.blackbox_repository.conversion_scripts.scripts.tabrepo_import import (
     TABREPO_DATASETS,
@@ -17,8 +17,8 @@ class BenchmarkDefinition:
     dataset_name: str
     max_num_evaluations: Optional[int] = None
     surrogate: Optional[str] = None
-    surrogate_kwargs: Optional[Dict] = None
-    datasets: Optional[List[str]] = None
+    surrogate_kwargs: Optional[dict] = None
+    datasets: Optional[list[str]] = None
 
 
 n_full_evals = 200

--- a/benchmarking/results_analysis/load_experiments_parallel.py
+++ b/benchmarking/results_analysis/load_experiments_parallel.py
@@ -3,7 +3,6 @@ import logging
 from collections import defaultdict
 from json import JSONDecodeError
 from pathlib import Path
-from typing import Dict, Tuple
 
 import numpy as np
 import pandas as pd
@@ -153,7 +152,7 @@ def load_benchmark_results(
     max_seed: int = None,
     experiment_filter=None,
     engine: str = "joblib",
-) -> Dict[str, Tuple[np.array, Dict[str, np.array]]]:
+) -> dict[str, tuple[np.array, dict[str, np.array]]]:
     """
     :param path: where results are stored
     :param methods: list of methods to consider

--- a/benchmarking/results_analysis/show_results.py
+++ b/benchmarking/results_analysis/show_results.py
@@ -1,7 +1,7 @@
 import logging
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Dict, Tuple, Optional, List
+from typing import Optional
 
 import dill
 import matplotlib
@@ -57,7 +57,7 @@ benchmark_names = {
 
 def plot_result_benchmark(
     t_range: np.array,
-    method_dict: Dict[str, np.array],
+    method_dict: dict[str, np.array],
     title: str,
     rename_dict: dict,
     ax=None,
@@ -110,7 +110,7 @@ def plot_result_benchmark(
 
 
 def plot_task_performance_over_time(
-    benchmark_results: Dict[str, Tuple[np.array, Dict[str, np.array]]],
+    benchmark_results: dict[str, tuple[np.array, dict[str, np.array]]],
     rename_dict: dict,
     result_folder: Path,
     title: str = None,
@@ -147,7 +147,7 @@ def plot_task_performance_over_time(
 
 def load_and_cache(
     path: Path,
-    methods: Optional[List[str]] = None,
+    methods: Optional[list[str]] = None,
     load_cache_if_exists: bool = True,
     num_time_steps=100,
     max_seed=10,
@@ -181,7 +181,7 @@ def plot_ranks(
     title: str,
     rename_dict: dict,
     result_folder: Path,
-    methods_to_show: List[str],
+    methods_to_show: list[str],
 ):
     plt.figure()
     # (num_methods, num_benchmarks, num_min_seeds, num_time_steps)
@@ -206,10 +206,10 @@ def plot_ranks(
 
 
 def stack_benchmark_results(
-    benchmark_results_dict: Dict[str, Tuple[np.array, Dict[str, np.array]]],
-    methods_to_show: Optional[List[str]],
-    benchmark_families: List[str],
-) -> Dict[str, np.array]:
+    benchmark_results_dict: dict[str, tuple[np.array, dict[str, np.array]]],
+    methods_to_show: Optional[list[str]],
+    benchmark_families: list[str],
+) -> dict[str, np.array]:
     """
     Stack benchmark results between benchmarks of the same family.
     :param benchmark_results_dict:
@@ -259,9 +259,9 @@ def stack_benchmark_results(
 
 
 def generate_rank_results(
-    benchmark_families: List[str],
-    stacked_benchmark_results: Dict[str, np.array],
-    methods_to_show: Optional[List[str]],
+    benchmark_families: list[str],
+    stacked_benchmark_results: dict[str, np.array],
+    methods_to_show: Optional[list[str]],
     rename_dict: dict,
     result_folder: Path,
 ):

--- a/examples/launch_ask_tell_scheduler_hyperband.py
+++ b/examples/launch_ask_tell_scheduler_hyperband.py
@@ -13,7 +13,6 @@ This is an extension of launch_ask_tell_scheduler.py to run multi-fidelity metho
 """
 
 import logging
-from typing import Tuple
 
 import numpy as np
 
@@ -49,7 +48,7 @@ def get_objective():
 
 def run_hyperband_step(
     scheduler: AskTellScheduler, trial_suggestion: Trial, max_steps: int, metric: str
-) -> Tuple[float, float]:
+) -> tuple[float, float]:
     for step in range(1, max_steps):
         test_result = target_function(**trial_suggestion.config, step=step)
         decision = scheduler.bscheduler.on_trial_result(

--- a/examples/launch_fashionmnist_checkpoint_removal.py
+++ b/examples/launch_fashionmnist_checkpoint_removal.py
@@ -1,7 +1,7 @@
 """
 Example for speculative checkpoint removal with asynchronous multi-fidelity
 """
-from typing import Optional, Dict, Any, List
+from typing import Optional, Any
 import logging
 
 from syne_tune.backend import LocalBackend
@@ -23,11 +23,11 @@ from benchmarking.benchmark_definitions.mlp_on_fashionmnist import (
 # This is used to monitor what the checkpoint removal mechanism is doing, and
 # writing out results. This is optional, the mechanism works without this.
 class CPRemovalExtraResults(ExtraResultsComposer):
-    def __call__(self, tuner: Tuner) -> Optional[Dict[str, Any]]:
+    def __call__(self, tuner: Tuner) -> Optional[dict[str, Any]]:
         callback = find_first_of_type(tuner.callbacks, HyperbandRemoveCheckpointsCommon)
         return None if callback is None else callback.extra_results()
 
-    def keys(self) -> List[str]:
+    def keys(self) -> list[str]:
         return HyperbandRemoveCheckpointsCommon.extra_results_keys()
 
 

--- a/examples/launch_height_extra_results.py
+++ b/examples/launch_height_extra_results.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional, List
+from typing import Any, Optional
 from pathlib import Path
 import logging
 
@@ -17,7 +17,7 @@ from syne_tune import Tuner, StoppingCriterion
 # We would like to extract some extra information from the scheduler during the
 # experiment. To this end, we implement a class for extracting this information
 class DyHPOExtraResults(ExtraResultsComposer):
-    def __call__(self, tuner: Tuner) -> Optional[Dict[str, Any]]:
+    def __call__(self, tuner: Tuner) -> Optional[dict[str, Any]]:
         scheduler = tuner.scheduler
         assert isinstance(scheduler, DyHPO)  # sanity check
         # :class:`~syne_tune.optimizer.schedulers.searchers.legacy_dyhpo.hyperband_dyhpo.DyHPORungSystem`
@@ -25,7 +25,7 @@ class DyHPOExtraResults(ExtraResultsComposer):
         # ``on_task_schedule``
         return scheduler.terminator._rung_systems[0].summary_schedule_records()
 
-    def keys(self) -> List[str]:
+    def keys(self) -> list[str]:
         return DyHPORungSystem.summary_schedule_keys()
 
 

--- a/examples/launch_height_standalone_scheduler.py
+++ b/examples/launch_height_standalone_scheduler.py
@@ -3,7 +3,7 @@ Example showing how to implement a new Scheduler.
 """
 import logging
 from pathlib import Path
-from typing import Optional,Any
+from typing import Optional, Any
 
 import numpy as np
 

--- a/examples/launch_height_standalone_scheduler.py
+++ b/examples/launch_height_standalone_scheduler.py
@@ -3,7 +3,7 @@ Example showing how to implement a new Scheduler.
 """
 import logging
 from pathlib import Path
-from typing import Optional, List, Dict, Any
+from typing import Optional,Any
 
 import numpy as np
 
@@ -26,7 +26,7 @@ from examples.training_scripts.height_example.train_height import (
 
 class SimpleScheduler(LegacyTrialScheduler):
     def __init__(
-        self, config_space: Dict[str, Any], metric: str, mode: Optional[str] = None
+        self, config_space: dict[str, Any], metric: str, mode: Optional[str] = None
     ):
         super(SimpleScheduler, self).__init__(config_space=config_space)
         self.metric = metric
@@ -42,7 +42,7 @@ class SimpleScheduler(LegacyTrialScheduler):
         }
         return TrialSuggestion.start_suggestion(config)
 
-    def on_trial_result(self, trial: Trial, result: Dict[str, Any]) -> str:
+    def on_trial_result(self, trial: Trial, result: dict[str, Any]) -> str:
         # Given a new result, we decide whether the trial should stop or continue.
         # In this case, we implement a naive strategy that stops if the result is worse than 80% of previous results.
         # This is a naive strategy as we do not account for the fact that trial improves with more steps.
@@ -66,7 +66,7 @@ class SimpleScheduler(LegacyTrialScheduler):
             )
             return SchedulerDecision.STOP
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return [self.metric]
 
 

--- a/examples/launch_nas201_transfer_learning.py
+++ b/examples/launch_nas201_transfer_learning.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from syne_tune.blackbox_repository import load_blackbox, BlackboxRepositoryBackend
 from syne_tune.backend.simulator_backend.simulator_callback import SimulatorCallback
 from syne_tune.experiments import load_experiment
@@ -13,7 +11,7 @@ from syne_tune import StoppingCriterion, Tuner
 
 def load_transfer_learning_evaluations(
     blackbox_name: str, test_task: str, metric: str
-) -> Dict[str, LegacyTransferLearningTaskEvaluations]:
+) -> dict[str, LegacyTransferLearningTaskEvaluations]:
     bb_dict = load_blackbox(blackbox_name)
     metric_index = [
         i

--- a/examples/launch_sklearn_surrogate_bo.py
+++ b/examples/launch_sklearn_surrogate_bo.py
@@ -1,6 +1,5 @@
 import copy
 from pathlib import Path
-from typing import Tuple
 import logging
 
 import numpy as np
@@ -35,7 +34,7 @@ class BayesianRidgePredictor(SKLearnPredictor):
     def __init__(self, ridge: BayesianRidge):
         self.ridge = ridge
 
-    def predict(self, X: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def predict(self, X: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         return self.ridge.predict(X, return_std=True)
 
 

--- a/examples/training_scripts/checkpoint_example/train_height_checkpoint.py
+++ b/examples/training_scripts/checkpoint_example/train_height_checkpoint.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from typing import Optional, Dict, Any
+from typing import Optional, Any
 import json
 from pathlib import Path
 import os
@@ -25,7 +25,7 @@ METRIC_MODE = "min"
 MAX_RESOURCE_ATTR = "steps"
 
 
-def load_checkpoint(checkpoint_path: Path) -> Dict[str, Any]:
+def load_checkpoint(checkpoint_path: Path) -> dict[str, Any]:
     with open(checkpoint_path, "r") as f:
         return json.load(f)
 
@@ -62,7 +62,7 @@ def train_height_delta(step: int, width: float, height: float, value: float) -> 
 
 def height_config_space(
     max_steps: int, sleep_time: Optional[float] = None
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     kwargs = {"sleep_time": sleep_time} if sleep_time is not None else dict()
     return {
         MAX_RESOURCE_ATTR: max_steps,

--- a/examples/training_scripts/height_example/blackbox_height.py
+++ b/examples/training_scripts/height_example/blackbox_height.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any
+from typing import Optional, Any
 import numpy as np
 
 from syne_tune.blackbox_repository.blackbox import Blackbox, ObjectiveFunctionResult
@@ -31,7 +31,7 @@ class HeightExampleBlackbox(Blackbox):
 
     def _objective_function(
         self,
-        configuration: Dict[str, Any],
+        configuration: dict[str, Any],
         fidelity: Optional[dict] = None,
         seed: Optional[int] = None,
     ) -> ObjectiveFunctionResult:

--- a/examples/training_scripts/height_example/train_height.py
+++ b/examples/training_scripts/height_example/train_height.py
@@ -3,7 +3,7 @@ Example similar to Raytune, https://github.com/ray-project/ray/blob/master/pytho
 """
 import logging
 import time
-from typing import Optional, Dict, Any
+from typing import Optional, Any
 
 from syne_tune import Reporter
 from argparse import ArgumentParser
@@ -29,7 +29,7 @@ def train_height(step: int, width: float, height: float) -> float:
 
 def height_config_space(
     max_steps: int, sleep_time: Optional[float] = None
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     kwargs = {"sleep_time": sleep_time} if sleep_time is not None else dict()
     return {
         MAX_RESOURCE_ATTR: max_steps,

--- a/examples/training_scripts/height_example/train_height_config_json.py
+++ b/examples/training_scripts/height_example/train_height_config_json.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from typing import Optional, Dict, Any
+from typing import Optional, Any
 from argparse import ArgumentParser
 
 from syne_tune import Reporter
@@ -26,7 +26,7 @@ def train_height(step: int, width: float, height: float) -> float:
 
 def height_config_space(
     max_steps: int, sleep_time: Optional[float] = None
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     if sleep_time is None:
         sleep_time = 0.1
     return {
@@ -48,7 +48,7 @@ def height_config_space(
     }
 
 
-def _check_extra_args(config: Dict[str, Any]):
+def _check_extra_args(config: dict[str, Any]):
     config_space = height_config_space(5)
     for k in ("list_arg", "dict_arg"):
         a, b = config[k], config_space[k]

--- a/nursery/benchmark_automl/baselines.py
+++ b/nursery/benchmark_automl/baselines.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, Optional, Any
+from typing import Optional, Any
 
 from syne_tune.blackbox_repository.simulated_tabular_backend import (
     BlackboxRepositoryBackend,
@@ -24,14 +24,14 @@ from syne_tune.optimizer.schedulers.transfer_learning.quantile_based.legacy_quan
 
 @dataclass
 class MethodArguments:
-    config_space: Dict[str, Any]
+    config_space: dict[str, Any]
     metric: str
     mode: str
     random_seed: int
     resource_attr: str
     max_t: Optional[int] = None
     max_resource_attr: Optional[str] = None
-    transfer_learning_evaluations: Optional[Dict] = None
+    transfer_learning_evaluations: Optional[dict] = None
     use_surrogates: bool = False
 
 
@@ -53,7 +53,7 @@ class Methods:
 
 def _max_resource_attr_or_max_t(
     args: MethodArguments, max_t_name: str = "max_t"
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     if args.max_resource_attr is not None:
         return {"max_resource_attr": args.max_resource_attr}
     else:
@@ -61,7 +61,7 @@ def _max_resource_attr_or_max_t(
         return {max_t_name: args.max_t}
 
 
-def search_options(args: MethodArguments) -> Dict[str, Any]:
+def search_options(args: MethodArguments) -> dict[str, Any]:
     return {"debug_log": False}
 
 

--- a/nursery/benchmark_automl/benchmark_main.py
+++ b/nursery/benchmark_automl/benchmark_main.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 import numpy as np
 import itertools
 import logging
@@ -18,7 +18,7 @@ from syne_tune.stopping_criterion import StoppingCriterion
 from syne_tune.tuner import Tuner
 
 
-def parse_args(methods: Dict[str, Any], benchmark_definitions: Dict[str, Any]):
+def parse_args(methods: dict[str, Any], benchmark_definitions: dict[str, Any]):
     parser = ArgumentParser()
     parser.add_argument(
         "--experiment_tag",
@@ -72,7 +72,7 @@ def parse_args(methods: Dict[str, Any], benchmark_definitions: Dict[str, Any]):
     return args, method_names, benchmark_names, seeds
 
 
-def main(methods: Dict[str, Any], benchmark_definitions: Dict[str, Any]):
+def main(methods: dict[str, Any], benchmark_definitions: dict[str, Any]):
     args, method_names, benchmark_names, seeds = parse_args(
         methods, benchmark_definitions
     )

--- a/nursery/benchmark_automl/results_analysis/utils.py
+++ b/nursery/benchmark_automl/results_analysis/utils.py
@@ -5,7 +5,7 @@ from tqdm import tqdm
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 import pandas as pd
 from datetime import datetime
 import matplotlib.pyplot as plt
@@ -80,7 +80,7 @@ plot_range = {
 
 def generate_df_dict(
     tag=None, date_min=None, date_max=None, methods_to_show=None
-) -> Dict[str, pd.DataFrame]:
+) -> dict[str, pd.DataFrame]:
     # todo load one df per task would be more efficient
     def metadata_filter(metadata, benchmark=None, tag=None):
         if methods_to_show is not None and not metadata["algorithm"] in methods_to_show:
@@ -161,7 +161,7 @@ def plot_result_benchmark(
     df_task,
     title: str,
     show_seeds: bool = False,
-    method_styles: Optional[Dict] = None,
+    method_styles: Optional[dict] = None,
     ax=None,
     methods_to_show: list = None,
 ):
@@ -253,7 +253,7 @@ def plot_result_benchmark(
 
 def plot_results(
     benchmarks_to_df,
-    method_styles: Optional[Dict] = None,
+    method_styles: Optional[dict] = None,
     prefix: str = "",
     title: str = None,
     ax=None,
@@ -350,7 +350,7 @@ def compute_best_value_over_time(benchmarks_to_df, methods_to_show):
     return methods_to_show, np.stack(benchmark_results)
 
 
-def print_rank_table(benchmarks_to_df, methods_to_show: Optional[List[str]]):
+def print_rank_table(benchmarks_to_df, methods_to_show: Optional[list[str]]):
     from sklearn.preprocessing import QuantileTransformer
     from benchmarking.nursery.benchmark_automl.results_analysis.utils import (
         compute_best_value_over_time,
@@ -407,7 +407,7 @@ def print_rank_table(benchmarks_to_df, methods_to_show: Optional[List[str]]):
 
 
 def load_and_cache(
-    experiment_tag: Union[str, List[str]],
+    experiment_tag: Union[str, list[str]],
     load_cache_if_exists: bool = True,
     methods_to_show=None,
 ):

--- a/nursery/benchmark_definitions/finetune_transformer_glue.py
+++ b/nursery/benchmark_definitions/finetune_transformer_glue.py
@@ -1,4 +1,3 @@
-from typing import Dict
 from pathlib import Path
 
 from syne_tune.experiments.benchmark_definitions.common import RealBenchmarkDefinition
@@ -158,7 +157,7 @@ def finetune_transformer_glue_all_benchmarks(
     train_valid_fraction: float = 0.7,
     random_seed: int = 31415927,
     **kwargs,
-) -> Dict[str, RealBenchmarkDefinition]:
+) -> dict[str, RealBenchmarkDefinition]:
     result = dict()
     for choose_model in [True, False]:
         prefix = "finetune_transformer_glue_"

--- a/nursery/benchmark_definitions/real_benchmark_definitions.py
+++ b/nursery/benchmark_definitions/real_benchmark_definitions.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from syne_tune.experiments.benchmark_definitions.common import RealBenchmarkDefinition
 from benchmarking.benchmark_definitions.distilbert_on_imdb import (
     distilbert_imdb_benchmark,
@@ -26,7 +24,7 @@ from benchmarking.benchmark_definitions.transformer_wikitext2 import (
 
 def real_benchmark_definitions(
     sagemaker_backend: bool = False, **kwargs
-) -> Dict[str, RealBenchmarkDefinition]:
+) -> dict[str, RealBenchmarkDefinition]:
     result = {
         "resnet_cifar10": resnet_cifar10_benchmark(
             sagemaker_backend=sagemaker_backend, **kwargs

--- a/nursery/benchmark_multiobjective/plot_results.py
+++ b/nursery/benchmark_multiobjective/plot_results.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional
+from typing import Any, Optional
 import logging
 
 from benchmarking.nursery.benchmark_multiobjective.baselines import methods
@@ -12,7 +12,7 @@ from syne_tune.experiments import (
 )
 
 
-def metadata_to_setup(metadata: Dict[str, Any]) -> Optional[str]:
+def metadata_to_setup(metadata: dict[str, Any]) -> Optional[str]:
     # The setup is the algorithm. No filtering
     return metadata["algorithm"]
 

--- a/nursery/benchmark_neuralband/baselines.py
+++ b/nursery/benchmark_neuralband/baselines.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 from syne_tune.experiments.baselines import (
     search_options,
     default_arguments,
@@ -34,7 +34,7 @@ class Methods:
     NeuralBandEpsilon = "NeuralBandEpsilon"
 
 
-def conv_numeric_only(margs) -> Dict[str, Any]:
+def conv_numeric_only(margs) -> dict[str, Any]:
     return convert_categorical_to_ordinal_numeric(
         margs.config_space, kind=margs.fcnet_ordinal
     )

--- a/nursery/benchmark_neuralband/hpo_main.py
+++ b/nursery/benchmark_neuralband/hpo_main.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 from syne_tune.experiments.launchers.hpo_main_simulator import main
 from baselines import methods
 from benchmark_definitions import benchmark_definitions
@@ -14,7 +14,7 @@ extra_args = [
 ]
 
 
-def map_method_args(args, method: str, method_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+def map_method_args(args, method: str, method_kwargs: dict[str, Any]) -> dict[str, Any]:
     if args.num_brackets is not None:
         new_dict = {
             "scheduler_kwargs": {"brackets": args.num_brackets},

--- a/nursery/examples/benchmark_dehb/baselines.py
+++ b/nursery/examples/benchmark_dehb/baselines.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 from syne_tune.experiments.baselines import (
     convert_categorical_to_ordinal,
     convert_categorical_to_ordinal_numeric,
@@ -25,7 +25,7 @@ class Methods:
     SYNCMOBSTER = "SYNCMOBSTER"
 
 
-def conv_numeric_then_rest(margs) -> Dict[str, Any]:
+def conv_numeric_then_rest(margs) -> dict[str, Any]:
     return convert_categorical_to_ordinal(
         convert_categorical_to_ordinal_numeric(
             margs.config_space, kind=margs.fcnet_ordinal

--- a/nursery/examples/benchmark_dehb/hpo_main.py
+++ b/nursery/examples/benchmark_dehb/hpo_main.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 
 from baselines import methods
 from benchmark_definitions import benchmark_definitions
@@ -15,7 +15,7 @@ extra_args = [
 ]
 
 
-def map_method_args(args, method: str, method_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+def map_method_args(args, method: str, method_kwargs: dict[str, Any]) -> dict[str, Any]:
     if args.num_brackets is not None:
         new_dict = {
             "scheduler_kwargs": {"brackets": args.num_brackets},

--- a/nursery/examples/benchmark_dyhpo/hpo_main.py
+++ b/nursery/examples/benchmark_dyhpo/hpo_main.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional, List
+from typing import Any, Optional
 
 from baselines import methods
 from benchmark_definitions import benchmark_definitions
@@ -36,7 +36,7 @@ extra_args = [
 ]
 
 
-def map_method_args(args, method: str, method_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+def map_method_args(args, method: str, method_kwargs: dict[str, Any]) -> dict[str, Any]:
     scheduler_kwargs = dict()
     if method.startswith("DYHPO"):
         if args.rung_increment is not None:
@@ -57,7 +57,7 @@ def map_method_args(args, method: str, method_kwargs: Dict[str, Any]) -> Dict[st
 
 
 class DyHPOExtraResults(ExtraResultsComposer):
-    def __call__(self, tuner: "Tuner") -> Optional[Dict[str, Any]]:
+    def __call__(self, tuner: "Tuner") -> Optional[dict[str, Any]]:
         # Only for DyHPO
         result = None
         scheduler = tuner.scheduler
@@ -68,7 +68,7 @@ class DyHPOExtraResults(ExtraResultsComposer):
             result = scheduler.terminator._rung_systems[0].summary_schedule_records()
         return result
 
-    def keys(self) -> List[str]:
+    def keys(self) -> list[str]:
         return DyHPORungSystem.summary_schedule_keys()
 
 

--- a/nursery/examples/benchmark_hypertune/hpo_main.py
+++ b/nursery/examples/benchmark_hypertune/hpo_main.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 
 from baselines import methods
 from benchmark_definitions import benchmark_definitions
@@ -21,7 +21,7 @@ extra_args = [
 ]
 
 
-def map_method_args(args, method: str, method_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+def map_method_args(args, method: str, method_kwargs: dict[str, Any]) -> dict[str, Any]:
     if method.startswith("HYPERTUNE"):
         scheduler_kwargs = {
             "search_options": {"hypertune_distribution_num_samples": args.num_samples},

--- a/nursery/examples/benchmark_hypertune/plot_results.py
+++ b/nursery/examples/benchmark_hypertune/plot_results.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional
+from typing import Any, Optional
 import logging
 
 from baselines import methods
@@ -6,7 +6,7 @@ from benchmark_definitions import benchmark_definitions
 from syne_tune.experiments import ComparativeResults, PlotParameters, SubplotParameters
 
 
-def metadata_to_setup(metadata: Dict[str, Any]) -> Optional[str]:
+def metadata_to_setup(metadata: dict[str, Any]) -> Optional[str]:
     # The setup is the algorithm. No filtering
     return metadata["algorithm"]
 
@@ -14,7 +14,7 @@ def metadata_to_setup(metadata: Dict[str, Any]) -> Optional[str]:
 SETUPS_RIGHT = ("ASHA", "SYNCHB", "BOHB")
 
 
-def metadata_to_subplot(metadata: Dict[str, Any]) -> Optional[int]:
+def metadata_to_subplot(metadata: dict[str, Any]) -> Optional[int]:
     return int(metadata["algorithm"] in SETUPS_RIGHT)
 
 

--- a/nursery/examples/demo_experiment/hpo_main.py
+++ b/nursery/examples/demo_experiment/hpo_main.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any, List
+from typing import Optional, Any
 
 from baselines import methods
 from benchmark_definitions import benchmark_definitions
@@ -17,7 +17,7 @@ class RungLevelsExtraResults(ExtraResultsComposer):
     information normally not recorded and stored.
     """
 
-    def __call__(self, tuner: Tuner) -> Optional[Dict[str, Any]]:
+    def __call__(self, tuner: Tuner) -> Optional[dict[str, Any]]:
         if not isinstance(tuner.scheduler, LegacyHyperbandScheduler):
             return None
         rung_information = tuner.scheduler.terminator.information_for_rungs()
@@ -27,7 +27,7 @@ class RungLevelsExtraResults(ExtraResultsComposer):
             if resource in RESOURCE_LEVELS
         }
 
-    def keys(self) -> List[str]:
+    def keys(self) -> list[str]:
         return [f"num_at_level{r}" for r in RESOURCE_LEVELS]
 
 

--- a/nursery/examples/demo_experiment/plot_results.py
+++ b/nursery/examples/demo_experiment/plot_results.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional, List, Set
+from typing import Any, Optional
 import logging
 
 from baselines import methods
@@ -7,7 +7,7 @@ from hpo_main import RungLevelsExtraResults
 from syne_tune.experiments import ComparativeResults, PlotParameters, SubplotParameters
 
 
-def metadata_to_setup(metadata: Dict[str, Any]) -> Optional[str]:
+def metadata_to_setup(metadata: dict[str, Any]) -> Optional[str]:
     # The setup is the algorithm. No filtering
     return metadata["algorithm"]
 
@@ -24,14 +24,14 @@ SETUP_TO_SUBPLOT = {
 }
 
 
-def metadata_to_subplot(metadata: Dict[str, Any]) -> Optional[int]:
+def metadata_to_subplot(metadata: dict[str, Any]) -> Optional[int]:
     return SETUP_TO_SUBPLOT[metadata["algorithm"]]
 
 
 def _print_extra_results(
-    extra_results: Dict[str, Dict[str, List[float]]],
-    keys: List[str],
-    skip_setups: Set[str],
+    extra_results: dict[str, dict[str, list[float]]],
+    keys: list[str],
+    skip_setups: set[str],
 ):
     for setup_name, results_for_setup in extra_results.items():
         if setup_name not in skip_setups:

--- a/nursery/examples/fine_tuning_transformer_glue/hpo_main.py
+++ b/nursery/examples/fine_tuning_transformer_glue/hpo_main.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 
 from benchmarking.examples.fine_tuning_transformer_glue.baselines import methods
 from benchmarking.benchmark_definitions import (
@@ -30,7 +30,7 @@ extra_args = [
 ]
 
 
-def map_method_args(args, method: str, method_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+def map_method_args(args, method: str, method_kwargs: dict[str, Any]) -> dict[str, Any]:
     # We need to change ``method_kwargs.config_space``, based on ``extra_args``
     new_method_kwargs = method_kwargs.copy()
     new_config_space = new_method_kwargs["config_space"].copy()

--- a/nursery/examples/fine_tuning_transformer_glue/plot_results.py
+++ b/nursery/examples/fine_tuning_transformer_glue/plot_results.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional
+from typing import Any, Optional
 
 from benchmarking.examples.fine_tuning_transformer_glue.baselines import methods
 from benchmarking.benchmark_definitions import (
@@ -14,7 +14,7 @@ from syne_tune.experiments import (
 SETUPS = list(methods.keys())
 
 
-def metadata_to_setup(metadata: Dict[str, Any]) -> Optional[str]:
+def metadata_to_setup(metadata: dict[str, Any]) -> Optional[str]:
     # The setup is the algorithm. No filtering
     return metadata["algorithm"]
 

--- a/nursery/examples/fine_tuning_transformer_swag/hpo_main.py
+++ b/nursery/examples/fine_tuning_transformer_swag/hpo_main.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 
 from benchmarking.examples.fine_tuning_transformer_swag.baselines import methods
 from benchmarking.benchmark_definitions import (
@@ -27,7 +27,7 @@ extra_args = [
 ]
 
 
-def map_method_args(args, method: str, method_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+def map_method_args(args, method: str, method_kwargs: dict[str, Any]) -> dict[str, Any]:
     # We need to change ``method_kwargs.config_space``, based on ``extra_args``
     new_method_kwargs = method_kwargs.copy()
     new_config_space = new_method_kwargs["config_space"].copy()

--- a/nursery/odsc_tutorial/transformer_wikitext2/benchmark_definitions.py
+++ b/nursery/odsc_tutorial/transformer_wikitext2/benchmark_definitions.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from syne_tune.experiments.benchmark_definitions import RealBenchmarkDefinition
 from transformer_wikitext2.code.transformer_wikitext2_definition import (
     transformer_wikitext2_benchmark,
@@ -8,7 +6,7 @@ from transformer_wikitext2.code.transformer_wikitext2_definition import (
 
 def benchmark_definitions(
     sagemaker_backend: bool = False, **kwargs
-) -> Dict[str, RealBenchmarkDefinition]:
+) -> dict[str, RealBenchmarkDefinition]:
     return {
         "transformer_wikitext2": transformer_wikitext2_benchmark(
             sagemaker_backend=sagemaker_backend, **kwargs

--- a/nursery/odsc_tutorial/transformer_wikitext2/local/plot_learning_curve_pairs.py
+++ b/nursery/odsc_tutorial/transformer_wikitext2/local/plot_learning_curve_pairs.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional
+from typing import Any, Optional
 import logging
 
 from transformer_wikitext2.baselines import methods
@@ -14,7 +14,7 @@ from syne_tune.experiments import (
 SETUPS = list(methods.keys())
 
 
-def metadata_to_setup(metadata: Dict[str, Any]) -> Optional[str]:
+def metadata_to_setup(metadata: dict[str, Any]) -> Optional[str]:
     return metadata["algorithm"]
 
 

--- a/nursery/odsc_tutorial/transformer_wikitext2/local/plot_learning_curves.py
+++ b/nursery/odsc_tutorial/transformer_wikitext2/local/plot_learning_curves.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional
+from typing import Any, Optional
 import logging
 
 from transformer_wikitext2.baselines import methods
@@ -14,7 +14,7 @@ from syne_tune.experiments import (
 SETUPS = list(methods.keys())
 
 
-def metadata_to_setup(metadata: Dict[str, Any]) -> Optional[str]:
+def metadata_to_setup(metadata: dict[str, Any]) -> Optional[str]:
     return metadata["algorithm"]
 
 

--- a/nursery/odsc_tutorial/transformer_wikitext2/local/plot_results.py
+++ b/nursery/odsc_tutorial/transformer_wikitext2/local/plot_results.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional
+from typing import Any, Optional
 import logging
 
 from transformer_wikitext2.baselines import methods
@@ -9,7 +9,7 @@ from syne_tune.experiments import ComparativeResults, PlotParameters
 SETUPS = list(methods.keys())
 
 
-def metadata_to_setup(metadata: Dict[str, Any]) -> Optional[str]:
+def metadata_to_setup(metadata: dict[str, Any]) -> Optional[str]:
     return metadata["algorithm"]
 
 

--- a/nursery/odsc_tutorial/transformer_wikitext2/sagemaker/plot_results.py
+++ b/nursery/odsc_tutorial/transformer_wikitext2/sagemaker/plot_results.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional
+from typing import Any, Optional
 import logging
 
 from transformer_wikitext2.benchmark_definitions import benchmark_definitions
@@ -12,7 +12,7 @@ TMLR10_SETUPS = [
 ]
 
 
-def metadata_to_setup(metadata: Dict[str, Any]) -> Optional[str]:
+def metadata_to_setup(metadata: dict[str, Any]) -> Optional[str]:
     return f"{metadata['n_workers']} workers"
 
 

--- a/nursery/othpo/bo_warm_transfer.py
+++ b/nursery/othpo/bo_warm_transfer.py
@@ -1,7 +1,7 @@
 import copy
 import numpy as np
 
-from typing import Dict, Any
+from typing import Any
 
 from syne_tune.optimizer.legacy_baselines import BoTorch
 from syne_tune.optimizer.schedulers.transfer_learning import (
@@ -168,9 +168,9 @@ class WarmStartBayesianOptimization(BoTorch):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        transfer_learning_evaluations: Dict[Any, LegacyTransferLearningTaskEvaluations],
+        transfer_learning_evaluations: dict[Any, LegacyTransferLearningTaskEvaluations],
         num_warm_points: int,
         points_to_evaluate=[],
         sort_by_task_id=None,

--- a/nursery/othpo/plotting/plot_yahpo_landscapes.py
+++ b/nursery/othpo/plotting/plot_yahpo_landscapes.py
@@ -2,7 +2,6 @@ import matplotlib.pyplot as plt
 import os
 import pandas as pd
 import numpy as np
-from typing import List
 import sys
 from pathlib import Path
 
@@ -21,7 +20,7 @@ def plot_hp_perf(
     scenario: str,
     instance: str,
     metric: str,
-    train_fracs: List[float],
+    train_fracs: list[float],
     x_par,
     y_par,
     log_x=True,

--- a/nursery/othpo/simopt/simopt_helpers.py
+++ b/nursery/othpo/simopt/simopt_helpers.py
@@ -1,6 +1,5 @@
 from simopt.base import Problem
 import numpy as np
-from typing import List
 
 
 def evaluate_problem_price(prob: Problem, xx, rand_gen, reps: int = 1):
@@ -39,7 +38,7 @@ def evaluate_problem_price(prob: Problem, xx, rand_gen, reps: int = 1):
 def plot_problem(
     ax,
     ii: int,
-    results: List[float],
+    results: list[float],
     task_num: int,
     N: int,
     num_cols: int,

--- a/nursery/test_checkpoints/hpo_main.py
+++ b/nursery/test_checkpoints/hpo_main.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Any, List
+from typing import Optional, Any
 
 from benchmarking.benchmark_definitions import (
     real_benchmark_definitions as benchmark_definitions,
@@ -14,11 +14,11 @@ from syne_tune.util import find_first_of_type
 
 
 class CPRemovalExtraResults(ExtraResultsComposer):
-    def __call__(self, tuner: Tuner) -> Optional[Dict[str, Any]]:
+    def __call__(self, tuner: Tuner) -> Optional[dict[str, Any]]:
         callback = find_first_of_type(tuner.callbacks, HyperbandRemoveCheckpointsCommon)
         return None if callback is None else callback.extra_results()
 
-    def keys(self) -> List[str]:
+    def keys(self) -> list[str]:
         return HyperbandRemoveCheckpointsCommon.extra_results_keys()
 
 

--- a/nursery/training_scripts/finetune_transformer_glue/run_glue_modified.py
+++ b/nursery/training_scripts/finetune_transformer_glue/run_glue_modified.py
@@ -8,7 +8,7 @@ import os
 import random
 import sys
 from dataclasses import dataclass, field
-from typing import Optional, Dict, Any
+from typing import Optional, Any
 
 import numpy as np
 import datasets
@@ -188,7 +188,7 @@ class ReportBackMetrics(transformers.trainer_callback.TrainerCallback):
 # [ 3]
 def additional_syne_tune_metrics(
     model, tokenizer, train_dataset, data_args, syne_tune_args
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Additional metrics are total number of trainable model parameters, and
     prediction latency of the model. The latter is estimated by running a

--- a/nursery/utils/get_cost_model.py
+++ b/nursery/utils/get_cost_model.py
@@ -1,8 +1,8 @@
-from typing import Tuple, Dict, Any
+from typing import Any
 
 
 def get_cost_model_for_batch_size(
-    params: Dict[str, Any], batch_size_key: str, batch_size_range: Tuple[int, int]
+    params: dict[str, Any], batch_size_key: str, batch_size_range: tuple[int, int]
 ):
     """
     Returns cost model depending on the batch size only.

--- a/nursery/utils/searcher_state_callback.py
+++ b/nursery/utils/searcher_state_callback.py
@@ -1,4 +1,3 @@
-from typing import Dict
 import json
 import time
 
@@ -37,7 +36,7 @@ class StoreSearcherStatesCallback(TunerCallback):
             if isinstance(searcher, ModelBasedSearcher):
                 self._searcher = searcher
 
-    def on_trial_result(self, trial: Trial, status: str, result: Dict, decision: str):
+    def on_trial_result(self, trial: Trial, status: str, result: dict, decision: str):
         if self._searcher is not None:
             state = self._searcher.state_transformer.state
             num_observations = state.num_observed_cases()

--- a/syne_tune/backend/local_backend.py
+++ b/syne_tune/backend/local_backend.py
@@ -6,7 +6,7 @@ from operator import itemgetter
 import subprocess
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional, Tuple, Dict, Any
+from typing import Optional, Any
 
 from syne_tune.backend.trial_backend import TrialBackend, BUSY_STATUS
 from syne_tune.num_gpu import get_num_gpus
@@ -57,7 +57,7 @@ class LocalBackend(TrialBackend):
         pass_args_as_json: bool = False,
         rotate_gpus: bool = True,
         num_gpus_per_trial: int = 1,
-        gpus_to_use: Optional[List[int]] = None,
+        gpus_to_use: Optional[list[int]] = None,
     ):
         super(LocalBackend, self).__init__(
             delete_checkpoints=delete_checkpoints, pass_args_as_json=pass_args_as_json
@@ -152,7 +152,7 @@ class LocalBackend(TrialBackend):
                 # Nothing to rotate over
                 self.rotate_gpus = False
 
-    def _gpus_for_new_trial(self) -> List[int]:
+    def _gpus_for_new_trial(self) -> list[int]:
         """
         Selects ``num_gpus_per_trial`` GPUs for trial to be scheduled on. GPUs
         not assigned to other running trials have precedence. Ties are resolved
@@ -184,7 +184,7 @@ class LocalBackend(TrialBackend):
             self.gpu_times_assigned[gpu] += 1
         return res_gpu
 
-    def _schedule(self, trial_id: int, config: Dict[str, Any]):
+    def _schedule(self, trial_id: int, config: dict[str, Any]):
         self._prepare_for_schedule()
         trial_path = self.trial_path(trial_id)
         os.makedirs(trial_path, exist_ok=True)
@@ -216,7 +216,7 @@ class LocalBackend(TrialBackend):
                 )
         self._busy_trial_id_candidates.add(trial_id)  # Mark trial as busy
 
-    def _allocate_gpu(self, trial_id: int, env: Dict[str, Any]):
+    def _allocate_gpu(self, trial_id: int, env: dict[str, Any]):
         if self.rotate_gpus:
             gpus = self._gpus_for_new_trial()
             if self.gpus_to_use is not None:
@@ -233,7 +233,7 @@ class LocalBackend(TrialBackend):
         if self.rotate_gpus and trial_id in self.trial_gpu:
             del self.trial_gpu[trial_id]
 
-    def _all_trial_results(self, trial_ids: List[int]) -> List[TrialResult]:
+    def _all_trial_results(self, trial_ids: list[int]) -> list[TrialResult]:
         res = []
         for trial_id in trial_ids:
             trial_path = self.trial_path(trial_id)
@@ -329,7 +329,7 @@ class LocalBackend(TrialBackend):
                 else:
                     return Status.failed
 
-    def _get_busy_trial_ids(self) -> List[Tuple[int, str]]:
+    def _get_busy_trial_ids(self) -> list[tuple[int, str]]:
         busy_list = []
         for trial_id in self._busy_trial_id_candidates:
             status = self._read_status(trial_id)
@@ -337,7 +337,7 @@ class LocalBackend(TrialBackend):
                 busy_list.append((trial_id, status))
         return busy_list
 
-    def busy_trial_ids(self) -> List[Tuple[int, str]]:
+    def busy_trial_ids(self) -> list[tuple[int, str]]:
         # Note that at this point, ``self._busy_trial_id_candidates`` contains
         # trials whose jobs have been busy in the past, but they may have
         # stopped or terminated since. We query the current status for all
@@ -350,11 +350,11 @@ class LocalBackend(TrialBackend):
         else:
             return []
 
-    def stdout(self, trial_id: int) -> List[str]:
+    def stdout(self, trial_id: int) -> list[str]:
         with open(self.trial_path(trial_id=trial_id) / "std.out", "r") as f:
             return f.readlines()
 
-    def stderr(self, trial_id: int) -> List[str]:
+    def stderr(self, trial_id: int) -> list[str]:
         with open(self.trial_path(trial_id=trial_id) / "std.err", "r") as f:
             return f.readlines()
 

--- a/syne_tune/backend/python_backend/python_backend.py
+++ b/syne_tune/backend/python_backend/python_backend.py
@@ -2,7 +2,8 @@ import hashlib
 import logging
 import types
 from pathlib import Path
-from typing import Callable, Dict, Optional, Any
+from typing import Optional, Any
+from collections.abc import Callable
 
 import dill
 
@@ -67,7 +68,7 @@ class PythonBackend(LocalBackend):
     def __init__(
         self,
         tune_function: Callable,
-        config_space: Dict[str, object],
+        config_space: dict[str, object],
         rotate_gpus: bool = True,
         delete_checkpoints: bool = False,
     ):
@@ -96,7 +97,7 @@ class PythonBackend(LocalBackend):
                 f"Path {self.local_path} already exists, make sure you have a unique tuner name."
             )
 
-    def _schedule(self, trial_id: int, config: Dict[str, Any]):
+    def _schedule(self, trial_id: int, config: dict[str, Any]):
         if not (self.tune_function_path / "tune_function.dill").exists():
             self.save_tune_function(self.tune_function)
         config = config.copy()

--- a/syne_tune/backend/simulator_backend/events.py
+++ b/syne_tune/backend/simulator_backend/events.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Tuple, Optional, Dict, Any
+from typing import Optional, Any
 import heapq
 
 
@@ -51,10 +51,10 @@ class OnTrialResultEvent(Event):
 
     """
 
-    result: Dict[str, Any]
+    result: dict[str, Any]
 
 
-EventHeapType = List[Tuple[float, int, Event]]
+EventHeapType = list[tuple[float, int, Event]]
 
 
 class SimulatorState:

--- a/syne_tune/backend/simulator_backend/simulator_backend.py
+++ b/syne_tune/backend/simulator_backend/simulator_backend.py
@@ -2,7 +2,7 @@ import logging
 import os
 from datetime import timedelta
 import copy
-from typing import Dict, List, Optional, Tuple
+from typing import Optional
 from dataclasses import dataclass
 import subprocess
 
@@ -156,7 +156,7 @@ class SimulatorBackend(LocalBackend):
         logger.debug(msg)
 
     def start_trial(
-        self, config: Dict, checkpoint_trial_id: Optional[int] = None
+        self, config: dict, checkpoint_trial_id: Optional[int] = None
     ) -> Trial:
         # Overwritten to record the correct ``creation_time``
         trial_id = self.new_trial_id()
@@ -314,7 +314,7 @@ class SimulatorBackend(LocalBackend):
         self._time_keeper.advance(self._time_keeper.real_time_since_last_recent_exit())
 
     def fetch_status_results(
-        self, trial_ids: List[int]
+        self, trial_ids: list[int]
     ) -> (TrialAndStatusInformation, TrialIdAndResultList):
         self._advance_by_outside_time()
         # Process all events in the past
@@ -370,7 +370,7 @@ class SimulatorBackend(LocalBackend):
         self._time_keeper.mark_exit()
         return trial_status_dict, results
 
-    def _schedule(self, trial_id: int, config: Dict):
+    def _schedule(self, trial_id: int, config: dict):
         """
         This is called by :meth:`start_trial` or :meth:`resume_trial`. We register a start
         event here. ``config`` can be ignored, it will be in
@@ -394,7 +394,7 @@ class SimulatorBackend(LocalBackend):
         logger.debug(f"Simulated time since start: {_time_start:.2f} secs")
         self._time_keeper.mark_exit()
 
-    def _all_trial_results(self, trial_ids: List[int]) -> List[TrialResult]:
+    def _all_trial_results(self, trial_ids: list[int]) -> list[TrialResult]:
         """
         Note: Since this is not used anymore in :meth:`fetch_results`, it can
         simply just return all registered trials which already have some
@@ -455,7 +455,7 @@ class SimulatorBackend(LocalBackend):
 
     def _run_job_and_collect_results(
         self, trial_id: int, config: Optional[dict] = None
-    ) -> (str, List[dict]):
+    ) -> (str, list[dict]):
         """
         Runs training evaluation script for trial ``trial_id``, using the config
         ``trial(trial_id).config``. This is a blocking call, we wait for the
@@ -506,6 +506,6 @@ class SimulatorBackend(LocalBackend):
         results = all_results[num_already_before:]
         return status, results
 
-    def busy_trial_ids(self) -> List[Tuple[int, str]]:
+    def busy_trial_ids(self) -> list[tuple[int, str]]:
         self._process_events_until_now()
         return [(trial_id, Status.in_progress) for trial_id in self._busy_trial_ids]

--- a/syne_tune/backend/trial_backend.py
+++ b/syne_tune/backend/trial_backend.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Tuple, Optional, Any
+from typing import Optional, Any
 import logging
 
 from syne_tune.backend.trial_status import TrialResult, Trial, Status
@@ -11,10 +11,10 @@ from syne_tune.constants import ST_WORKER_TIMESTAMP
 logger = logging.getLogger(__name__)
 
 
-TrialAndStatusInformation = Dict[int, Tuple[Trial, str]]
+TrialAndStatusInformation = dict[int, Tuple[Trial, str]]
 
 
-TrialIdAndResultList = List[Tuple[int, dict]]
+TrialIdAndResultList = list[Tuple[int, dict]]
 
 
 BUSY_STATUS = {Status.in_progress, Status.stopping}
@@ -57,7 +57,7 @@ class TrialBackend:
         self._last_metric_seen_index = defaultdict(lambda: 0)
 
     def start_trial(
-        self, config: Dict[str, Any], checkpoint_trial_id: Optional[int] = None
+        self, config: dict[str, Any], checkpoint_trial_id: Optional[int] = None
     ) -> TrialResult:
         """Start new trial with new trial ID
 
@@ -203,7 +203,7 @@ class TrialBackend:
     def new_trial_id(self) -> int:
         return len(self.trial_ids)
 
-    def _schedule(self, trial_id: int, config: Dict[str, Any]):
+    def _schedule(self, trial_id: int, config: dict[str, Any]):
         """Schedules job for trial evaluation.
 
         Called by :meth:`start_trial`, :meth:`resume_trial`.
@@ -213,7 +213,7 @@ class TrialBackend:
         """
         raise NotImplementedError
 
-    def _all_trial_results(self, trial_ids: List[int]) -> List[TrialResult]:
+    def _all_trial_results(self, trial_ids: list[int]) -> list[TrialResult]:
         """Returns results for selected trials
 
         :param trial_ids: IDs of trials for which results are to be queried
@@ -223,7 +223,7 @@ class TrialBackend:
         raise NotImplementedError
 
     def fetch_status_results(
-        self, trial_ids: List[int]
+        self, trial_ids: list[int]
     ) -> (TrialAndStatusInformation, TrialIdAndResultList):
         """
         :param trial_ids: Trials whose information should be fetched.
@@ -267,7 +267,7 @@ class TrialBackend:
         results = sorted(results, key=lambda result: result[1][ST_WORKER_TIMESTAMP])
         return trial_status_dict, results
 
-    def busy_trial_ids(self) -> List[Tuple[int, str]]:
+    def busy_trial_ids(self) -> list[tuple[int, str]]:
         """Returns list of ids for currently busy trials
 
         A trial is busy if its status is
@@ -281,7 +281,7 @@ class TrialBackend:
         """
         raise NotImplementedError
 
-    def stdout(self, trial_id: int) -> List[str]:
+    def stdout(self, trial_id: int) -> list[str]:
         """Fetch ``stdout`` log for trial
 
         :param trial_id: ID of trial
@@ -289,7 +289,7 @@ class TrialBackend:
         """
         raise NotImplementedError
 
-    def stderr(self, trial_id: int) -> List[str]:
+    def stderr(self, trial_id: int) -> list[str]:
         """Fetch ``stderr`` log for trial
 
         :param trial_id: ID of trial

--- a/syne_tune/backend/trial_status.py
+++ b/syne_tune/backend/trial_status.py
@@ -2,7 +2,7 @@
 import logging
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Dict, Optional, List
+from typing import Optional
 
 try:
     from typing_extensions import Literal
@@ -26,7 +26,7 @@ class Status:
 @dataclass
 class Trial:
     trial_id: int
-    config: Dict[str, object]
+    config: dict[str, object]
     creation_time: datetime
 
     def add_results(self, metrics, status, training_end_time):
@@ -43,8 +43,8 @@ class Trial:
 @dataclass
 class TrialResult(Trial):
     # Metrics recorded for each call of ``report``. Each metric is a dictionary from metric name to value (
-    # could be numeric or string, the only constrain is that it must be compatible with json).
-    metrics: List[Dict[str, object]]
+    # could be numeric or string, the only constraint is that it must be compatible with json).
+    metrics: list[dict[str, object]]
     status: Literal[
         Status.completed,
         Status.in_progress,

--- a/syne_tune/blackbox_repository/blackbox.py
+++ b/syne_tune/blackbox_repository/blackbox.py
@@ -1,11 +1,12 @@
 from numbers import Number
 
 import pandas as pd
-from typing import Optional, Callable, List, Tuple, Union, Dict, Any
+from typing import Optional, Union, Any
+from collections.abc import Callable
 import numpy as np
 
 
-ObjectiveFunctionResult = Union[Dict[str, float], np.ndarray]
+ObjectiveFunctionResult = Union[dict[str, float], np.ndarray]
 
 
 class Blackbox:
@@ -23,9 +24,9 @@ class Blackbox:
 
     def __init__(
         self,
-        configuration_space: Dict[str, Any],
+        configuration_space: dict[str, Any],
         fidelity_space: Optional[dict] = None,
-        objectives_names: Optional[List[str]] = None,
+        objectives_names: Optional[list[str]] = None,
     ):
         self.configuration_space = configuration_space
         self.fidelity_space = fidelity_space
@@ -33,7 +34,7 @@ class Blackbox:
 
     def objective_function(
         self,
-        configuration: Dict[str, Any],
+        configuration: dict[str, Any],
         fidelity: Union[dict, Number] = None,
         seed: Optional[int] = None,
     ) -> ObjectiveFunctionResult:
@@ -81,7 +82,7 @@ class Blackbox:
 
     def _objective_function(
         self,
-        configuration: Dict[str, Any],
+        configuration: dict[str, Any],
         fidelity: Optional[dict] = None,
         seed: Optional[int] = None,
     ) -> ObjectiveFunctionResult:
@@ -118,7 +119,7 @@ class Blackbox:
 
     def hyperparameter_objectives_values(
         self, predict_curves: bool = False
-    ) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
         """
         If ``predict_curves`` is False, the shape of ``X`` is
         ``(num_evals * num_seeds * num_fidelities, num_hps + 1)``, the shape of ``y``
@@ -157,7 +158,7 @@ class Blackbox:
 
     def configuration_space_with_max_resource_attr(
         self, max_resource_attr: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         It is best practice to have one attribute in the configuration space to
         represent the maximum fidelity value used for evaluation (e.g., the
@@ -179,10 +180,10 @@ class Blackbox:
 
 
 def from_function(
-    configuration_space: Dict[str, Any],
+    configuration_space: dict[str, Any],
     eval_fun: Callable,
     fidelity_space: Optional[dict] = None,
-    objectives_names: Optional[List[str]] = None,
+    objectives_names: Optional[list[str]] = None,
 ) -> Blackbox:
     """
     Helper to create a blackbox from a function, useful for test or to wrap-up
@@ -206,7 +207,7 @@ def from_function(
 
         def objective_function(
             self,
-            configuration: Dict[str, Any],
+            configuration: dict[str, Any],
             fidelity: Optional[dict] = None,
             seed: Optional[int] = None,
         ) -> ObjectiveFunctionResult:

--- a/syne_tune/blackbox_repository/blackbox_offline.py
+++ b/syne_tune/blackbox_repository/blackbox_offline.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, List, Optional, Union, Any
+from typing import Optional, Union, Any
 
 import pandas as pd
 
@@ -33,9 +33,9 @@ class BlackboxOffline(Blackbox):
     def __init__(
         self,
         df_evaluations: pd.DataFrame,
-        configuration_space: Dict[str, Any],
+        configuration_space: dict[str, Any],
         fidelity_space: Optional[dict] = None,
-        objectives_names: Optional[List[str]] = None,
+        objectives_names: Optional[list[str]] = None,
         seed_col: Optional[str] = None,
     ):
         if objectives_names is not None:
@@ -85,7 +85,7 @@ class BlackboxOffline(Blackbox):
 
     def _objective_function(
         self,
-        configuration: Dict[str, Any],
+        configuration: dict[str, Any],
         fidelity: Optional[dict] = None,
         seed: Optional[int] = None,
     ) -> ObjectiveFunctionResult:
@@ -133,7 +133,7 @@ class BlackboxOffline(Blackbox):
 
 
 def serialize(
-    bb_dict: Dict[str, BlackboxOffline], path: str, categorical_cols: List[str] = []
+    bb_dict: dict[str, BlackboxOffline], path: str, categorical_cols: list[str] = []
 ):
     """
     :param bb_dict:
@@ -186,7 +186,7 @@ def serialize(
     )
 
 
-def deserialize(path: str) -> Union[Dict[str, BlackboxOffline], BlackboxOffline]:
+def deserialize(path: str) -> Union[dict[str, BlackboxOffline], BlackboxOffline]:
     """
     :param path: where to find blackbox serialized information (at least data.csv.zip and configspace.json)
     :param groupby_col: separate evaluations into a list of blackbox with different task if the column is provided

--- a/syne_tune/blackbox_repository/blackbox_surrogate.py
+++ b/syne_tune/blackbox_repository/blackbox_surrogate.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, List, Dict, Any
+from typing import Optional, Any
 import pandas as pd
 from sklearn.neighbors import KNeighborsRegressor
 from sklearn.pipeline import Pipeline, FeatureUnion, make_pipeline
@@ -104,14 +104,14 @@ class BlackboxSurrogate(Blackbox):
         self,
         X: pd.DataFrame,
         y: pd.DataFrame,
-        configuration_space: Dict[str, Any],
-        objectives_names: List[str],
+        configuration_space: dict[str, Any],
+        objectives_names: list[str],
         fidelity_space: Optional[dict] = None,
         fidelity_values: Optional[np.array] = None,
         surrogate=None,
         predict_curves: bool = False,
         num_seeds: int = 1,
-        fit_differences: Optional[List[str]] = None,
+        fit_differences: Optional[list[str]] = None,
         max_fit_samples: Optional[int] = None,
         name: Optional[str] = None,
     ):
@@ -352,7 +352,7 @@ class BlackboxSurrogate(Blackbox):
 
     def _objective_function(
         self,
-        configuration: Dict[str, Any],
+        configuration: dict[str, Any],
         fidelity: Optional[dict] = None,
         seed: Optional[int] = None,
     ) -> ObjectiveFunctionResult:
@@ -419,7 +419,7 @@ class BlackboxSurrogate(Blackbox):
 
     def hyperparameter_objectives_values(
         self, predict_curves: bool = False
-    ) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
         raise NotImplementedError("This is a surrogate already!")
 
 
@@ -429,7 +429,7 @@ def add_surrogate(
     configuration_space: Optional[dict] = None,
     predict_curves: Optional[bool] = None,
     separate_seeds: bool = False,
-    fit_differences: Optional[List[str]] = None,
+    fit_differences: Optional[list[str]] = None,
 ):
     """
     Fits a blackbox surrogates that can be evaluated anywhere, which can be useful

--- a/syne_tune/blackbox_repository/blackbox_tabular.py
+++ b/syne_tune/blackbox_repository/blackbox_tabular.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Dict, Optional, Tuple, Union, Any
+from typing import Optional, Union, Any
 import pandas as pd
 import numpy as np
 
@@ -42,7 +42,7 @@ class BlackboxTabular(Blackbox):
         fidelity_space: Dict[str, Any],
         objectives_evaluations: np.array,
         fidelity_values: Optional[np.array] = None,
-        objectives_names: Optional[List[str]] = None,
+        objectives_names: Optional[list[str]] = None,
     ):
         super(BlackboxTabular, self).__init__(
             configuration_space=configuration_space,
@@ -143,7 +143,7 @@ class BlackboxTabular(Blackbox):
     def fidelity_values(self) -> np.array:
         return self._fidelity_values
 
-    def _impute_objectives_values(self) -> Tuple[pd.DataFrame, np.array]:
+    def _impute_objectives_values(self) -> tuple[pd.DataFrame, np.array]:
         """Replaces nan values in objectives with first previous non-nan value.
 
         Time objective should be cumulative, otherwise each step will consume additional time.
@@ -184,7 +184,7 @@ class BlackboxTabular(Blackbox):
     # to understand if this was not done
     def hyperparameter_objectives_values(
         self, predict_curves: bool = False
-    ) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
         """
         If ``predict_curves`` is False, the shape of ``X`` is
         ``(num_evals * num_seeds * num_fidelities, num_hps + 1)``, the shape of ``y``
@@ -241,7 +241,7 @@ class BlackboxTabular(Blackbox):
         return X, y
 
     def rename_objectives(
-        self, objective_name_mapping: Dict[str, str]
+        self, objective_name_mapping: dict[str, str]
     ) -> "BlackboxTabular":
         """
         :param objective_name_mapping: dictionary from old objective name to
@@ -269,7 +269,7 @@ class BlackboxTabular(Blackbox):
             objectives_names=list(objective_name_mapping.values()),
         )
 
-    def all_configurations(self) -> List[Dict[str, Any]]:
+    def all_configurations(self) -> list[dict[str, Any]]:
         """
         This method is useful in order to set ``restrict_configurations`` in
         :class:`~syne_tune.optimizer.schedulers.searchers.StochasticAndFilterDuplicatesSearcher`
@@ -304,7 +304,7 @@ class BlackboxTabular(Blackbox):
 
 
 def serialize(
-    bb_dict: Dict[str, BlackboxTabular], path: str, metadata: Optional[dict] = None
+    bb_dict: dict[str, BlackboxTabular], path: str, metadata: Optional[dict] = None
 ):
     # check all blackboxes share the same search space and have evaluated the same hyperparameters
     # pick an arbitrary blackbox
@@ -360,7 +360,7 @@ def serialize(
     )
 
 
-def deserialize(path: str) -> Dict[str, BlackboxTabular]:
+def deserialize(path: str) -> dict[str, BlackboxTabular]:
     """
     Deserialize blackboxes contained in a path that were saved with :func:`serialize`
     above.

--- a/syne_tune/blackbox_repository/conversion_scripts/scripts/hpob_import.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/scripts/hpob_import.py
@@ -4,7 +4,7 @@ import json
 import pandas as pd
 import numpy as np
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 from syne_tune.blackbox_repository.blackbox_tabular import BlackboxTabular
 from syne_tune.blackbox_repository.conversion_scripts.scripts import metric_elapsed_time
 from syne_tune.blackbox_repository.conversion_scripts.utils import (
@@ -304,7 +304,7 @@ def serialize(
     )
 
 
-def deserialize(path: str) -> Dict[str, BlackboxTabular]:
+def deserialize(path: str) -> dict[str, BlackboxTabular]:
     """
     Deserialize blackboxes contained in a path that were saved with ``serialize`` above.
     TODO: the API is currently dissonant with ``serialize``, ``deserialize`` for BlackboxOffline as ``serialize`` is there a member.

--- a/syne_tune/blackbox_repository/conversion_scripts/scripts/pd1_import.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/scripts/pd1_import.py
@@ -3,7 +3,7 @@ import logging
 import os
 import tarfile
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -137,7 +137,7 @@ class PD1Recipe(BlackboxRecipe):
         else:
             logger.info(f"Skip downloading since {file_name} is available locally.")
 
-    def _convert_data(self) -> Dict[str, BlackboxTabular]:
+    def _convert_data(self) -> dict[str, BlackboxTabular]:
         with tarfile.open(repository_path / f"{BLACKBOX_NAME}.tar.gz") as f:
 
             def is_within_directory(directory, target):
@@ -210,7 +210,7 @@ class PD1Recipe(BlackboxRecipe):
                 bb_dict[task_name] = convert_task(task_data)
         return bb_dict
 
-    def _save_data(self, bb_dict: Dict[str, BlackboxTabular]) -> None:
+    def _save_data(self, bb_dict: dict[str, BlackboxTabular]) -> None:
         with catchtime("saving to disk"):
             serialize(
                 bb_dict=bb_dict,
@@ -229,7 +229,7 @@ class PD1Recipe(BlackboxRecipe):
 
 
 def serialize(
-    bb_dict: Dict[str, BlackboxTabular], path: str, metadata: Optional[Dict] = None
+    bb_dict: dict[str, BlackboxTabular], path: str, metadata: Optional[dict] = None
 ):
     # check all blackboxes share the objectives
     bb_first = next(iter(bb_dict.values()))
@@ -280,7 +280,7 @@ def serialize(
     )
 
 
-def deserialize(path: str) -> Dict[str, BlackboxTabular]:
+def deserialize(path: str) -> dict[str, BlackboxTabular]:
     """
     Deserialize blackboxes contained in a path that were saved with ``serialize`` above.
     TODO: the API is currently dissonant with ``serialize``, ``deserialize`` for BlackboxOffline as ``serialize`` is there a member.

--- a/syne_tune/blackbox_repository/conversion_scripts/scripts/yahpo_import.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/scripts/yahpo_import.py
@@ -3,7 +3,7 @@ Wrap Surrogates from
 YAHPO Gym - An Efficient Multi-Objective Multi-Fidelity Benchmark for Hyperparameter Optimization
 Florian Pfisterer, Lennart Schneider, Julia Moosbauer, Martin Binder, Bernd Bischl
 """
-from typing import Optional, List, Dict, Any
+from typing import Optional, Any
 import logging
 import shutil
 
@@ -99,7 +99,7 @@ class BlackBoxYAHPO(Blackbox):
     def __init__(
         self,
         benchmark: BenchmarkSet,
-        fidelities: Optional[List[int]] = None,
+        fidelities: Optional[list[int]] = None,
     ):
         self.benchmark = benchmark
         super(BlackBoxYAHPO, self).__init__(
@@ -163,7 +163,7 @@ class BlackBoxYAHPO(Blackbox):
             }
             self._shortened_keys = set(shortened_keys)
 
-    def _adjust_fidelity_space(self, fidelities: Optional[List[int]]):
+    def _adjust_fidelity_space(self, fidelities: Optional[list[int]]):
         assert len(self.fidelity_space) == 1, "Only one fidelity is supported"
         self._fidelity_name, domain = next(iter(self.fidelity_space.items()))
         assert (
@@ -181,7 +181,7 @@ class BlackBoxYAHPO(Blackbox):
             self._fidelity_values = np.array(fidelities)
             self.fidelity_space[self._fidelity_name] = cs.ordinal(fidelities.copy())
 
-    def _map_configuration(self, config: Dict[str, Any]) -> Dict[str, Any]:
+    def _map_configuration(self, config: dict[str, Any]) -> dict[str, Any]:
         if self._is_nb301:
 
             def map_key(k: str) -> str:
@@ -195,8 +195,8 @@ class BlackBoxYAHPO(Blackbox):
             return config
 
     def _prepare_yahpo_configuration(
-        self, configuration: Dict[str, Any], fidelity: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, configuration: dict[str, Any], fidelity: dict[str, Any]
+    ) -> dict[str, Any]:
         """Some of the hyperparameters are only active for certain values of other
         hyperparameters. We filter out the inactive ones, and add the fidelity to the
         configuration in order to interface with YAHPO.
@@ -212,7 +212,7 @@ class BlackBoxYAHPO(Blackbox):
         )
         return {k: v for k, v in configuration.items() if k in active_hyperparameters}
 
-    def _parse_fidelity(self, fidelity: Dict[str, Any]) -> Dict[str, Any]:
+    def _parse_fidelity(self, fidelity: dict[str, Any]) -> dict[str, Any]:
         if self._is_iaml or self._is_rbv2:
             k = "trainsize"
             fidelity_value = fidelity.get(k)
@@ -227,10 +227,10 @@ class BlackBoxYAHPO(Blackbox):
 
     def _objective_function(
         self,
-        configuration: Dict[str, Any],
+        configuration: dict[str, Any],
         fidelity: Optional[dict] = None,
         seed: Optional[int] = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         configuration = self._map_configuration(configuration.copy())
 
         if fidelity is not None:
@@ -335,7 +335,7 @@ def cs_to_synetune(config_space):
 def instantiate_yahpo(
     scenario: str,
     check: bool = False,
-    fidelities: Optional[List[int]] = None,
+    fidelities: Optional[list[int]] = None,
 ):
     """
     Instantiates a dict of ``BlackBoxYAHPO``, one entry for each instance.

--- a/syne_tune/blackbox_repository/repository.py
+++ b/syne_tune/blackbox_repository/repository.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Union, Dict, Optional
+from typing import Union, Optional
 
 from huggingface_hub import snapshot_download
 
@@ -29,7 +29,7 @@ from syne_tune.blackbox_repository.conversion_scripts.utils import (
 logger = logging.getLogger(__name__)
 
 
-def blackbox_list() -> List[str]:
+def blackbox_list() -> list[str]:
     """
     :return: list of blackboxes available
     """
@@ -43,7 +43,7 @@ def load_blackbox(
     local_files_only: bool = False,
     force_download: bool = False,
     **snapshot_download_kwargs,
-) -> Union[Dict[str, Blackbox], Blackbox]:
+) -> Union[dict[str, Blackbox], Blackbox]:
     """
     :param name: name of a blackbox present in the repository, see
         :func:`blackbox_list` to get list of available blackboxes. Syne Tune

--- a/syne_tune/blackbox_repository/serialize.py
+++ b/syne_tune/blackbox_repository/serialize.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional, Dict
+from typing import Optional
 import json
 
 from syne_tune.config_space import (
@@ -10,7 +10,7 @@ from syne_tune.util import dump_json_with_numpy
 
 
 def serialize_configspace(
-    path: str, configuration_space: Dict, fidelity_space: Optional[Dict] = None
+    path: str, configuration_space: dict, fidelity_space: Optional[dict] = None
 ):
     path = Path(path)
     dump_json_with_numpy(

--- a/syne_tune/blackbox_repository/simulated_tabular_backend.py
+++ b/syne_tune/blackbox_repository/simulated_tabular_backend.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import List, Optional, Dict, Any
+from typing import Optional, Any
 
 import numpy as np
 
@@ -66,11 +66,11 @@ class _BlackboxSimulatorBackend(SimulatorBackend):
             resource = int(result[resource_attr])
             self._resource_paused_for_trial[trial_id] = resource
 
-    def _filter_config(self, config: Dict[str, Any]) -> Dict[str, Any]:
+    def _filter_config(self, config: dict[str, Any]) -> dict[str, Any]:
         config_space = self.blackbox.configuration_space
         return {k: v for k, v in config.items() if k in config_space}
 
-    def config_objectives(self, config: Dict[str, Any], seed: int) -> List[dict]:
+    def config_objectives(self, config: dict[str, Any], seed: int) -> list[dict]:
         mattr = self._max_resource_attr
         if mattr is not None and mattr in config:
             max_resource = int(config[mattr])
@@ -90,7 +90,7 @@ class _BlackboxSimulatorBackend(SimulatorBackend):
 
     def _run_job_and_collect_results(
         self, trial_id: int, config: Optional[dict] = None
-    ) -> (str, List[dict]):
+    ) -> (str, list[dict]):
         assert (
             trial_id in self._trial_dict
         ), f"Trial with trial_id = {trial_id} not registered with backend"

--- a/syne_tune/blackbox_repository/utils.py
+++ b/syne_tune/blackbox_repository/utils.py
@@ -1,15 +1,15 @@
-from typing import List, Optional, Tuple, Dict, Any
+from typing import Optional, Any
 
 from syne_tune.blackbox_repository.blackbox import Blackbox
 
 
 def metrics_for_configuration(
     blackbox: Blackbox,
-    config: Dict[str, Any],
+    config: dict[str, Any],
     resource_attr: str,
-    fidelity_range: Optional[Tuple[float, float]] = None,
+    fidelity_range: Optional[tuple[float, float]] = None,
     seed: Optional[int] = None,
-) -> List[dict]:
+) -> list[dict]:
     """
     Returns all results for configuration ``config`` at fidelities in range
     ``fidelity_range``.

--- a/syne_tune/callbacks/hyperband_remove_checkpoints_callback.py
+++ b/syne_tune/callbacks/hyperband_remove_checkpoints_callback.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Dict, Any, Optional
+from typing import Any, Optional
 import numpy as np
 import logging
 import time
@@ -40,7 +40,7 @@ class BetaBinomialEstimator:
         self._num_one = 0
         self._num_total = 0
 
-    def update(self, data: List[bool]):
+    def update(self, data: list[bool]):
         self._num_one += sum(data)
         self._num_total += len(data)
 
@@ -154,7 +154,7 @@ class HyperbandRemoveCheckpointsCommon(TunerCallback):
         self,
         paused_trials_with_checkpoints: PausedTrialsResult,
         num_to_remove: int,
-    ) -> List[TrialInformation]:
+    ) -> list[TrialInformation]:
         """
         Determine trials to be removed in :meth:`on_loop_end`.
         :param paused_trials_with_checkpoints: Paused trials with checkpoints
@@ -184,13 +184,13 @@ class HyperbandRemoveCheckpointsCommon(TunerCallback):
                 )
             logger.info("\n".join(msg_parts))
 
-    def on_trial_complete(self, trial: Trial, result: Dict[str, Any]):
+    def on_trial_complete(self, trial: Trial, result: dict[str, Any]):
         trial_id = str(trial.trial_id)
         self._trial_status[trial_id] = TrialStatus.STOPPED_OR_COMPLETED
         self._trials_with_checkpoints_removed.pop(trial_id, None)
 
     def on_trial_result(
-        self, trial: Trial, status: str, result: Dict[str, Any], decision: str
+        self, trial: Trial, status: str, result: dict[str, Any], decision: str
     ):
         trial_id = str(trial.trial_id)
         if decision == SchedulerDecision.CONTINUE:
@@ -217,14 +217,14 @@ class HyperbandRemoveCheckpointsCommon(TunerCallback):
             self._trials_resumed_without_checkpoint.append((trial_id, level))
             del self._trials_with_checkpoints_removed[trial_id]
 
-    def trials_resumed_without_checkpoint(self) -> List[Tuple[str, int]]:
+    def trials_resumed_without_checkpoint(self) -> list[tuple[str, int]]:
         """
         :return: List of ``(trial_id, level)`` for trials which were resumed, even
             though their checkpoint was removed
         """
         return self._trials_resumed_without_checkpoint
 
-    def extra_results(self) -> Dict[str, Any]:
+    def extra_results(self) -> dict[str, Any]:
         """
         :return: Dictionary containing information which can be appended to
             results written out
@@ -239,7 +239,7 @@ class HyperbandRemoveCheckpointsCommon(TunerCallback):
         }
 
     @staticmethod
-    def extra_results_keys() -> List[str]:
+    def extra_results_keys() -> list[str]:
         return ["num_checkpoints_removed", "num_trials_resumed", "cost_resources"]
 
 
@@ -340,7 +340,7 @@ class HyperbandRemoveCheckpointsCallback(HyperbandRemoveCheckpointsCommon):
 
     def _prepare_score_inputs(
         self, trials_to_score: PausedTrialsResult
-    ) -> (List[str], np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray):
+    ) -> (list[str], np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray):
         info_rungs = self._scheduler.terminator.information_for_rungs()
         lens_rung = {r: n for r, n, _ in info_rungs}
         prom_quants_rung = {r: alpha for r, _, alpha in info_rungs}
@@ -367,7 +367,7 @@ class HyperbandRemoveCheckpointsCallback(HyperbandRemoveCheckpointsCommon):
 
     def _compute_scores(
         self, trials_to_score: PausedTrialsResult, time_ratio: float
-    ) -> List[TrialInformation]:
+    ) -> list[TrialInformation]:
         r"""
         Computes scores for paused trials in ``trials_to_score``, with entries
         ``(trial_id, rank, metric_val, level)``. These are approximations of
@@ -429,14 +429,14 @@ class HyperbandRemoveCheckpointsCallback(HyperbandRemoveCheckpointsCommon):
         self,
         paused_trials_with_checkpoints: PausedTrialsResult,
         num_to_remove: int,
-    ) -> List[TrialInformation]:
+    ) -> list[TrialInformation]:
         time_ratio = self._get_time_ratio()
         # logger.info(f"*** Time ratio beta = {time_ratio}")
         # self._log_estimator_status()
         scores = self._compute_scores(paused_trials_with_checkpoints, time_ratio)
         return sorted(scores, key=lambda trial: trial.score_val)[:num_to_remove]
 
-    def _update_estimators(self, trial_id: str, result: Dict[str, Any]):
+    def _update_estimators(self, trial_id: str, result: dict[str, Any]):
         metric_val = float(result[self._metric])
         level = int(result[self._resource_attr])
         # Paused trials with checkpoints at rung level ``level``. If ``level`` is
@@ -456,7 +456,7 @@ class HyperbandRemoveCheckpointsCallback(HyperbandRemoveCheckpointsCommon):
                 estimator.update(data)
 
     def on_trial_result(
-        self, trial: Trial, status: str, result: Dict[str, Any], decision: str
+        self, trial: Trial, status: str, result: dict[str, Any], decision: str
     ):
         super().on_trial_result(trial, status, result, decision)
         trial_id = str(trial.trial_id)
@@ -510,7 +510,7 @@ class HyperbandRemoveCheckpointsBaselineCallback(HyperbandRemoveCheckpointsCommo
         self,
         paused_trials_with_checkpoints: PausedTrialsResult,
         num_to_remove: int,
-    ) -> List[TrialInformation]:
+    ) -> list[TrialInformation]:
         terminator = self._scheduler.terminator
         info_rungs = terminator.information_for_rungs()
         lens_rung = {r: n for r, n, _ in info_rungs}

--- a/syne_tune/callbacks/remove_checkpoints_callback.py
+++ b/syne_tune/callbacks/remove_checkpoints_callback.py
@@ -1,4 +1,5 @@
-from typing import List, Optional, Callable
+from typing import Optional
+from collections.abc import Callable
 
 from syne_tune.tuner_callback import TunerCallback
 from syne_tune.tuning_status import TuningStatus
@@ -36,7 +37,7 @@ class DefaultRemoveCheckpointsSchedulerMixin(RemoveCheckpointsSchedulerMixin):
     scheduler has to implement :meth:`trials_checkpoints_can_be_removed`.
     """
 
-    def trials_checkpoints_can_be_removed(self) -> List[int]:
+    def trials_checkpoints_can_be_removed(self) -> list[int]:
         """
         Supports the general case (see header comment).
         This method returns IDs of paused trials for which checkpoints can safely

--- a/syne_tune/callbacks/tensorboard_callback.py
+++ b/syne_tune/callbacks/tensorboard_callback.py
@@ -1,7 +1,7 @@
 import numbers
 import os
 from time import perf_counter
-from typing import Optional, List, Dict, Any
+from typing import Optional, Any
 import logging
 
 from syne_tune.backend.trial_status import Trial
@@ -29,7 +29,7 @@ class TensorboardCallback(TunerCallback):
 
     def __init__(
         self,
-        ignore_metrics: Optional[List[str]] = None,
+        ignore_metrics: Optional[list[str]] = None,
         target_metric: Optional[str] = None,
         mode: Optional[str] = None,
         log_hyperparameters: bool = True,
@@ -57,7 +57,7 @@ class TensorboardCallback(TunerCallback):
         self.output_path = None
         self.log_hyperparameters = log_hyperparameters
 
-    def _set_time_fields(self, result: Dict[str, Any]):
+    def _set_time_fields(self, result: dict[str, Any]):
         """
         Note that we only add wallclock time to the result if this has not
         already been done (by the backend)
@@ -66,7 +66,7 @@ class TensorboardCallback(TunerCallback):
             result[ST_TUNER_TIME] = perf_counter() - self.start_time_stamp
 
     def on_trial_result(
-        self, trial: Trial, status: str, result: Dict[str, Any], decision: str
+        self, trial: Trial, status: str, result: dict[str, Any], decision: str
     ):
         self._set_time_fields(result)
         walltime = result[ST_TUNER_TIME]

--- a/syne_tune/config_space.py
+++ b/syne_tune/config_space.py
@@ -5,7 +5,8 @@ import logging
 from copy import copy
 from math import isclose
 import sys
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, Optional, Union
+from collections.abc import Sequence
 import argparse
 
 import numpy as np
@@ -63,10 +64,10 @@ class Domain:
 
     def sample(
         self,
-        spec: Optional[Union[List[dict], dict]] = None,
+        spec: Optional[Union[list[dict], dict]] = None,
         size: int = 1,
         random_state: Optional[np.random.RandomState] = None,
-    ) -> Union[Any, List[Any]]:
+    ) -> Union[Any, list[Any]]:
         """
         :param spec: Passed to sampler
         :param size: Number of values to sample, defaults to 1
@@ -123,7 +124,7 @@ class Sampler:
     def sample(
         self,
         domain: Domain,
-        spec: Optional[Union[List[dict], dict]] = None,
+        spec: Optional[Union[list[dict], dict]] = None,
         size: int = 1,
         random_state: Optional[np.random.RandomState] = None,
     ):
@@ -191,7 +192,7 @@ class Grid(Sampler):
     def sample(
         self,
         domain: Domain,
-        spec: Optional[Union[List[dict], dict]] = None,
+        spec: Optional[Union[list[dict], dict]] = None,
         size: int = 1,
         random_state: Optional[np.random.RandomState] = None,
     ):
@@ -220,7 +221,7 @@ class Float(Domain):
         def sample(
             self,
             domain: "Float",
-            spec: Optional[Union[List[dict], dict]] = None,
+            spec: Optional[Union[list[dict], dict]] = None,
             size: int = 1,
             random_state: Optional[np.random.RandomState] = None,
         ):
@@ -235,7 +236,7 @@ class Float(Domain):
         def sample(
             self,
             domain: "Float",
-            spec: Optional[Union[List[dict], dict]] = None,
+            spec: Optional[Union[list[dict], dict]] = None,
             size: int = 1,
             random_state: Optional[np.random.RandomState] = None,
         ):
@@ -258,7 +259,7 @@ class Float(Domain):
         def sample(
             self,
             domain: "Float",
-            spec: Optional[Union[List[dict], dict]] = None,
+            spec: Optional[Union[list[dict], dict]] = None,
             size: int = 1,
             random_state: Optional[np.random.RandomState] = None,
         ):
@@ -275,7 +276,7 @@ class Float(Domain):
         def sample(
             self,
             domain: "Float",
-            spec: Optional[Union[List[dict], dict]] = None,
+            spec: Optional[Union[list[dict], dict]] = None,
             size: int = 1,
             random_state: Optional[np.random.RandomState] = None,
         ):
@@ -397,7 +398,7 @@ class Integer(Domain):
         def sample(
             self,
             domain: "Integer",
-            spec: Optional[Union[List[dict], dict]] = None,
+            spec: Optional[Union[list[dict], dict]] = None,
             size: int = 1,
             random_state: Optional[np.random.RandomState] = None,
         ):
@@ -412,7 +413,7 @@ class Integer(Domain):
         def sample(
             self,
             domain: "Integer",
-            spec: Optional[Union[List[dict], dict]] = None,
+            spec: Optional[Union[list[dict], dict]] = None,
             size: int = 1,
             random_state: Optional[np.random.RandomState] = None,
         ):
@@ -505,7 +506,7 @@ class Categorical(Domain):
         def sample(
             self,
             domain: "Categorical",
-            spec: Optional[Union[List[dict], dict]] = None,
+            spec: Optional[Union[list[dict], dict]] = None,
             size: int = 1,
             random_state: Optional[np.random.RandomState] = None,
         ):
@@ -708,10 +709,10 @@ class OrdinalNearestNeighbor(Ordinal):
 
     def sample(
         self,
-        spec: Optional[Union[List[dict], dict]] = None,
+        spec: Optional[Union[list[dict], dict]] = None,
         size: int = 1,
         random_state: Optional[np.random.RandomState] = None,
-    ) -> Union[Any, List[Any]]:
+    ) -> Union[Any, list[Any]]:
         if random_state is None:
             random_state = np.random
         items = random_state.uniform(self._lower_int, self._upper_int, size=size)
@@ -812,10 +813,10 @@ class FiniteRange(Domain):
 
     def sample(
         self,
-        spec: Optional[Union[List[dict], dict]] = None,
+        spec: Optional[Union[list[dict], dict]] = None,
         size: int = 1,
         random_state: Optional[np.random.RandomState] = None,
-    ) -> Union[Any, List[Any]]:
+    ) -> Union[Any, list[Any]]:
         int_sample = self._uniform_int.sample(spec, size, random_state)
         if size > 1:
             return [self._values[x] for x in int_sample]
@@ -1022,7 +1023,7 @@ def is_uniform_space(domain: Domain) -> bool:
         )
 
 
-def add_to_argparse(parser: argparse.ArgumentParser, config_space: Dict[str, Any]):
+def add_to_argparse(parser: argparse.ArgumentParser, config_space: dict[str, Any]):
     """
     Use this to prepare argument parser in endpoint script, for the
     non-fixed parameters in ``config_space``.
@@ -1036,8 +1037,8 @@ def add_to_argparse(parser: argparse.ArgumentParser, config_space: Dict[str, Any
 
 
 def cast_config_values(
-    config: Dict[str, Any], config_space: Dict[str, Any]
-) -> Dict[str, Any]:
+    config: dict[str, Any], config_space: dict[str, Any]
+) -> dict[str, Any]:
     """
     Returns config with keys, values of ``config``, but values are cast to
     their specific types.
@@ -1054,8 +1055,8 @@ def cast_config_values(
 
 
 def postprocess_config(
-    config: Dict[str, Any], config_space: Dict[str, Any]
-) -> Dict[str, Any]:
+    config: dict[str, Any], config_space: dict[str, Any]
+) -> dict[str, Any]:
     """Post-processes a config as returned by a searcher
 
     * Adding parameters which are constant, therefore do not feature
@@ -1073,8 +1074,8 @@ def postprocess_config(
 
 
 def remove_constant_and_cast(
-    config: Dict[str, Any], config_space: Dict[str, Any]
-) -> Dict[str, Any]:
+    config: dict[str, Any], config_space: dict[str, Any]
+) -> dict[str, Any]:
     """Pre-processes a config before passing it to a searcher
 
     * Removing parameters which are constant in ``config_space`` (these do
@@ -1093,7 +1094,7 @@ def remove_constant_and_cast(
     )
 
 
-def non_constant_hyperparameter_keys(config_space: Dict[str, Any]) -> List[str]:
+def non_constant_hyperparameter_keys(config_space: dict[str, Any]) -> list[str]:
     """
     :param config_space: Configuration space
     :return: Keys corresponding to (non-fixed) hyperparameters
@@ -1102,7 +1103,7 @@ def non_constant_hyperparameter_keys(config_space: Dict[str, Any]) -> List[str]:
 
 
 def config_space_size(
-    config_space: Dict[str, Any], upper_limit: int = 2**20
+    config_space: dict[str, Any], upper_limit: int = 2**20
 ) -> Optional[int]:
     """
     Counts the number of distinct configurations in the configuration space
@@ -1128,7 +1129,7 @@ def config_space_size(
 
 
 def config_to_match_string(
-    config: Dict[str, Any], config_space: Dict[str, Any], keys: List[str]
+    config: dict[str, Any], config_space: dict[str, Any], keys: list[str]
 ) -> str:
     """
     Maps configuration to a match string, which can be used to compare configs
@@ -1147,7 +1148,7 @@ def config_to_match_string(
     return ",".join(parts)
 
 
-def to_dict(x: Domain) -> Dict[str, Any]:
+def to_dict(x: Domain) -> dict[str, Any]:
     """
     We assume that for each :class:`Domain` subclass, the :meth:`__init__`
     kwargs are also members, and all other members start with ``_``.
@@ -1168,7 +1169,7 @@ def to_dict(x: Domain) -> Dict[str, Any]:
     return result
 
 
-def from_dict(d: Dict[str, Any]) -> Domain:
+def from_dict(d: dict[str, Any]) -> Domain:
     """
     :param d: Representation of :class:`Domain` object as ``dict``
     :return: Decoded :class:`Domain` object
@@ -1185,8 +1186,8 @@ def from_dict(d: Dict[str, Any]) -> Domain:
 
 
 def config_space_to_json_dict(
-    config_space: Dict[str, Union[Domain, int, float, str]]
-) -> Dict[str, Union[int, float, str]]:
+    config_space: dict[str, Union[Domain, int, float, str]]
+) -> dict[str, Union[int, float, str]]:
     """Converts ``config_space`` into a dictionary that can be saved as a json file.
 
     :param config_space: Configuration space
@@ -1198,8 +1199,8 @@ def config_space_to_json_dict(
 
 
 def config_space_from_json_dict(
-    config_space_dict: Dict[str, Union[int, float, str]]
-) -> Dict[str, Union[Domain, int, float, str]]:
+    config_space_dict: dict[str, Union[int, float, str]]
+) -> dict[str, Union[Domain, int, float, str]]:
     """Converts the given dictionary into a Syne Tune search space.
 
     Reverse of :func:`config_space_to_json_dict`.
@@ -1267,7 +1268,7 @@ class Quantized(Sampler):
     def sample(
         self,
         domain: Domain,
-        spec: Optional[Union[List[dict], dict]] = None,
+        spec: Optional[Union[list[dict], dict]] = None,
         size: int = 1,
         random_state: Optional[np.random.RandomState] = None,
     ):

--- a/syne_tune/experiments/experiment_result.py
+++ b/syne_tune/experiments/experiment_result.py
@@ -4,7 +4,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from json.decoder import JSONDecodeError
 from pathlib import Path
-from typing import List, Dict, Callable, Optional, Union, Any, Tuple
+from typing import Optional, Union, Any
+from collections.abc import Callable
 
 import numpy as np
 import pandas as pd
@@ -35,7 +36,7 @@ class ExperimentResult:
 
     name: str
     results: pd.DataFrame
-    metadata: Dict[str, Any]
+    metadata: dict[str, Any]
     tuner: Tuner
     path: Path
 
@@ -53,7 +54,7 @@ class ExperimentResult:
 
     def plot_hypervolume(
         self,
-        metrics_to_plot: Union[List[int], List[str]] = None,
+        metrics_to_plot: Union[list[int], list[str]] = None,
         reference_point: np.ndarray = None,
         figure_path: str = None,
         **plt_kwargs,
@@ -176,16 +177,16 @@ class ExperimentResult:
         else:
             fig.show()
 
-    def metric_mode(self) -> Union[str, List[str]]:
+    def metric_mode(self) -> Union[str, list[str]]:
         return self.metadata["metric_mode"]
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return self.metadata["metric_names"]
 
     def entrypoint_name(self) -> str:
         return self.metadata["entrypoint"]
 
-    def best_config(self, metric: Union[str, int] = 0) -> Dict[str, Any]:
+    def best_config(self, metric: Union[str, int] = 0) -> dict[str, Any]:
         """
         Return the best config found for the specified metric
         :param metric: Indicates which metric to use, can be the index or a name of the metric.
@@ -204,7 +205,7 @@ class ExperimentResult:
         # Don't include internal fields
         return {k: v for k, v in res.items() if not k.startswith("st_")}
 
-    def _metric_name_mode(self, metric: Union[str, int]) -> Tuple[str, str]:
+    def _metric_name_mode(self, metric: Union[str, int]) -> tuple[str, str]:
         """
         Determine the name and its mode given ambiguous input.
         :param metric: Index or name of the selected metric
@@ -284,7 +285,7 @@ def _impute_filter(filt: Optional[PathOrExperimentFilter]) -> PathOrExperimentFi
 
 def get_metadata(
     path_filter: Optional[PathFilter] = None, root: Path = experiment_path()
-) -> Dict[str, dict]:
+) -> dict[str, dict]:
     """Load meta-data for a number of experiments
 
     :param path_filter: If passed then only experiments whose path matching
@@ -321,7 +322,7 @@ def list_experiments(
     experiment_filter: Optional[ExperimentFilter] = None,
     root: Path = experiment_path(),
     load_tuner: bool = False,
-) -> List[ExperimentResult]:
+) -> list[ExperimentResult]:
     """List experiments for which results are found
 
     :param path_filter: If passed then only experiments whose path matching
@@ -398,7 +399,7 @@ def load_experiments_df(
         df = experiment.results
         df["tuner_name"] = experiment.name
         for k, v in experiment.metadata.items():
-            if isinstance(v, List):
+            if isinstance(v, list):
                 if len(v) > 1:
                     for i, x in enumerate(v):
                         df[f"{k}-{i}"] = x

--- a/syne_tune/experiments/multiobjective.py
+++ b/syne_tune/experiments/multiobjective.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Optional
+from typing import Optional
 
 import pandas as pd
 import numpy as np
@@ -7,7 +7,7 @@ from syne_tune.optimizer.schedulers.multiobjective.utils import hypervolume_cumu
 
 
 def hypervolume_indicator_column_generator(
-    metrics_and_modes: List[Tuple[str, str]],
+    metrics_and_modes: list[tuple[str, str]],
     reference_point: Optional[np.ndarray] = None,
     increment: int = 1,
 ):

--- a/syne_tune/experiments/util.py
+++ b/syne_tune/experiments/util.py
@@ -1,11 +1,10 @@
 import logging
-from typing import Dict, Tuple, List
 
 import pandas as pd
 
 from syne_tune.constants import ST_TUNER_TIME
 
-DataFrameGroups = Dict[Tuple[int, str], List[Tuple[str, pd.DataFrame]]]
+DataFrameGroups = dict[tuple[int, str], list[tuple[str, pd.DataFrame]]]
 
 logger = logging.getLogger(__name__)
 

--- a/syne_tune/optimizer/baselines.py
+++ b/syne_tune/optimizer/baselines.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Any, List
+from typing import Optional, Any
 import logging
 
 from syne_tune.optimizer.schedulers.asha import AsynchronousSuccessiveHalving
@@ -40,11 +40,11 @@ class RandomSearch(SingleFidelityScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        metrics: List[str],
+        config_space: dict[str, Any],
+        metrics: list[str],
         do_minimize: Optional[bool] = True,
         random_seed: Optional[int] = None,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
     ):
         super(RandomSearch, self).__init__(
             config_space=config_space,
@@ -77,11 +77,11 @@ class BORE(SingleObjectiveScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         do_minimize: Optional[bool] = True,
         random_seed: Optional[int] = None,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
     ):
         super(BORE, self).__init__(
             config_space=config_space,
@@ -134,11 +134,11 @@ class TPE(SingleObjectiveScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         do_minimize: Optional[bool] = True,
         random_seed: Optional[int] = None,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
         num_min_data_points: Optional[int] = None,
         top_n_percent: int = 15,
         min_bandwidth: float = 1e-3,
@@ -185,13 +185,13 @@ class REA(SingleObjectiveScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         do_minimize: Optional[bool] = True,
         random_seed: Optional[int] = None,
         population_size: int = 100,
         sample_size: int = 10,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
     ):
         super(REA, self).__init__(
             config_space=config_space,
@@ -221,11 +221,11 @@ class BOTorch(SingleObjectiveScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         do_minimize: Optional[bool] = True,
         random_seed: Optional[int] = None,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
     ):
         super(BOTorch, self).__init__(
             config_space=config_space,
@@ -266,13 +266,13 @@ class ASHA(AsynchronousSuccessiveHalving):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         time_attr: str,
         max_t: int,
         do_minimize: Optional[bool] = True,
         random_seed: Optional[int] = None,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
     ):
         super(ASHA, self).__init__(
             config_space=config_space,
@@ -306,13 +306,13 @@ class ASHABORE(AsynchronousSuccessiveHalving):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         time_attr: str,
         max_t: int,
         do_minimize: Optional[bool] = True,
         random_seed: Optional[int] = None,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
     ):
         super(ASHABORE, self).__init__(
             config_space=config_space,
@@ -347,13 +347,13 @@ class ASHACQR(AsynchronousSuccessiveHalving):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         time_attr: str,
         max_t: int,
         do_minimize: Optional[bool] = True,
         random_seed: Optional[int] = None,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
     ):
         super(ASHACQR, self).__init__(
             config_space=config_space,
@@ -388,7 +388,7 @@ class BOHB(AsynchronousSuccessiveHalving):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         time_attr: str,
         max_t: int,
@@ -400,7 +400,7 @@ class BOHB(AsynchronousSuccessiveHalving):
         num_candidates: int = 64,
         bandwidth_factor: int = 3,
         random_fraction: float = 0.33,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
     ):
         super(BOHB, self).__init__(
             config_space=config_space,
@@ -442,11 +442,11 @@ class CQR(SingleObjectiveScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         do_minimize: Optional[bool] = True,
         random_seed: Optional[int] = None,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
     ):
         super(CQR, self).__init__(
             config_space=config_space,

--- a/syne_tune/optimizer/legacy_baselines.py
+++ b/syne_tune/optimizer/legacy_baselines.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Any, List, Union
+from typing import Optional, Any, Union
 import logging
 import copy
 from functools import partial
@@ -46,7 +46,7 @@ def _random_seed_from_generator(random_seed: int) -> int:
     return RandomSeedGenerator(random_seed)()
 
 
-def _assert_searcher_must_be(kwargs: Dict[str, Any], name: str):
+def _assert_searcher_must_be(kwargs: dict[str, Any], name: str):
     searcher = kwargs.get("searcher")
     assert searcher is None or searcher == name, f"Must have searcher='{name}'"
 
@@ -63,7 +63,7 @@ class RandomSearch(LegacyFIFOScheduler):
         :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`
     """
 
-    def __init__(self, config_space: Dict[str, Any], metric: str, **kwargs):
+    def __init__(self, config_space: dict[str, Any], metric: str, **kwargs):
         searcher_name = "random"
         _assert_searcher_must_be(kwargs, searcher_name)
         super(RandomSearch, self).__init__(
@@ -86,7 +86,7 @@ class GridSearch(LegacyFIFOScheduler):
         :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`
     """
 
-    def __init__(self, config_space: Dict[str, Any], metric: str, **kwargs):
+    def __init__(self, config_space: dict[str, Any], metric: str, **kwargs):
         searcher_name = "grid"
         _assert_searcher_must_be(kwargs, searcher_name)
         super(GridSearch, self).__init__(
@@ -109,7 +109,7 @@ class BayesianOptimization(LegacyFIFOScheduler):
         :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`
     """
 
-    def __init__(self, config_space: Dict[str, Any], metric: str, **kwargs):
+    def __init__(self, config_space: dict[str, Any], metric: str, **kwargs):
         searcher_name = "bayesopt"
         _assert_searcher_must_be(kwargs, searcher_name)
         super(BayesianOptimization, self).__init__(
@@ -120,7 +120,7 @@ class BayesianOptimization(LegacyFIFOScheduler):
         )
 
 
-def _assert_need_one(kwargs: Dict[str, Any], need_one: Optional[set] = None):
+def _assert_need_one(kwargs: dict[str, Any], need_one: Optional[set] = None):
     if need_one is None:
         need_one = {"max_t", "max_resource_attr"}
     assert need_one.intersection(kwargs.keys()), f"Need one of these: {need_one}"
@@ -142,7 +142,7 @@ class ASHA(LegacyHyperbandScheduler):
     """
 
     def __init__(
-        self, config_space: Dict[str, Any], metric: str, resource_attr: str, **kwargs
+        self, config_space: dict[str, Any], metric: str, resource_attr: str, **kwargs
     ):
         _assert_need_one(kwargs)
         searcher_name = "random"
@@ -183,7 +183,7 @@ class MOBSTER(LegacyHyperbandScheduler):
     """
 
     def __init__(
-        self, config_space: Dict[str, Any], metric: str, resource_attr: str, **kwargs
+        self, config_space: dict[str, Any], metric: str, resource_attr: str, **kwargs
     ):
         _assert_need_one(kwargs)
         searcher_name = "bayesopt"
@@ -230,7 +230,7 @@ class HyperTune(LegacyHyperbandScheduler):
     :param kwargs: Additional arguments to :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`
     """
 
-    def __init__(self, config_space: Dict, metric: str, resource_attr: str, **kwargs):
+    def __init__(self, config_space: dict, metric: str, resource_attr: str, **kwargs):
         _assert_need_one(kwargs)
         searcher_name = "legacy_hypertune"
         _assert_searcher_must_be(kwargs, searcher_name)
@@ -314,7 +314,7 @@ class DyHPO(LegacyHyperbandScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         resource_attr: str,
         probability_sh: Optional[float] = None,
@@ -364,7 +364,7 @@ class PASHA(LegacyHyperbandScheduler):
     """
 
     def __init__(
-        self, config_space: Dict[str, Any], metric: str, resource_attr: str, **kwargs
+        self, config_space: dict[str, Any], metric: str, resource_attr: str, **kwargs
     ):
         _assert_need_one(kwargs)
         super(PASHA, self).__init__(
@@ -400,7 +400,7 @@ class BOHB(LegacyHyperbandScheduler):
     """
 
     def __init__(
-        self, config_space: Dict[str, Any], metric: str, resource_attr: str, **kwargs
+        self, config_space: dict[str, Any], metric: str, resource_attr: str, **kwargs
     ):
         _assert_need_one(kwargs)
         searcher_name = "kde"
@@ -432,7 +432,7 @@ class SyncHyperband(SynchronousGeometricHyperbandScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         resource_attr: str,
         **kwargs,
@@ -469,7 +469,7 @@ class SyncBOHB(SynchronousGeometricHyperbandScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         resource_attr: str,
         **kwargs,
@@ -503,7 +503,7 @@ class DEHB(GeometricDifferentialEvolutionHyperbandScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         resource_attr: str,
         **kwargs,
@@ -544,7 +544,7 @@ class SyncMOBSTER(SynchronousGeometricHyperbandScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         resource_attr: str,
         **kwargs,
@@ -566,11 +566,11 @@ class SyncMOBSTER(SynchronousGeometricHyperbandScheduler):
 
 
 def _create_searcher_kwargs(
-    config_space: Dict[str, Any],
-    metric: Union[str, List[str]],
+    config_space: dict[str, Any],
+    metric: Union[str, list[str]],
     random_seed: Optional[int],
-    kwargs: Dict[str, Any],
-) -> Dict[str, Any]:
+    kwargs: dict[str, Any],
+) -> dict[str, Any]:
     searcher_kwargs = dict(
         config_space=config_space,
         metric=metric,
@@ -598,7 +598,7 @@ class BORE(LegacyFIFOScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         random_seed: Optional[int] = None,
         **kwargs,
@@ -638,7 +638,7 @@ class ASHABORE(LegacyHyperbandScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         resource_attr: str,
         random_seed: Optional[int] = None,
@@ -681,7 +681,7 @@ class BoTorch(LegacyFIFOScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         random_seed: Optional[int] = None,
         **kwargs,
@@ -726,7 +726,7 @@ class REA(LegacyFIFOScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         population_size: int = 100,
         sample_size: int = 10,
@@ -748,10 +748,10 @@ class REA(LegacyFIFOScheduler):
 
 
 def create_gaussian_process_estimator(
-    config_space: Dict[str, Any],
+    config_space: dict[str, Any],
     metric: str,
     random_seed: Optional[int] = None,
-    search_options: Optional[Dict[str, Any]] = None,
+    search_options: Optional[dict[str, Any]] = None,
 ) -> Estimator:
     scheduler = BayesianOptimization(
         config_space=config_space,
@@ -794,11 +794,11 @@ class MORandomScalarizationBayesOpt(LegacyFIFOScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        metric: List[str],
-        mode: Union[List[str], str] = "min",
+        config_space: dict[str, Any],
+        metric: list[str],
+        mode: Union[list[str], str] = "min",
         random_seed: Optional[int] = None,
-        estimators: Optional[Dict[str, Estimator]] = None,
+        estimators: Optional[dict[str, Estimator]] = None,
         **kwargs,
     ):
         try:
@@ -867,9 +867,9 @@ class NSGA2(LegacyFIFOScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        metric: List[str],
-        mode: Union[List[str], str] = "min",
+        config_space: dict[str, Any],
+        metric: list[str],
+        mode: Union[list[str], str] = "min",
         population_size: int = 20,
         random_seed: Optional[int] = None,
         **kwargs,
@@ -910,9 +910,9 @@ class MOREA(LegacyFIFOScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        metric: List[str],
-        mode: Union[List[str], str] = "min",
+        config_space: dict[str, Any],
+        metric: list[str],
+        mode: Union[list[str], str] = "min",
         population_size: int = 100,
         sample_size: int = 10,
         random_seed: Optional[int] = None,
@@ -952,9 +952,9 @@ class MOLinearScalarizationBayesOpt(LegacyLinearScalarizedScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        metric: List[str],
-        scalarization_weights: Optional[List[float]] = None,
+        config_space: dict[str, Any],
+        metric: list[str],
+        scalarization_weights: Optional[list[float]] = None,
         **kwargs,
     ):
         searcher_name = "bayesopt"
@@ -982,7 +982,7 @@ class ConstrainedBayesianOptimization(LegacyFIFOScheduler):
     """
 
     def __init__(
-        self, config_space: Dict[str, Any], metric: str, constraint_attr: str, **kwargs
+        self, config_space: dict[str, Any], metric: str, constraint_attr: str, **kwargs
     ):
         searcher_name = "bayesopt_constrained"
         _assert_searcher_must_be(kwargs, searcher_name)
@@ -1025,8 +1025,8 @@ class ZeroShotTransfer(LegacyFIFOScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        transfer_learning_evaluations: Dict[str, LegacyTransferLearningTaskEvaluations],
+        config_space: dict[str, Any],
+        transfer_learning_evaluations: dict[str, LegacyTransferLearningTaskEvaluations],
         metric: str,
         mode: str = "min",
         sort_transfer_learning_evaluations: bool = True,
@@ -1089,10 +1089,10 @@ class ASHACTS(LegacyHyperbandScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         resource_attr: str,
-        transfer_learning_evaluations: Dict[str, LegacyTransferLearningTaskEvaluations],
+        transfer_learning_evaluations: dict[str, LegacyTransferLearningTaskEvaluations],
         mode: str = "min",
         random_seed: Optional[int] = None,
         **kwargs,
@@ -1139,7 +1139,7 @@ class KDE(LegacyFIFOScheduler):
     :param kwargs: Additional arguments to :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`
     """
 
-    def __init__(self, config_space: Dict[str, Any], metric: str, **kwargs):
+    def __init__(self, config_space: dict[str, Any], metric: str, **kwargs):
         searcher_name = "kde"
         _assert_searcher_must_be(kwargs, searcher_name)
         super(KDE, self).__init__(
@@ -1162,7 +1162,7 @@ class CQR(LegacyFIFOScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         mode: str = "min",
         random_seed: Optional[int] = None,
@@ -1201,7 +1201,7 @@ class ASHACQR(LegacyHyperbandScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         resource_attr: str,
         mode: str = "min",
@@ -1240,7 +1240,7 @@ try:
 
         def __init__(
             self,
-            config_space: Dict[str, Any],
+            config_space: dict[str, Any],
             metric: str,
             mode: str = "min",
             points_to_evaluate: Optional[list] = None,
@@ -1293,9 +1293,9 @@ try:
 
         def __init__(
             self,
-            config_space: Dict[str, Any],
-            metric: List[str],
-            mode: Union[List[str], str] = "min",
+            config_space: dict[str, Any],
+            metric: list[str],
+            mode: Union[list[str], str] = "min",
             random_seed: Optional[int] = None,
             **kwargs,
         ):

--- a/syne_tune/optimizer/legacy_scheduler.py
+++ b/syne_tune/optimizer/legacy_scheduler.py
@@ -12,7 +12,7 @@
 # permissions and limitations under the License.
 import logging
 
-from typing import Optional, List, Dict, Any, Union
+from typing import Optional, Any, Union
 
 from syne_tune.backend.trial_status import Trial
 from syne_tune.config_space import (
@@ -37,7 +37,7 @@ class LegacyTrialScheduler:
     :param config_space: Configuration spoce
     """
 
-    def __init__(self, config_space: Dict[str, Any]):
+    def __init__(self, config_space: dict[str, Any]):
         self.config_space = config_space
         self._hyperparameter_keys = set(non_constant_hyperparameter_keys(config_space))
 
@@ -81,7 +81,7 @@ class LegacyTrialScheduler:
                 )
         return ret_val
 
-    def _postprocess_config(self, config: Dict[str, Any]) -> Dict[str, Any]:
+    def _postprocess_config(self, config: dict[str, Any]) -> dict[str, Any]:
         """Post-processes a config as returned by a searcher
 
         * Adding parameters which are constant, therefore do not feature
@@ -96,7 +96,7 @@ class LegacyTrialScheduler:
         new_config.update(cast_config_values(config, config_space=self.config_space))
         return new_config
 
-    def _preprocess_config(self, config: Dict[str, Any]) -> Dict[str, Any]:
+    def _preprocess_config(self, config: dict[str, Any]) -> dict[str, Any]:
         """Pre-processes a config before passing it to a searcher
 
         * Removing parameters which are constant in ``config_space`` (these do
@@ -143,7 +143,7 @@ class LegacyTrialScheduler:
         """
         pass
 
-    def on_trial_result(self, trial: Trial, result: Dict[str, Any]) -> str:
+    def on_trial_result(self, trial: Trial, result: dict[str, Any]) -> str:
         """Called on each intermediate result reported by a trial.
 
         At this point, the trial scheduler can make a decision by returning
@@ -157,7 +157,7 @@ class LegacyTrialScheduler:
         """
         return SchedulerDecision.CONTINUE
 
-    def on_trial_complete(self, trial: Trial, result: Dict[str, Any]):
+    def on_trial_complete(self, trial: Trial, result: dict[str, Any]):
         """Notification for the completion of trial.
 
         Note that :meth:`on_trial_result` is called with the same result before.
@@ -179,15 +179,15 @@ class LegacyTrialScheduler:
         """
         pass
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         """
-        :return: List of metric names. The first one is the target
+        :return: list of metric names. The first one is the target
             metric optimized over, unless the scheduler is a genuine
             multi-objective metric (for example, for sampling the Pareto front)
         """
         raise NotImplementedError()
 
-    def metric_mode(self) -> Union[str, List[str]]:
+    def metric_mode(self) -> Union[str, list[str]]:
         """
         :return: "min" if target metric is minimized, otherwise "max".
             Here, "min" should be the default. For a genuine multi-objective
@@ -198,7 +198,7 @@ class LegacyTrialScheduler:
         else:
             raise NotImplementedError
 
-    def metadata(self) -> Dict[str, Any]:
+    def metadata(self) -> dict[str, Any]:
         """
         :return: Metadata for the scheduler
         """

--- a/syne_tune/optimizer/scheduler.py
+++ b/syne_tune/optimizer/scheduler.py
@@ -2,7 +2,7 @@ import numpy as np
 import logging
 
 from dataclasses import dataclass
-from typing import Optional, Dict, Any
+from typing import Optional, Any
 
 from syne_tune.backend.trial_status import Trial
 
@@ -52,7 +52,7 @@ class TrialSuggestion:
 
     @staticmethod
     def start_suggestion(
-        config: Dict[str, Any], checkpoint_trial_id: Optional[int] = None
+        config: dict[str, Any], checkpoint_trial_id: Optional[int] = None
     ) -> "TrialSuggestion":
         """Suggestion to start new trial
 
@@ -158,7 +158,7 @@ class TrialScheduler:
     def on_trial_error(self, trial: Trial):
         pass
 
-    def on_trial_result(self, trial: Trial, result: Dict[str, Any]) -> str:
+    def on_trial_result(self, trial: Trial, result: dict[str, Any]) -> str:
         """Called on each intermediate result reported by a trial.
 
         At this point, the trial scheduler can make a decision by returning
@@ -172,7 +172,7 @@ class TrialScheduler:
         """
         return SchedulerDecision.CONTINUE
 
-    def on_trial_complete(self, trial: Trial, result: Dict[str, Any]):
+    def on_trial_complete(self, trial: Trial, result: dict[str, Any]):
         """Notification for the completion of trial.
 
         Note that :meth:`on_trial_result` is called with the same result before.
@@ -194,7 +194,7 @@ class TrialScheduler:
         """
         pass
 
-    def metadata(self) -> Dict[str, Any]:
+    def metadata(self) -> dict[str, Any]:
         """
         :return: Metadata for the scheduler
         """

--- a/syne_tune/optimizer/schedulers/asha.py
+++ b/syne_tune/optimizer/schedulers/asha.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Union, Dict, Any, List
+from typing import Optional, Union, Any
 
 import numpy as np
 from syne_tune.backend.trial_status import Trial
@@ -65,7 +65,7 @@ class AsynchronousSuccessiveHalving(TrialScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         do_minimize: Optional[bool] = True,
         searcher: Optional[
@@ -141,7 +141,7 @@ class AsynchronousSuccessiveHalving(TrialScheduler):
         self.searcher.on_trial_error(trial.trial_id)
         logger.warning(f"trial_id {trial.trial_id}: Evaluation failed!")
 
-    def on_trial_result(self, trial: Trial, result: Dict[str, Any]) -> str:
+    def on_trial_result(self, trial: Trial, result: dict[str, Any]) -> str:
         config = remove_constant_and_cast(trial.config, self.config_space)
         metric = result[self.metric] * self.metric_multiplier
         self.searcher.on_trial_result(
@@ -161,7 +161,7 @@ class AsynchronousSuccessiveHalving(TrialScheduler):
             self.num_stopped += 1
         return action
 
-    def on_trial_complete(self, trial: Trial, result: Dict[str, Any]):
+    def on_trial_complete(self, trial: Trial, result: dict[str, Any]):
 
         config = remove_constant_and_cast(trial.config, self.config_space)
         metric = result[self.metric] * self.metric_multiplier
@@ -181,13 +181,13 @@ class AsynchronousSuccessiveHalving(TrialScheduler):
     def on_trial_remove(self, trial: Trial):
         del self.trial_info[trial.trial_id]
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return [self.metric]
 
     def metric_mode(self) -> str:
         return "min" if self.do_minimize else "max"
 
-    def metadata(self) -> Dict[str, Any]:
+    def metadata(self) -> dict[str, Any]:
         """
         :return: Metadata for the scheduler
         """
@@ -201,7 +201,7 @@ class AsynchronousSuccessiveHalving(TrialScheduler):
         metadata["metric_mode"] = self.metric_mode()
         return metadata
 
-    def _check_metrics_are_present(self, result: Dict[str, Any]):
+    def _check_metrics_are_present(self, result: dict[str, Any]):
         for key in [self.metric, self.time_attr]:
             if key not in result:
                 assert key in result, f"{key} not found in reported result {result}"

--- a/syne_tune/optimizer/schedulers/ask_tell_scheduler.py
+++ b/syne_tune/optimizer/schedulers/ask_tell_scheduler.py
@@ -1,4 +1,3 @@
-from typing import Dict
 import datetime
 
 from syne_tune.backend.trial_status import Trial, Status, TrialResult
@@ -8,7 +7,7 @@ from syne_tune.optimizer.scheduler import TrialScheduler
 class AskTellScheduler:
     base_scheduler: TrialScheduler
     trial_counter: int
-    completed_experiments: Dict[int, TrialResult]
+    completed_experiments: dict[int, TrialResult]
 
     def __init__(self, base_scheduler: TrialScheduler):
         """
@@ -42,7 +41,7 @@ class AskTellScheduler:
         self.trial_counter += 1
         return trial
 
-    def tell(self, trial: Trial, experiment_result: Dict[str, float]):
+    def tell(self, trial: Trial, experiment_result: dict[str, float]):
         """
         Feed experiment results back to the Scheduler
 

--- a/syne_tune/optimizer/schedulers/legacy_fifo.py
+++ b/syne_tune/optimizer/schedulers/legacy_fifo.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any, Union
+from typing import Optional, Any, Union
 import logging
 
 from syne_tune.optimizer.schedulers.random_seeds import RANDOM_SEED_UPPER_BOUND
@@ -49,7 +49,7 @@ _CONSTRAINTS = {
 }
 
 
-MetricModeType = Union[str, List[str]]
+MetricModeType = Union[str, list[str]]
 
 
 def _to_list(x) -> list:
@@ -128,7 +128,7 @@ class LegacyFIFOScheduler(TrialSchedulerWithSearcher):
         optional
     """
 
-    def __init__(self, config_space: Dict[str, Any], **kwargs):
+    def __init__(self, config_space: dict[str, Any], **kwargs):
         super().__init__(config_space, **kwargs)
         # Check values and impute default values
         assert_no_invalid_options(kwargs, _ARGUMENT_KEYS, name="FIFOScheduler")
@@ -244,7 +244,7 @@ class LegacyFIFOScheduler(TrialSchedulerWithSearcher):
             mode = mode[0]
         return metric, mode
 
-    def _extend_search_options(self, search_options: Dict[str, Any]) -> Dict[str, Any]:
+    def _extend_search_options(self, search_options: dict[str, Any]) -> dict[str, Any]:
         """Allows child classes to extend ``search_options``.
 
         :param search_options: Original dict of options
@@ -286,8 +286,8 @@ class LegacyFIFOScheduler(TrialSchedulerWithSearcher):
         return config
 
     def _on_config_suggest(
-        self, config: Dict[str, Any], trial_id: str, **kwargs
-    ) -> Dict[str, Any]:
+        self, config: dict[str, Any], trial_id: str, **kwargs
+    ) -> dict[str, Any]:
         """Called by ``suggest`` to allow scheduler to register a new config.
 
         We register the config here, not in ``on_trial_add``. While this risks
@@ -338,7 +338,7 @@ class LegacyFIFOScheduler(TrialSchedulerWithSearcher):
         return self.time_keeper.time()
 
     @staticmethod
-    def _check_keys_of_result(result: Dict[str, Any], keys: List[str]):
+    def _check_keys_of_result(result: dict[str, Any], keys: list[str]):
         assert all(key in result for key in keys), (
             "Your training evaluation function needs to report values for the "
             + f"keys {keys}:\n   report("
@@ -346,10 +346,10 @@ class LegacyFIFOScheduler(TrialSchedulerWithSearcher):
             + ", ...)"
         )
 
-    def _check_result(self, result: Dict[str, Any]):
+    def _check_result(self, result: dict[str, Any]):
         self._check_keys_of_result(result, self.metric_names())
 
-    def on_trial_result(self, trial: Trial, result: Dict[str, Any]) -> str:
+    def on_trial_result(self, trial: Trial, result: dict[str, Any]) -> str:
         """
         We simply relay ``result`` to the searcher. Other decisions are done
         in ``on_trial_complete``.
@@ -376,10 +376,10 @@ class LegacyFIFOScheduler(TrialSchedulerWithSearcher):
         logger.debug(log_msg)
         return trial_decision
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return _to_list(self.metric)
 
-    def metric_mode(self) -> Union[str, List[str]]:
+    def metric_mode(self) -> Union[str, list[str]]:
         return self.mode
 
     def is_multiobjective_scheduler(self) -> bool:

--- a/syne_tune/optimizer/schedulers/legacy_hyperband.py
+++ b/syne_tune/optimizer/schedulers/legacy_hyperband.py
@@ -1,7 +1,7 @@
 import copy
 import logging
 from dataclasses import dataclass
-from typing import Optional,Any
+from typing import Optional, Any
 from collections.abc import Callable
 
 import numpy as np

--- a/syne_tune/optimizer/schedulers/legacy_hyperband.py
+++ b/syne_tune/optimizer/schedulers/legacy_hyperband.py
@@ -1,7 +1,8 @@
 import copy
 import logging
 from dataclasses import dataclass
-from typing import Optional, List, Dict, Any, Tuple, Callable
+from typing import Optional,Any
+from collections.abc import Callable
 
 import numpy as np
 
@@ -133,7 +134,7 @@ class TrialInformation:
     attributes ``self.metric`` and ``self._resource_attr``.
     """
 
-    config: Dict[str, Any]
+    config: dict[str, Any]
     time_stamp: float
     bracket: int
     keep_case: bool
@@ -390,7 +391,7 @@ class LegacyHyperbandScheduler(
     :type early_checkpoint_removal_kwargs: Dict[str, Any], optional
     """
 
-    def __init__(self, config_space: Dict[str, Any], **kwargs):
+    def __init__(self, config_space: dict[str, Any], **kwargs):
         # Before we can call the superclass constructor, we need to set a few
         # members (see also ``_extend_search_options``).
         # To do this properly, we first check values and impute defaults for
@@ -501,7 +502,7 @@ class LegacyHyperbandScheduler(
         )
 
     def _initialize_early_checkpoint_removal(
-        self, callback_kwargs: Optional[Dict[str, Any]]
+        self, callback_kwargs: Optional[dict[str, Any]]
     ):
         if callback_kwargs is not None:
             for name in ["max_num_checkpoints"]:
@@ -518,7 +519,7 @@ class LegacyHyperbandScheduler(
         return HyperbandBracketManager.does_pause_resume(self.scheduler_type)
 
     @property
-    def rung_levels(self) -> List[int]:
+    def rung_levels(self) -> list[int]:
         """
         Note that all entries of ``rung_levels`` are smaller than ``max_t`` (or
         ``config_space[max_resource_attr]``): rung levels are resource levels where
@@ -551,7 +552,7 @@ class LegacyHyperbandScheduler(
             super()._initialize_searcher()
             self.bracket_distribution.configure(self)
 
-    def _extend_search_options(self, search_options: Dict[str, Any]) -> Dict[str, Any]:
+    def _extend_search_options(self, search_options: dict[str, Any]) -> dict[str, Any]:
         # Note: Needs ``self.scheduler_type`` to be set
         scheduler = "hyperband_{}".format(self.scheduler_type)
         result = dict(
@@ -600,8 +601,8 @@ class LegacyHyperbandScheduler(
             return self._cost_attr
 
     def _on_config_suggest(
-        self, config: Dict[str, Any], trial_id: str, **kwargs
-    ) -> Dict[str, Any]:
+        self, config: dict[str, Any], trial_id: str, **kwargs
+    ) -> dict[str, Any]:
         """
         ``kwargs`` being used here:
 
@@ -778,7 +779,7 @@ class LegacyHyperbandScheduler(
         self._cleanup_trial(str(trial.trial_id), trial_decision=SchedulerDecision.STOP)
 
     def _update_searcher_internal(
-        self, trial_id: str, config: Dict[str, Any], result: Dict[str, Any]
+        self, trial_id: str, config: dict[str, Any], result: dict[str, Any]
     ):
         if self.searcher_data == "rungs_and_last":
             # Remove last recently added result for this task. This is not
@@ -791,9 +792,9 @@ class LegacyHyperbandScheduler(
     def _update_searcher(
         self,
         trial_id: str,
-        config: Dict[str, Any],
-        result: Dict[str, Any],
-        task_info: Dict[str, Any],
+        config: dict[str, Any],
+        result: dict[str, Any],
+        task_info: dict[str, Any],
     ):
         """Updates searcher with ``result``, registers pending config there
 
@@ -844,7 +845,7 @@ class LegacyHyperbandScheduler(
             )
         return do_update
 
-    def _check_result(self, result: Dict[str, Any]):
+    def _check_result(self, result: dict[str, Any]):
         super()._check_result(result)
         keys = [self._resource_attr]
         if self.scheduler_type == "cost_promotion":
@@ -857,7 +858,7 @@ class LegacyHyperbandScheduler(
             + f"value {resource}, which is not permitted"
         )
 
-    def on_trial_result(self, trial: Trial, result: Dict[str, Any]) -> str:
+    def on_trial_result(self, trial: Trial, result: dict[str, Any]) -> str:
         self._check_result(result)
         trial_id = str(trial.trial_id)
         debug_log = self.searcher.debug_log
@@ -992,7 +993,7 @@ class LegacyHyperbandScheduler(
     def on_trial_remove(self, trial: Trial):
         self._cleanup_trial(str(trial.trial_id), trial_decision=SchedulerDecision.PAUSE)
 
-    def on_trial_complete(self, trial: Trial, result: Dict[str, Any]):
+    def on_trial_complete(self, trial: Trial, result: dict[str, Any]):
         # Check whether searcher was already updated based on ``result``
         trial_id = str(trial.trial_id)
         largest_update_resource = self._active_trials[trial_id].largest_update_resource
@@ -1052,12 +1053,12 @@ class HyperbandBracketManager:
         metric: str,
         mode: str,
         max_t: int,
-        rung_levels: List[int],
+        rung_levels: list[int],
         brackets: int,
         rung_system_per_bracket: bool,
         cost_attr: str,
         random_seed: int,
-        rung_system_kwargs: Dict[str, Any],
+        rung_system_kwargs: dict[str, Any],
         scheduler: LegacyHyperbandScheduler,
     ):
         assert (
@@ -1126,7 +1127,7 @@ class HyperbandBracketManager:
         rung_sys, skip_rungs = self._get_rung_system_for_bracket_id(bracket_id)
         return rung_sys, bracket_id, skip_rungs
 
-    def on_task_add(self, trial_id: str, **kwargs) -> List[int]:
+    def on_task_add(self, trial_id: str, **kwargs) -> list[int]:
         """
         Called when new task is started (can be new trial or trial being
         resumed).
@@ -1153,7 +1154,7 @@ class HyperbandBracketManager:
             milestones = [self._max_t]
         return milestones
 
-    def on_task_report(self, trial_id: str, result: Dict[str, Any]) -> Dict[str, Any]:
+    def on_task_report(self, trial_id: str, result: dict[str, Any]) -> dict[str, Any]:
         """
         This method is called whenever a new report is received. It returns a
         dictionary with all the information needed for making decisions
@@ -1268,7 +1269,7 @@ class HyperbandBracketManager:
             entry for rs in self._rung_systems for entry in rs.paused_trials(resource)
         ]
 
-    def information_for_rungs(self) -> List[Tuple[int, int, float]]:
+    def information_for_rungs(self) -> list[tuple[int, int, float]]:
         """
         :return: List of ``(resource, num_entries, prom_quant)``, where
             ``resource`` is a rung level, ``num_entries`` the number of entries

--- a/syne_tune/optimizer/schedulers/legacy_hyperband_checkpoint_removal.py
+++ b/syne_tune/optimizer/schedulers/legacy_hyperband_checkpoint_removal.py
@@ -1,4 +1,5 @@
-from typing import Optional, Dict, Any, Callable
+from typing import Optional, Any
+from collections.abc import Callable
 
 from syne_tune.callbacks.hyperband_remove_checkpoints_callback import (
     HyperbandRemoveCheckpointsCallback,
@@ -10,7 +11,7 @@ from syne_tune.tuner_callback import TunerCallback
 
 
 def create_callback_for_checkpoint_removal(
-    callback_kwargs: Dict[str, Any],
+    callback_kwargs: dict[str, Any],
     stop_criterion: Callable[[TuningStatus], bool],
 ) -> Optional[TunerCallback]:
     if isinstance(stop_criterion, StoppingCriterion):

--- a/syne_tune/optimizer/schedulers/legacy_hyperband_cost_promotion.py
+++ b/syne_tune/optimizer/schedulers/legacy_hyperband_cost_promotion.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple, Dict, Any
+from typing import Optional, Any
 import logging
 
 from syne_tune.optimizer.schedulers.legacy_hyperband_stopping import Rung
@@ -67,8 +67,8 @@ class CostPromotionRungSystem(PromotionRungSystem):
 
     def __init__(
         self,
-        rung_levels: List[int],
-        promote_quantiles: List[float],
+        rung_levels: list[int],
+        promote_quantiles: list[float],
         metric: str,
         mode: str,
         resource_attr: str,
@@ -80,7 +80,7 @@ class CostPromotionRungSystem(PromotionRungSystem):
         )
         self._cost_attr = cost_attr
 
-    def _find_promotable_trial(self, rung: Rung) -> Optional[Tuple[str, int]]:
+    def _find_promotable_trial(self, rung: Rung) -> Optional[tuple[str, int]]:
         """
         The promotability condition depends on the cost values (see header
         comment).
@@ -100,7 +100,7 @@ class CostPromotionRungSystem(PromotionRungSystem):
         return result
 
     def _register_metrics_at_rung_level(
-        self, trial_id: str, result: Dict[str, Any], rung: Rung
+        self, trial_id: str, result: dict[str, Any], rung: Rung
     ):
         assert trial_id not in rung  # Sanity check
         rung.add(

--- a/syne_tune/optimizer/schedulers/legacy_hyperband_pasha.py
+++ b/syne_tune/optimizer/schedulers/legacy_hyperband_pasha.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from syne_tune.optimizer.schedulers.legacy_hyperband_promotion import (
@@ -22,8 +22,8 @@ class PASHARungSystem(PromotionRungSystem):
 
     def __init__(
         self,
-        rung_levels: List[int],
-        promote_quantiles: List[float],
+        rung_levels: list[int],
+        promote_quantiles: list[float],
         metric: str,
         mode: str,
         resource_attr: str,
@@ -249,8 +249,8 @@ class PASHARungSystem(PromotionRungSystem):
         return not keep_current_budget
 
     def on_task_report(
-        self, trial_id: str, result: Dict[str, Any], skip_rungs: int
-    ) -> Dict[str, Any]:
+        self, trial_id: str, result: dict[str, Any], skip_rungs: int
+    ) -> dict[str, Any]:
         """
         Apart from calling the superclass method, we also check the rankings
         and decides if to increase the current maximum resources.

--- a/syne_tune/optimizer/schedulers/legacy_hyperband_promotion.py
+++ b/syne_tune/optimizer/schedulers/legacy_hyperband_promotion.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any, Tuple
+from typing import Optional, Any
 
 from syne_tune.optimizer.schedulers.legacy_hyperband_stopping import (
     RungEntry,
@@ -52,8 +52,8 @@ class PromotionRungSystem(RungSystem):
 
     def __init__(
         self,
-        rung_levels: List[int],
-        promote_quantiles: List[float],
+        rung_levels: list[int],
+        promote_quantiles: list[float],
         metric: str,
         mode: str,
         resource_attr: str,
@@ -71,7 +71,7 @@ class PromotionRungSystem(RungSystem):
         # is required for ``on_task_report`` to properly report ``ignore_data``.
         self._running = dict()
 
-    def _find_promotable_trial(self, rung: Rung) -> Optional[Tuple[str, int]]:
+    def _find_promotable_trial(self, rung: Rung) -> Optional[tuple[str, int]]:
         """
         Check whether any not yet promoted entry in ``rung`` is
         promotable, i.e. it lies left of (or is equal to) the pivot.
@@ -129,7 +129,7 @@ class PromotionRungSystem(RungSystem):
         """
         return self._max_t
 
-    def on_task_schedule(self, new_trial_id: str) -> Dict[str, Any]:
+    def on_task_schedule(self, new_trial_id: str) -> dict[str, Any]:
         """
         Used to implement
         :meth:`~syne_tune.optimizer.schedulers.HyperbandScheduler._promote_trial`.
@@ -190,14 +190,14 @@ class PromotionRungSystem(RungSystem):
         self._running[trial_id] = {"milestone": milestone, "resume_from": resume_from}
 
     def _register_metrics_at_rung_level(
-        self, trial_id: str, result: Dict[str, Any], rung: Rung
+        self, trial_id: str, result: dict[str, Any], rung: Rung
     ):
         assert trial_id not in rung  # Sanity check
         rung.add(PromotionRungEntry(trial_id=trial_id, metric_val=result[self._metric]))
 
     def on_task_report(
-        self, trial_id: str, result: Dict[str, Any], skip_rungs: int
-    ) -> Dict[str, Any]:
+        self, trial_id: str, result: dict[str, Any], skip_rungs: int
+    ) -> dict[str, Any]:
         """
         Decision on whether task may continue (``task_continues=True``), or
         should be paused (``task_continues=False``).

--- a/syne_tune/optimizer/schedulers/legacy_hyperband_rush.py
+++ b/syne_tune/optimizer/schedulers/legacy_hyperband_rush.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, List
+from typing import Optional
 
 from syne_tune.optimizer.schedulers.legacy_hyperband_promotion import (
     PromotionRungEntry,
@@ -88,8 +88,8 @@ class RUSHStoppingRungSystem(StoppingRungSystem):
 
     def __init__(
         self,
-        rung_levels: List[int],
-        promote_quantiles: List[float],
+        rung_levels: list[int],
+        promote_quantiles: list[float],
         metric: str,
         mode: str,
         resource_attr: str,
@@ -125,8 +125,8 @@ class RUSHPromotionRungSystem(PromotionRungSystem):
 
     def __init__(
         self,
-        rung_levels: List[int],
-        promote_quantiles: List[float],
+        rung_levels: list[int],
+        promote_quantiles: list[float],
         metric: str,
         mode: str,
         resource_attr: str,

--- a/syne_tune/optimizer/schedulers/legacy_hyperband_stopping.py
+++ b/syne_tune/optimizer/schedulers/legacy_hyperband_stopping.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Tuple, Dict, Any, Optional
+from typing import Any, Optional
 from sortedcontainers import SortedList
 
 logger = logging.getLogger(__name__)
@@ -32,7 +32,7 @@ class Rung:
         level: int,
         prom_quant: float,
         mode: str,
-        data: Optional[List[RungEntry]] = None,
+        data: Optional[list[RungEntry]] = None,
     ):
         self.level = level
         assert 0 < prom_quant < 1
@@ -96,7 +96,7 @@ class Rung:
         return g * values[1] + (1 - g) * values[0]
 
 
-PausedTrialsResult = List[Tuple[str, int, float, int]]
+PausedTrialsResult = list[tuple[str, int, float, int]]
 
 
 class RungSystem:
@@ -120,8 +120,8 @@ class RungSystem:
 
     def __init__(
         self,
-        rung_levels: List[int],
-        promote_quantiles: List[float],
+        rung_levels: list[int],
+        promote_quantiles: list[float],
         metric: str,
         mode: str,
         resource_attr: str,
@@ -139,7 +139,7 @@ class RungSystem:
             for x, y in reversed(list(zip(rung_levels, promote_quantiles)))
         ]
 
-    def on_task_schedule(self, new_trial_id: str) -> Dict[str, Any]:
+    def on_task_schedule(self, new_trial_id: str) -> dict[str, Any]:
         """Called when new task is to be scheduled.
 
         For a promotion-based rung system, check whether any trial can be
@@ -178,8 +178,8 @@ class RungSystem:
         pass
 
     def on_task_report(
-        self, trial_id: str, result: Dict[str, Any], skip_rungs: int
-    ) -> Dict[str, Any]:
+        self, trial_id: str, result: dict[str, Any], skip_rungs: int
+    ) -> dict[str, Any]:
         """Called when a trial reports metric results.
 
         Returns dict with keys "milestone_reached" (trial reaches its milestone),
@@ -214,13 +214,13 @@ class RungSystem:
             else self._max_t
         )
 
-    def _milestone_rungs(self, skip_rungs: int) -> List[Rung]:
+    def _milestone_rungs(self, skip_rungs: int) -> list[Rung]:
         if skip_rungs > 0:
             return self._rungs[:(-skip_rungs)]
         else:
             return self._rungs
 
-    def get_milestones(self, skip_rungs: int) -> List[int]:
+    def get_milestones(self, skip_rungs: int) -> list[int]:
         """
         :param skip_rungs: This number of the smallest rung levels are not
             considered milestones for this task
@@ -230,9 +230,9 @@ class RungSystem:
         milestone_rungs = self._milestone_rungs(skip_rungs)
         return [x.level for x in milestone_rungs]
 
-    def snapshot_rungs(self, skip_rungs: int) -> List[Tuple[int, List[RungEntry]]]:
+    def snapshot_rungs(self, skip_rungs: int) -> list[tuple[int, list[RungEntry]]]:
         """
-        A snapshot is a list of rung levels with entries ``(level, data)``,
+        A snapshot is a List of rung levels with entries ``(level, data)``,
         ordered from top to bottom (largest rung first).
 
         :param skip_rungs: This number of the smallest rung levels are not
@@ -274,7 +274,7 @@ class RungSystem:
         """
         return []
 
-    def information_for_rungs(self) -> List[Tuple[int, int, float]]:
+    def information_for_rungs(self) -> list[tuple[int, int, float]]:
         """
         :return: List of ``(resource, num_entries, prom_quant)``, where
             ``resource`` is a rung level, ``num_entries`` the number of entries
@@ -323,12 +323,12 @@ class StoppingRungSystem(RungSystem):
             return True
         return metric_val <= cutoff if self._mode == "min" else metric_val >= cutoff
 
-    def on_task_schedule(self, new_trial_id: str) -> Dict[str, Any]:
+    def on_task_schedule(self, new_trial_id: str) -> dict[str, Any]:
         return dict()
 
     def on_task_report(
-        self, trial_id: str, result: Dict[str, Any], skip_rungs: int
-    ) -> Dict[str, Any]:
+        self, trial_id: str, result: dict[str, Any], skip_rungs: int
+    ) -> dict[str, Any]:
         resource = result[self._resource_attr]
         metric_val = result[self._metric]
         if resource == self._max_t:

--- a/syne_tune/optimizer/schedulers/legacy_median_stopping_rule.py
+++ b/syne_tune/optimizer/schedulers/legacy_median_stopping_rule.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-from typing import Optional, Dict, List
+from typing import Optional
 
 import numpy as np
 
@@ -78,7 +78,7 @@ class LegacyMedianStoppingRule(LegacyTrialScheduler):
     def _suggest(self, trial_id: int) -> Optional[TrialSuggestion]:
         return self.scheduler._suggest(trial_id=trial_id)
 
-    def on_trial_result(self, trial: Trial, result: Dict) -> str:
+    def on_trial_result(self, trial: Trial, result: dict) -> str:
         new_metric = result[self.metric]
         if self.mode == "max":
             new_metric *= -1
@@ -123,7 +123,7 @@ class LegacyMedianStoppingRule(LegacyTrialScheduler):
             return True
         return False
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return self.scheduler.metric_names()
 
     def metric_mode(self) -> str:

--- a/syne_tune/optimizer/schedulers/legacy_pbt.py
+++ b/syne_tune/optimizer/schedulers/legacy_pbt.py
@@ -5,7 +5,8 @@ import numpy as np
 
 from dataclasses import dataclass
 from collections import deque
-from typing import Callable, List, Optional, Tuple, Dict, Any
+from collections.abc import Callable
+from typing import Optional, Any
 
 from syne_tune.config_space import Domain, Integer, Float, FiniteRange
 from syne_tune.backend.trial_status import Trial
@@ -123,7 +124,7 @@ class LegacyPopulationBasedTraining(LegacyFIFOScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         custom_explore_fn: Optional[Callable[[dict], dict]] = None,
         **kwargs,
     ):
@@ -191,7 +192,7 @@ class LegacyPopulationBasedTraining(LegacyFIFOScheduler):
         else:
             return trial_id
 
-    def on_trial_result(self, trial: Trial, result: Dict[str, Any]) -> str:
+    def on_trial_result(self, trial: Trial, result: dict[str, Any]) -> str:
         for name, value in [
             ("resource_attr", self._resource_attr),
             ("metric", self.metric),
@@ -245,7 +246,7 @@ class LegacyPopulationBasedTraining(LegacyFIFOScheduler):
             return SchedulerDecision.STOP
 
     def _save_trial_state(
-        self, state: PBTTrialState, time: int, result: Dict[str, Any]
+        self, state: PBTTrialState, time: int, result: dict[str, Any]
     ) -> float:
         """Saves necessary trial information when result is received.
 
@@ -263,7 +264,7 @@ class LegacyPopulationBasedTraining(LegacyFIFOScheduler):
         state.last_result = result
         return score
 
-    def _quantiles(self) -> Tuple[List[Trial], List[Trial]]:
+    def _quantiles(self) -> tuple[list[Trial], list[Trial]]:
         """Returns trials in the lower and upper ``quantile`` of the population.
 
         If there is not enough data to compute this, returns empty lists.
@@ -305,7 +306,7 @@ class LegacyPopulationBasedTraining(LegacyFIFOScheduler):
                 config=config, checkpoint_trial_id=trial_id_to_continue
             )
 
-    def _explore(self, config: Dict[str, Any]) -> Dict[str, Any]:
+    def _explore(self, config: dict[str, Any]) -> dict[str, Any]:
         """Return a config perturbed as specified.
 
         :param config: Original hyperparameter configuration from the cloned trial

--- a/syne_tune/optimizer/schedulers/legacy_smac_scheduler.py
+++ b/syne_tune/optimizer/schedulers/legacy_smac_scheduler.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, List, Dict, Any
+from typing import Optional, Any
 
 from ConfigSpace import Configuration
 from smac import Scenario, HyperparameterOptimizationFacade
@@ -20,7 +20,7 @@ from syne_tune.config_space import Domain, Integer, is_log_space, Float
 
 
 def to_smac_configspace(
-    config_space: Dict[str, Domain], random_seed: int
+    config_space: dict[str, Domain], random_seed: int
 ) -> CS.ConfigurationSpace:
     cs = CS.ConfigurationSpace(seed=random_seed)
     for hp_name, hp in config_space.items():
@@ -60,7 +60,7 @@ def to_smac_configspace(
 class LegacySMACScheduler(TrialScheduler):
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         mode: Optional[str] = None,
         points_to_evaluate=None,
@@ -110,7 +110,7 @@ class LegacySMACScheduler(TrialScheduler):
         )
         self.trial_info = {}
 
-    def on_trial_complete(self, trial: Trial, result: Dict[str, Any]) -> str:
+    def on_trial_complete(self, trial: Trial, result: dict[str, Any]) -> str:
         info = self.trial_info[trial.trial_id]
         cost = result[self.metric]
         if self.mode == "max":
@@ -144,5 +144,5 @@ class LegacySMACScheduler(TrialScheduler):
         # Avoid serialization issues with swig
         return None
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return [self.metric]

--- a/syne_tune/optimizer/schedulers/median_stopping_rule.py
+++ b/syne_tune/optimizer/schedulers/median_stopping_rule.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-from typing import Optional, Dict, Any
+from typing import Optional, Any
 
 import numpy as np
 
@@ -83,7 +83,7 @@ class MedianStoppingRule(TrialScheduler):
     def suggest(self) -> Optional[TrialSuggestion]:
         return self.scheduler.suggest()
 
-    def on_trial_result(self, trial: Trial, result: Dict) -> str:
+    def on_trial_result(self, trial: Trial, result: dict) -> str:
         new_metric = result[self.metric] * self.metric_multiplier
 
         time_step = result[self.resource_attr]
@@ -127,7 +127,7 @@ class MedianStoppingRule(TrialScheduler):
             return True
         return False
 
-    def metadata(self) -> Dict[str, Any]:
+    def metadata(self) -> dict[str, Any]:
         """
         :return: Metadata for the scheduler
         """

--- a/syne_tune/optimizer/schedulers/multi_fidelity.py
+++ b/syne_tune/optimizer/schedulers/multi_fidelity.py
@@ -1,6 +1,3 @@
-from typing import List
-
-
 class MultiFidelitySchedulerMixin:
     """
     Declares properties which are required for multi-fidelity schedulers.
@@ -21,7 +18,7 @@ class MultiFidelitySchedulerMixin:
         raise NotImplementedError
 
     @property
-    def rung_levels(self) -> List[int]:
+    def rung_levels(self) -> list[int]:
         """
         :return: Rung levels (positive int; increasing), may or may not
             include ``max_resource_level``

--- a/syne_tune/optimizer/schedulers/multiobjective/expected_hyper_volume_improvement.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/expected_hyper_volume_improvement.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any
+from typing import Optional, Any
 import logging
 
 import numpy as np
@@ -68,8 +68,8 @@ class ExpectedHyperVolumeImprovement(BaseSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        points_to_evaluate: Optional[List[dict]] = None,
+        config_space: dict[str, Any],
+        points_to_evaluate: Optional[list[dict]] = None,
         num_init_random: int = 3,
         no_fantasizing: bool = False,
         max_num_observations: Optional[int] = 200,
@@ -97,7 +97,7 @@ class ExpectedHyperVolumeImprovement(BaseSearcher):
         self.random_state = np.random.RandomState(self.random_seed)
 
     def on_trial_complete(
-        self, trial_id: int, config: Dict[str, Any], metrics: List[float]
+        self, trial_id: int, config: dict[str, Any], metrics: list[float]
     ):
 
         self.trial_observations[trial_id] = metrics
@@ -240,7 +240,7 @@ class ExpectedHyperVolumeImprovement(BaseSearcher):
             warp_tf = None
         return SingleTaskGP(X_tensor, Y_tensor, input_transform=warp_tf)
 
-    def _config_to_feature_matrix(self, configs: List[dict]):
+    def _config_to_feature_matrix(self, configs: list[dict]):
         bounds = Tensor(self._hp_ranges.get_ndarray_bounds()).T
         X = Tensor(self._hp_ranges.to_ndarray_matrix(configs))
         return normalize(X, bounds)
@@ -248,14 +248,14 @@ class ExpectedHyperVolumeImprovement(BaseSearcher):
     def objectives(self):
         return np.array(list(self.trial_observations.values()))
 
-    def _configs_with_results(self) -> List[dict]:
+    def _configs_with_results(self) -> list[dict]:
         return [
             config
             for trial, config in self.trial_configs.items()
             if not trial in self.pending_trials
         ]
 
-    def _configs_pending(self) -> List[dict]:
+    def _configs_pending(self) -> list[dict]:
         return [
             config
             for trial, config in self.trial_configs.items()

--- a/syne_tune/optimizer/schedulers/multiobjective/legacy_expected_hyper_volume_improvement.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/legacy_expected_hyper_volume_improvement.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any, Union
+from typing import Optional, Any, Union
 import logging
 
 import numpy as np
@@ -66,12 +66,12 @@ class LegacyExpectedHyperVolumeImprovement(StochasticAndFilterDuplicatesSearcher
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        metric: List[str],
-        mode: Union[List[str], str],
-        points_to_evaluate: Optional[List[dict]] = None,
+        config_space: dict[str, Any],
+        metric: list[str],
+        mode: Union[list[str], str],
+        points_to_evaluate: Optional[list[dict]] = None,
         allow_duplicates: bool = False,
-        restrict_configurations: Optional[List[Dict[str, Any]]] = None,
+        restrict_configurations: Optional[list[dict[str, Any]]] = None,
         num_init_random: int = 3,
         no_fantasizing: bool = False,
         max_num_observations: Optional[int] = 200,
@@ -105,7 +105,7 @@ class LegacyExpectedHyperVolumeImprovement(StochasticAndFilterDuplicatesSearcher
         if "random_seed" in kwargs:
             random.manual_seed(kwargs["random_seed"])
 
-    def _update(self, trial_id: str, config: Dict[str, Any], result: Dict[str, Any]):
+    def _update(self, trial_id: str, config: dict[str, Any], result: dict[str, Any]):
         trial_id = int(trial_id)
 
         observations = []
@@ -120,7 +120,7 @@ class LegacyExpectedHyperVolumeImprovement(StochasticAndFilterDuplicatesSearcher
         if trial_id in self.pending_trials:
             self.pending_trials.remove(trial_id)
 
-    def clone_from_state(self, state: Dict[str, Any]):
+    def clone_from_state(self, state: dict[str, Any]):
         raise NotImplementedError
 
     def num_suggestions(self):
@@ -275,7 +275,7 @@ class LegacyExpectedHyperVolumeImprovement(StochasticAndFilterDuplicatesSearcher
             warp_tf = None
         return SingleTaskGP(X_tensor, Y_tensor, input_transform=warp_tf)
 
-    def _config_to_feature_matrix(self, configs: List[dict]):
+    def _config_to_feature_matrix(self, configs: list[dict]):
         bounds = Tensor(self._hp_ranges.get_ndarray_bounds()).T
         X = Tensor(self._hp_ranges.to_ndarray_matrix(configs))
         return normalize(X, bounds)
@@ -301,21 +301,21 @@ class LegacyExpectedHyperVolumeImprovement(StochasticAndFilterDuplicatesSearcher
         else:
             return self._get_random_config()
 
-    def _configs_with_results(self) -> List[dict]:
+    def _configs_with_results(self) -> list[dict]:
         return [
             config
             for trial, config in self.trial_configs.items()
             if not trial in self.pending_trials
         ]
 
-    def _configs_pending(self) -> List[dict]:
+    def _configs_pending(self) -> list[dict]:
         return [
             config
             for trial, config in self.trial_configs.items()
             if trial in self.pending_trials
         ]
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return [self._metric]
 
     def metric_mode(self) -> str:

--- a/syne_tune/optimizer/schedulers/multiobjective/legacy_linear_scalarizer.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/legacy_linear_scalarizer.py
@@ -1,9 +1,9 @@
 import logging
 import string
-from collections.abc import Iterable
+from collections.abc import Iterable, Callable
 from itertools import groupby
 import random
-from typing import Dict, Any, List, Union, Callable, Optional
+from typing import Any, Union, Optional
 
 import numpy as np
 
@@ -51,10 +51,10 @@ class LegacyLinearScalarizedScheduler(LegacyTrialScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        metric: List[str],
-        mode: Union[List[str], str] = "min",
-        scalarization_weights: Union[np.ndarray, List[float]] = None,
+        config_space: dict[str, Any],
+        metric: list[str],
+        mode: Union[list[str], str] = "min",
+        scalarization_weights: Union[np.ndarray, list[float]] = None,
         base_scheduler_factory: Callable[[Any], LegacyTrialScheduler] = None,
         **base_scheduler_kwargs,
     ):
@@ -98,7 +98,7 @@ class LegacyLinearScalarizedScheduler(LegacyTrialScheduler):
             **base_scheduler_kwargs,
         )
 
-    def _scalarized_metric(self, result: Dict[str, Any]) -> float:
+    def _scalarized_metric(self, result: dict[str, Any]) -> float:
         if isinstance(self.base_scheduler, LegacyFIFOScheduler):
             LegacyFIFOScheduler._check_keys_of_result(result, self.metric_names())
 
@@ -123,7 +123,7 @@ class LegacyLinearScalarizedScheduler(LegacyTrialScheduler):
         """
         return self.base_scheduler.on_trial_error(trial)
 
-    def on_trial_result(self, trial: Trial, result: Dict[str, Any]) -> str:
+    def on_trial_result(self, trial: Trial, result: dict[str, Any]) -> str:
         """Called on each intermediate result reported by a trial.
         See the docstring of the chosen base_scheduler for details
         """
@@ -133,7 +133,7 @@ class LegacyLinearScalarizedScheduler(LegacyTrialScheduler):
         }
         return self.base_scheduler.on_trial_result(trial, local_results)
 
-    def on_trial_complete(self, trial: Trial, result: Dict[str, Any]):
+    def on_trial_complete(self, trial: Trial, result: dict[str, Any]):
         """Notification for the completion of trial.
         See the docstring of the chosen base_scheduler for details
         """
@@ -149,26 +149,26 @@ class LegacyLinearScalarizedScheduler(LegacyTrialScheduler):
         """
         return self.base_scheduler.on_trial_remove(trial)
 
-    def trials_checkpoints_can_be_removed(self) -> List[int]:
+    def trials_checkpoints_can_be_removed(self) -> list[int]:
         """
         See the docstring of the chosen base_scheduler for details
         :return: IDs of paused trials for which checkpoints can be removed
         """
         return self.base_scheduler.trials_checkpoints_can_be_removed()
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         """
         :return: List of metric names.
         """
         return self.metric
 
-    def metric_mode(self) -> Union[str, List[str]]:
+    def metric_mode(self) -> Union[str, list[str]]:
         """
         :return: "min" if target metric is minimized, otherwise "max".
         """
         return self.mode
 
-    def metadata(self) -> Dict[str, Any]:
+    def metadata(self) -> dict[str, Any]:
         """
         :return: Metadata of the scheduler
         """

--- a/syne_tune/optimizer/schedulers/multiobjective/legacy_moasha.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/legacy_moasha.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Union, List, Dict, Any
+from typing import Optional, Union, Any
 
 import numpy as np
 from syne_tune.backend.trial_status import Trial
@@ -58,9 +58,9 @@ class LegacyMOASHA(LegacyTrialScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        metrics: List[str],
-        mode: Optional[Union[str, List[str]]] = None,
+        config_space: dict[str, Any],
+        metrics: list[str],
+        mode: Optional[Union[str, list[str]]] = None,
         time_attr: str = "training_iteration",
         multiobjective_priority: Optional[MOPriority] = None,
         max_t: int = 100,
@@ -75,7 +75,7 @@ class LegacyMOASHA(LegacyTrialScheduler):
         assert reduction_factor > 1, "reduction factor not valid!"
         assert brackets > 0, "brackets must be positive!"
         if mode:
-            if isinstance(mode, List):
+            if isinstance(mode, list):
                 assert len(mode) == len(metrics), "one mode should be given per metric"
                 assert all(
                     m in ["min", "max"] for m in mode
@@ -104,7 +104,7 @@ class LegacyMOASHA(LegacyTrialScheduler):
         self._num_stopped = 0
         self._metrics = metrics
         self._mode = mode
-        if isinstance(self._mode, List):
+        if isinstance(self._mode, list):
             self._metric_op = {
                 metric: 1 if mode == "min" else -1
                 for metric, mode in zip(metrics, self._mode)
@@ -116,7 +116,7 @@ class LegacyMOASHA(LegacyTrialScheduler):
                 self._metric_op = dict(zip(self._metrics, [-1.0] * len(self._metrics)))
         self._time_attr = time_attr
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return self._metrics
 
     def metric_mode(self) -> str:
@@ -137,7 +137,7 @@ class LegacyMOASHA(LegacyTrialScheduler):
         print(f"adding trial {trial.trial_id}")
         self._trial_info[trial.trial_id] = self._brackets[idx]
 
-    def on_trial_result(self, trial: Trial, result: Dict[str, Any]) -> str:
+    def on_trial_result(self, trial: Trial, result: dict[str, Any]) -> str:
         self._check_metrics_are_present(result)
         if result[self._time_attr] >= self._max_t:
             action = SchedulerDecision.STOP
@@ -153,18 +153,18 @@ class LegacyMOASHA(LegacyTrialScheduler):
             self._num_stopped += 1
         return action
 
-    def _metric_dict(self, reported_results: Dict[str, Any]) -> Dict[str, Any]:
+    def _metric_dict(self, reported_results: dict[str, Any]) -> dict[str, Any]:
         return {
             metric: reported_results[metric] * self._metric_op[metric]
             for metric in self._metrics
         }
 
-    def _check_metrics_are_present(self, result: Dict[str, Any]):
+    def _check_metrics_are_present(self, result: dict[str, Any]):
         for key in [self._time_attr] + self._metrics:
             if key not in result:
                 assert key in result, f"{key} not found in reported result {result}"
 
-    def on_trial_complete(self, trial: Trial, result: Dict[str, Any]):
+    def on_trial_complete(self, trial: Trial, result: dict[str, Any]):
         self._check_metrics_are_present(result)
         bracket = self._trial_info[trial.trial_id]
         bracket.on_result(

--- a/syne_tune/optimizer/schedulers/multiobjective/legacy_multi_objective_regularized_evolution.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/legacy_multi_objective_regularized_evolution.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from typing import Optional, List, Union
+from typing import Optional, Union
 
 from syne_tune.optimizer.schedulers.searchers.legacy_regularized_evolution import (
     PopulationElement,
@@ -32,9 +32,9 @@ class LegacyMultiObjectiveRegularizedEvolution(LegacyRegularizedEvolution):
     def __init__(
         self,
         config_space,
-        metric: List[str],
-        mode: Union[List[str], str],
-        points_to_evaluate: Optional[List[dict]] = None,
+        metric: list[str],
+        mode: Union[list[str], str],
+        points_to_evaluate: Optional[list[dict]] = None,
         population_size: int = 100,
         sample_size: int = 10,
         multiobjective_priority: Optional[MOPriority] = None,

--- a/syne_tune/optimizer/schedulers/multiobjective/linear_scalarizer.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/linear_scalarizer.py
@@ -3,7 +3,7 @@ import string
 from collections.abc import Iterable
 from itertools import groupby
 import random
-from typing import Dict, Any, List, Union, Optional
+from typing import Any, Union, Optional
 
 import numpy as np
 
@@ -50,10 +50,10 @@ class LinearScalarizedScheduler(TrialScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        metrics: List[str],
+        config_space: dict[str, Any],
+        metrics: list[str],
         do_minimize: Optional[bool] = True,
-        scalarization_weights: Union[np.ndarray, List[float]] = None,
+        scalarization_weights: Union[np.ndarray, list[float]] = None,
         random_seed: int = None,
         **base_scheduler_kwargs,
     ):
@@ -88,7 +88,7 @@ class LinearScalarizedScheduler(TrialScheduler):
             **base_scheduler_kwargs,
         )
 
-    def _scalarized_metric(self, result: Dict[str, Any]) -> float:
+    def _scalarized_metric(self, result: dict[str, Any]) -> float:
         mo_results = np.array([result[item] for item in self.metrics])
         return np.sum(np.multiply(mo_results, self.scalarization_weights))
 
@@ -110,7 +110,7 @@ class LinearScalarizedScheduler(TrialScheduler):
         """
         return self.base_scheduler.on_trial_error(trial)
 
-    def on_trial_result(self, trial: Trial, result: Dict[str, Any]) -> str:
+    def on_trial_result(self, trial: Trial, result: dict[str, Any]) -> str:
         """Called on each intermediate result reported by a trial.
         See the docstring of the chosen base_scheduler for details
         """
@@ -120,7 +120,7 @@ class LinearScalarizedScheduler(TrialScheduler):
         }
         return self.base_scheduler.on_trial_result(trial, local_results)
 
-    def on_trial_complete(self, trial: Trial, result: Dict[str, Any]):
+    def on_trial_complete(self, trial: Trial, result: dict[str, Any]):
         """Notification for the completion of trial.
         See the docstring of the chosen base_scheduler for details
         """
@@ -136,7 +136,7 @@ class LinearScalarizedScheduler(TrialScheduler):
         """
         return self.base_scheduler.on_trial_remove(trial)
 
-    def metadata(self) -> Dict[str, Any]:
+    def metadata(self) -> dict[str, Any]:
         """
         :return: Metadata of the scheduler
         """
@@ -148,5 +148,5 @@ class LinearScalarizedScheduler(TrialScheduler):
         metadata["scalarized_metric"] = self.single_objective_metric
         return metadata
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return self.metrics

--- a/syne_tune/optimizer/schedulers/multiobjective/moasha.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/moasha.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, List, Dict, Any
+from typing import Optional, Any
 
 import numpy as np
 from syne_tune.backend.trial_status import Trial
@@ -60,8 +60,8 @@ class MOASHA(TrialScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        metrics: List[str],
+        config_space: dict[str, Any],
+        metrics: list[str],
         do_minimize: Optional[bool] = True,
         time_attr: str = "training_iteration",
         multiobjective_priority: Optional[MOPriority] = None,
@@ -101,7 +101,7 @@ class MOASHA(TrialScheduler):
         self.metric_multiplier = 1 if self.do_minimize else -1
         self.time_attr = time_attr
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return self.metrics
 
     def metric_mode(self) -> str:
@@ -121,7 +121,7 @@ class MOASHA(TrialScheduler):
         idx = np.random.choice(len(self.brackets), p=normalized)
         self.trial_info[trial.trial_id] = self.brackets[idx]
 
-    def on_trial_result(self, trial: Trial, result: Dict[str, Any]) -> str:
+    def on_trial_result(self, trial: Trial, result: dict[str, Any]) -> str:
         self.check_metrics_are_present(result)
         if result[self.time_attr] >= self.max_t:
             action = SchedulerDecision.STOP
@@ -137,18 +137,18 @@ class MOASHA(TrialScheduler):
             self.num_stopped += 1
         return action
 
-    def metric_dict(self, reported_results: Dict[str, Any]) -> Dict[str, Any]:
+    def metric_dict(self, reported_results: dict[str, Any]) -> dict[str, Any]:
         return {
             metric: reported_results[metric] * self.metric_multiplier
             for metric in self.metrics
         }
 
-    def check_metrics_are_present(self, result: Dict[str, Any]):
+    def check_metrics_are_present(self, result: dict[str, Any]):
         for key in [self.time_attr] + self.metrics:
             if key not in result:
                 assert key in result, f"{key} not found in reported result {result}"
 
-    def on_trial_complete(self, trial: Trial, result: Dict[str, Any]):
+    def on_trial_complete(self, trial: Trial, result: dict[str, Any]):
         self.check_metrics_are_present(result)
         bracket = self.trial_info[trial.trial_id]
         bracket.on_result(
@@ -161,7 +161,7 @@ class MOASHA(TrialScheduler):
     def on_trial_remove(self, trial: Trial):
         del self.trial_info[trial.trial_id]
 
-    def metadata(self) -> Dict[str, Any]:
+    def metadata(self) -> dict[str, Any]:
         """
         :return: Metadata for the scheduler
         """

--- a/syne_tune/optimizer/schedulers/multiobjective/multi_objective_regularized_evolution.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/multi_objective_regularized_evolution.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from typing import Optional, List, Dict, Any
+from typing import Optional, Any
 from collections import deque
 
 from syne_tune.optimizer.schedulers.searchers.regularized_evolution import (
@@ -33,7 +33,7 @@ class MultiObjectiveRegularizedEvolution(BaseSearcher):
     def __init__(
         self,
         config_space,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
         population_size: int = 100,
         sample_size: int = 10,
         multiobjective_priority: Optional[MOPriority] = None,
@@ -83,8 +83,8 @@ class MultiObjectiveRegularizedEvolution(BaseSearcher):
     def on_trial_complete(
         self,
         trial_id: int,
-        config: Dict[str, Any],
-        metrics: List[float],
+        config: dict[str, Any],
+        metrics: list[float],
     ):
 
         # Add element to the population

--- a/syne_tune/optimizer/schedulers/multiobjective/multi_surrogate_multi_objective_searcher.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/multi_surrogate_multi_objective_searcher.py
@@ -1,6 +1,6 @@
 import logging
 from functools import partial
-from typing import Optional, List, Dict, Any, Union
+from typing import Optional, Any, Union
 
 from syne_tune.optimizer.schedulers.multiobjective.random_scalarization import (
     MultiObjectiveLCBRandomLinearScalarization,
@@ -58,16 +58,16 @@ class MultiObjectiveMultiSurrogateSearcher(BayesianOptimizationSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        metric: List[str],
-        estimators: Dict[str, Estimator],
-        mode: Union[List[str], str] = "min",
-        points_to_evaluate: Optional[List[Dict[str, Any]]] = None,
+        config_space: dict[str, Any],
+        metric: list[str],
+        estimators: dict[str, Estimator],
+        mode: Union[list[str], str] = "min",
+        points_to_evaluate: Optional[list[dict[str, Any]]] = None,
         scoring_class: Optional[ScoringFunctionConstructor] = None,
         num_initial_candidates: int = DEFAULT_NUM_INITIAL_CANDIDATES,
         num_initial_random_choices: int = DEFAULT_NUM_INITIAL_RANDOM_EVALUATIONS,
         allow_duplicates: bool = False,
-        restrict_configurations: Optional[List[Dict[str, Any]]] = None,
+        restrict_configurations: Optional[list[dict[str, Any]]] = None,
         clone_from_state: bool = False,
         **kwargs,
     ):
@@ -119,7 +119,7 @@ class MultiObjectiveMultiSurrogateSearcher(BayesianOptimizationSearcher):
             mode = self._mode
         self._metric_to_internal_signs = [-1 if m == "max" else 1 for m in mode]
 
-    def _update(self, trial_id: str, config: Dict[str, Any], result: Dict[str, Any]):
+    def _update(self, trial_id: str, config: dict[str, Any], result: dict[str, Any]):
         # Gather metrics
         metrics = {
             name: result[name] * self._metric_to_internal_signs[pos]

--- a/syne_tune/optimizer/schedulers/multiobjective/multiobjective_priority.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/multiobjective_priority.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional
 
 import numpy as np
 from syne_tune.optimizer.schedulers.multiobjective.non_dominated_priority import (
@@ -7,7 +7,7 @@ from syne_tune.optimizer.schedulers.multiobjective.non_dominated_priority import
 
 
 class MOPriority:
-    def __init__(self, metrics: Optional[List[str]] = None):
+    def __init__(self, metrics: Optional[list[str]] = None):
         """
         :param metrics: name of the objectives, optional if not passed anonymous names are created when seeing the
         first objectives to rank.
@@ -33,7 +33,7 @@ class MOPriority:
 
 class LinearScalarizationPriority(MOPriority):
     def __init__(
-        self, metrics: Optional[List[str]] = None, weights: Optional[np.array] = None
+        self, metrics: Optional[list[str]] = None, weights: Optional[np.array] = None
     ):
         """
         A simple multiobjective scalarization strategy that do a weighed sum to assign a priority to the objectives.
@@ -58,7 +58,7 @@ class LinearScalarizationPriority(MOPriority):
 
 
 class FixedObjectivePriority(MOPriority):
-    def __init__(self, metrics: Optional[List[str]] = None, dim: Optional[int] = None):
+    def __init__(self, metrics: Optional[list[str]] = None, dim: Optional[int] = None):
         """
         Optimizes a fixed objective, the first one by default.
         :param metrics:
@@ -74,7 +74,7 @@ class FixedObjectivePriority(MOPriority):
 class NonDominatedPriority(MOPriority):
     def __init__(
         self,
-        metrics: Optional[List[str]] = None,
+        metrics: Optional[list[str]] = None,
         dim: Optional[int] = 0,
         max_num_samples: Optional[int] = None,
     ):

--- a/syne_tune/optimizer/schedulers/multiobjective/non_dominated_priority.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/non_dominated_priority.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Union
+from typing import Optional, Union
 
 import numpy as np
 
@@ -95,7 +95,7 @@ def nondominated_sort(
     dim: Optional[int] = None,
     max_items: Optional[int] = None,
     flatten: bool = True,
-) -> Union[List[int], List[List[int]]]:
+) -> Union[list[int], list[list[int]]]:
     """
     Performs a multi-objective sort by iteratively computing the Pareto front and sparsifying the
     items within the Pareto front. This is a non-dominated sort leveraging an epsilon-net.

--- a/syne_tune/optimizer/schedulers/multiobjective/nsga2_searcher.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/nsga2_searcher.py
@@ -1,7 +1,7 @@
 import logging
 import numpy as np
 
-from typing import Optional, List, Union, Dict, Any
+from typing import Optional, Union, Any
 
 from syne_tune.optimizer.schedulers.searchers import StochasticSearcher
 from syne_tune.config_space import Domain, Float, Integer, Categorical, FiniteRange
@@ -24,13 +24,13 @@ except ImportError as e:
     logging.debug(e)
 
 
-def _create_multiobjective_problem(config_space: Dict[str, Any], n_obj: int, **kwargs):
+def _create_multiobjective_problem(config_space: dict[str, Any], n_obj: int, **kwargs):
     # This needs to be an inner class, since ``Problem`` can only be imported
     # with ``moo`` dependencies. We want this module to be importable even if
     # ``moo`` dependencies are not present: only creating a ``NSGA2Searcher``
     # object should fail in this case.
     class _MultiObjectiveMixedVariableProblem(Problem):
-        def __init__(self, n_obj: int, config_space: Dict[str, Any], **kwargs):
+        def __init__(self, n_obj: int, config_space: dict[str, Any], **kwargs):
             vars = {}
 
             for hp_name, hp in config_space.items():
@@ -90,10 +90,10 @@ class NSGA2Searcher(StochasticSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        metric: List[str],
-        mode: Union[List[str], str] = "min",
-        points_to_evaluate: Optional[List[dict]] = None,
+        config_space: dict[str, Any],
+        metric: list[str],
+        mode: Union[list[str], str] = "min",
+        points_to_evaluate: Optional[list[dict]] = None,
         population_size: int = 20,
         **kwargs,
     ):
@@ -156,7 +156,7 @@ class NSGA2Searcher(StochasticSearcher):
             self.observed_values = dict()
             self.current_individual = 0
 
-    def get_config(self, **kwargs) -> Optional[Dict[str, Any]]:
+    def get_config(self, **kwargs) -> Optional[dict[str, Any]]:
         """Suggest a new configuration.
 
         Note: Query :meth:`_next_initial_config` for initial configs to return

--- a/syne_tune/optimizer/schedulers/multiobjective/random_scalarization.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/random_scalarization.py
@@ -1,4 +1,5 @@
-from typing import Dict, Optional, Iterable, List, Callable
+from typing import Optional
+from collections.abc import Callable, Iterable
 
 import numpy as np
 from numpy.random import RandomState
@@ -35,9 +36,9 @@ class MultiObjectiveLCBRandomLinearScalarization(ScoringFunction):
 
     def __init__(
         self,
-        predictor: Dict[str, Predictor],
-        active_metric: Optional[List[str]] = None,
-        weights_sampler: Optional[Callable[[], Dict[str, float]]] = None,
+        predictor: dict[str, Predictor],
+        active_metric: Optional[list[str]] = None,
+        weights_sampler: Optional[Callable[[], dict[str, float]]] = None,
         kappa: float = 0.5,
         normalize_acquisition: bool = True,
         random_seed: int = None,
@@ -59,8 +60,8 @@ class MultiObjectiveLCBRandomLinearScalarization(ScoringFunction):
     def score(
         self,
         candidates: Iterable[Configuration],
-        predictor: Optional[Dict[str, Predictor]] = None,
-    ) -> List[float]:
+        predictor: Optional[dict[str, Predictor]] = None,
+    ) -> list[float]:
         from scipy import stats
 
         if predictor is None:

--- a/syne_tune/optimizer/schedulers/multiobjective/utils.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/utils.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 import numpy as np
 
 try:
@@ -35,7 +34,7 @@ def hypervolume(
     return indicator_fn(results_array)
 
 
-def linear_interpolate(hv_indicator: np.ndarray, indices: List[int]):
+def linear_interpolate(hv_indicator: np.ndarray, indices: list[int]):
     for first, last in zip(indices[:-1], indices[1:]):
         num = last - first + 1
         v_first = hv_indicator[first]

--- a/syne_tune/optimizer/schedulers/pbt.py
+++ b/syne_tune/optimizer/schedulers/pbt.py
@@ -5,7 +5,8 @@ import numpy as np
 
 from dataclasses import dataclass
 from collections import deque
-from typing import Callable, List, Optional, Tuple, Dict, Any
+from collections.abc import Callable
+from typing import Optional, Any
 
 from syne_tune.config_space import (
     Domain,
@@ -98,7 +99,7 @@ class PopulationBasedTraining(TrialScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         resource_attr: str,
         max_t: int = 100,
@@ -169,7 +170,7 @@ class PopulationBasedTraining(TrialScheduler):
         else:
             return trial_id
 
-    def on_trial_result(self, trial: Trial, result: Dict[str, Any]) -> str:
+    def on_trial_result(self, trial: Trial, result: dict[str, Any]) -> str:
         for name, value in [
             ("resource_attr", self.resource_attr),
             ("metric", self.metric),
@@ -218,7 +219,7 @@ class PopulationBasedTraining(TrialScheduler):
             return SchedulerDecision.STOP
 
     def _save_trial_state(
-        self, state: PBTTrialState, time: int, result: Dict[str, Any]
+        self, state: PBTTrialState, time: int, result: dict[str, Any]
     ) -> float:
         """Saves necessary trial information when result is received.
 
@@ -236,7 +237,7 @@ class PopulationBasedTraining(TrialScheduler):
         state.last_result = result
         return score
 
-    def _quantiles(self) -> Tuple[List[Trial], List[Trial]]:
+    def _quantiles(self) -> tuple[list[Trial], list[Trial]]:
         """Returns trials in the lower and upper ``quantile`` of the population.
 
         If there is not enough data to compute this, returns empty lists.
@@ -275,7 +276,7 @@ class PopulationBasedTraining(TrialScheduler):
                 config=config, checkpoint_trial_id=trial_id_to_continue
             )
 
-    def _explore(self, config: Dict[str, Any]) -> Dict[str, Any]:
+    def _explore(self, config: dict[str, Any]) -> dict[str, Any]:
         """Return a config perturbed as specified.
 
         :param config: Original hyperparameter configuration from the cloned trial
@@ -323,7 +324,7 @@ class PopulationBasedTraining(TrialScheduler):
 
         return new_config
 
-    def metadata(self) -> Dict[str, Any]:
+    def metadata(self) -> dict[str, Any]:
         """
         :return: Metadata for the scheduler
         """
@@ -336,7 +337,7 @@ class PopulationBasedTraining(TrialScheduler):
         metadata["metric_mode"] = self.metric_mode()
         return metadata
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return [self.metric]
 
     def metric_mode(self) -> str:

--- a/syne_tune/optimizer/schedulers/ray_scheduler.py
+++ b/syne_tune/optimizer/schedulers/ray_scheduler.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, List
+from typing import Optional
 import logging
 
 from syne_tune.optimizer.scheduler import TrialScheduler, TrialSuggestion
@@ -35,19 +35,19 @@ class RayTuneScheduler(TrialScheduler):
 
     class RandomSearch(RT_Searcher):
         def __init__(
-            self, config_space: Dict, points_to_evaluate: List[Dict], mode: str
+            self, config_space: dict, points_to_evaluate: list[dict], mode: str
         ):
             super().__init__(mode=mode)
             self.config_space = config_space
             self._points_to_evaluate = points_to_evaluate
 
-        def _next_initial_config(self) -> Optional[Dict]:
+        def _next_initial_config(self) -> Optional[dict]:
             if self._points_to_evaluate:
                 return self._points_to_evaluate.pop(0)
             else:
                 return None  # No more initial configs
 
-        def suggest(self, trial_id: str) -> Optional[Dict]:
+        def suggest(self, trial_id: str) -> Optional[dict]:
             config = self._next_initial_config()
             if config is None:
                 config = {
@@ -57,16 +57,16 @@ class RayTuneScheduler(TrialScheduler):
             return config
 
         def on_trial_complete(
-            self, trial_id: str, result: Optional[Dict] = None, error: bool = False
+            self, trial_id: str, result: Optional[dict] = None, error: bool = False
         ):
             pass
 
     def __init__(
         self,
-        config_space: Dict,
+        config_space: dict,
         ray_scheduler=None,
         ray_searcher: Optional[RT_Searcher] = None,
-        points_to_evaluate: Optional[List[Dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
     ):
         super().__init__(config_space)
         if ray_scheduler is None:
@@ -114,21 +114,21 @@ class RayTuneScheduler(TrialScheduler):
             trial=trial,
         )
 
-    def on_trial_result(self, trial: Trial, result: Dict) -> str:
+    def on_trial_result(self, trial: Trial, result: dict) -> str:
         self._check_valid_result(result=result)
         self.searcher.on_trial_result(trial_id=str(trial.trial_id), result=result)
         return self.scheduler.on_trial_result(
             trial_runner=self.trial_runner_wrapper, trial=trial, result=result
         )
 
-    def on_trial_complete(self, trial: Trial, result: Dict):
+    def on_trial_complete(self, trial: Trial, result: dict):
         self._check_valid_result(result=result)
         self.searcher.on_trial_complete(trial_id=str(trial.trial_id), result=result)
         self.scheduler.on_trial_complete(
             trial_runner=self.trial_runner_wrapper, trial=trial, result=result
         )
 
-    def _check_valid_result(self, result: Dict):
+    def _check_valid_result(self, result: dict):
         for m in self.metric_names():
             assert m in result, (
                 f"metric {m} is not present in reported results {result},"
@@ -145,7 +145,7 @@ class RayTuneScheduler(TrialScheduler):
         config = self.searcher.suggest(trial_id=str(trial_id))
         return TrialSuggestion.start_suggestion(config)
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return [self.scheduler.metric]
 
     def metric_mode(self) -> str:

--- a/syne_tune/optimizer/schedulers/remove_checkpoints.py
+++ b/syne_tune/optimizer/schedulers/remove_checkpoints.py
@@ -1,4 +1,5 @@
-from typing import Optional, Callable
+from typing import Optional
+from collections.abc import Callable
 
 from syne_tune.tuner_callback import TunerCallback
 from syne_tune.tuning_status import TuningStatus

--- a/syne_tune/optimizer/schedulers/scheduler_searcher.py
+++ b/syne_tune/optimizer/schedulers/scheduler_searcher.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any
+from typing import Optional, Any
 import logging
 
 from syne_tune.optimizer.schedulers.searchers import LegacyBaseSearcher
@@ -27,7 +27,7 @@ class TrialSchedulerWithSearcher(LegacyTrialScheduler):
     * Master seed, :attr:`random_seed_generator`
     """
 
-    def __init__(self, config_space: Dict[str, Any], **kwargs):
+    def __init__(self, config_space: dict[str, Any], **kwargs):
         super().__init__(config_space)
         self._searcher_initialized = False
         # Generator for random seeds
@@ -60,7 +60,7 @@ class TrialSchedulerWithSearcher(LegacyTrialScheduler):
             if self.searcher.debug_log is not None:
                 logger.info(f"trial_id {trial_id}: Evaluation failed!")
 
-    def on_trial_complete(self, trial: Trial, result: Dict[str, Any]):
+    def on_trial_complete(self, trial: Trial, result: dict[str, Any]):
         self._initialize_searcher()
         if self.searcher is not None:
             config = self._preprocess_config(trial.config)

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/common.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/common.py
@@ -1,4 +1,4 @@
-from typing import Union, Dict, Optional, List
+from typing import Union, Optional
 from dataclasses import dataclass
 import numpy as np
 
@@ -14,7 +14,7 @@ def dictionarize_objective(x):
     return {INTERNAL_METRIC_NAME: x}
 
 
-MetricValues = Union[float, Dict[str, float]]
+MetricValues = Union[float, dict[str, float]]
 
 
 @dataclass
@@ -26,7 +26,7 @@ class TrialEvaluations:
     """
 
     trial_id: str
-    metrics: Dict[str, MetricValues]
+    metrics: dict[str, MetricValues]
 
     def num_cases(
         self, metric_name: str = INTERNAL_METRIC_NAME, resource: Optional[int] = None
@@ -52,7 +52,7 @@ class TrialEvaluations:
 
     def _map_value_for_matching(
         self, value: MetricValues
-    ) -> (Optional[List[str]], np.ndarray):
+    ) -> (Optional[list[str]], np.ndarray):
         if isinstance(value, dict):
             keys = list(sorted(value.keys()))
             vals = np.array(value[k] for k in keys)
@@ -106,7 +106,7 @@ class FantasizedPendingEvaluation(PendingEvaluation):
     def __init__(
         self,
         trial_id: str,
-        fantasies: Dict[str, np.ndarray],
+        fantasies: dict[str, np.ndarray],
         resource: Optional[int] = None,
     ):
         super().__init__(trial_id, resource)

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/config_ext.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/config_ext.py
@@ -1,4 +1,3 @@
-from typing import Tuple
 import copy
 
 from syne_tune.config_space import randint
@@ -29,7 +28,7 @@ class ExtendedConfiguration:
         self,
         hp_ranges: HyperparameterRanges,
         resource_attr_key: str,
-        resource_attr_range: Tuple[int, int],
+        resource_attr_range: tuple[int, int],
     ):
         assert resource_attr_range[0] >= 1
         assert resource_attr_range[1] >= resource_attr_range[0]

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/tuning_job_state.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/tuning_job_state.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Optional
+from typing import Optional
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common import (
     TrialEvaluations,
@@ -35,10 +35,10 @@ class TuningJobState:
     def __init__(
         self,
         hp_ranges: HyperparameterRanges,
-        config_for_trial: Dict[str, Configuration],
-        trials_evaluations: List[TrialEvaluations],
-        failed_trials: List[str] = None,
-        pending_evaluations: List[PendingEvaluation] = None,
+        config_for_trial: dict[str, Configuration],
+        trials_evaluations: list[TrialEvaluations],
+        failed_trials: list[str] = None,
+        pending_evaluations: list[PendingEvaluation] = None,
     ):
         if failed_trials is None:
             failed_trials = []
@@ -54,7 +54,7 @@ class TuningJobState:
         self.pending_evaluations = pending_evaluations
 
     @staticmethod
-    def _check_all_string(trial_ids: List[str], name: str):
+    def _check_all_string(trial_ids: list[str], name: str):
         assert all(
             isinstance(x, str) for x in trial_ids
         ), f"trial_ids in {name} contain non-string values:\n{trial_ids}"
@@ -158,7 +158,7 @@ class TuningJobState:
 
     def observed_data_for_metric(
         self, metric_name: str = INTERNAL_METRIC_NAME, resource_attr_name: str = None
-    ) -> (List[Configuration], List[float]):
+    ) -> (list[Configuration], list[float]):
         """
         Extracts datapoints from ``trials_evaluations`` for particular
         metric ``metric_name``, in the form of a list of configs and a list of
@@ -250,7 +250,7 @@ class TuningJobState:
 
     def pending_configurations(
         self, resource_attr_name: str = None
-    ) -> List[Configuration]:
+    ) -> list[Configuration]:
         """
         Returns list of configurations corresponding to pending evaluations.
         If the latter have resource values, the configs are extended.
@@ -271,8 +271,8 @@ class TuningJobState:
         return configs
 
     def _map_configs_for_matching(
-        self, config_for_trial: Dict[str, Configuration]
-    ) -> Dict[str, str]:
+        self, config_for_trial: dict[str, Configuration]
+    ) -> dict[str, str]:
         return {
             trial_id: self.hp_ranges.config_to_match_string(config)
             for trial_id, config in config_for_trial.items()
@@ -296,7 +296,7 @@ class TuningJobState:
 
     def all_configurations(
         self, filter_observed_data: Optional[ConfigurationFilter] = None
-    ) -> List[Configuration]:
+    ) -> list[Configuration]:
         """
         Returns list of configurations for all trials represented here, whether
         observed, pending, or failed. If ``filter_observed_data`` is given, the

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/gp_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/gp_model.py
@@ -1,7 +1,7 @@
 import numpy as np
 import autograd.numpy as anp
 from autograd.builtins import isinstance
-from typing import List, Optional, Dict, Any
+from typing import Optional, Any
 import logging
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.constants import (
@@ -40,14 +40,14 @@ class GaussianProcessModel:
         return self._random_state
 
     @property
-    def states(self) -> Optional[List[PosteriorState]]:
+    def states(self) -> Optional[list[PosteriorState]]:
         """
         :return: Current posterior states (one per MCMC sample; just a single
             state if model parameters are optimized)
         """
         raise NotImplementedError
 
-    def fit(self, data: Dict[str, Any]):
+    def fit(self, data: dict[str, Any]):
         """
         Adjust model parameters based on training data ``data``. Can be done via
         optimization or MCMC sampling. The posterior states are computed at the
@@ -57,7 +57,7 @@ class GaussianProcessModel:
         """
         raise NotImplementedError
 
-    def recompute_states(self, data: Dict[str, Any]):
+    def recompute_states(self, data: dict[str, Any]):
         """
         Recomputes posterior states for current model parameters.
 
@@ -169,7 +169,7 @@ class GaussianProcessModel:
         return _concatenate_samples(samples_list)
 
 
-def _concatenate_samples(samples_list: List[anp.ndarray]) -> anp.ndarray:
+def _concatenate_samples(samples_list: list[anp.ndarray]) -> anp.ndarray:
     return anp.concatenate(samples_list, axis=-1)
 
 
@@ -193,14 +193,14 @@ class GaussianProcessOptimizeModel(GaussianProcessModel):
         self.optimization_config = optimization_config
 
     @property
-    def states(self) -> Optional[List[PosteriorState]]:
+    def states(self) -> Optional[list[PosteriorState]]:
         return self._states
 
     @property
     def likelihood(self) -> MarginalLikelihood:
         raise NotImplementedError
 
-    def fit(self, data: Dict[str, Any]):
+    def fit(self, data: dict[str, Any]):
         """
         Fit the model parameters by optimizing the marginal likelihood,
         and set posterior states.
@@ -262,23 +262,23 @@ class GaussianProcessOptimizeModel(GaussianProcessModel):
         # Recompute posterior state for new hyperparameters
         self._recompute_states(data)
 
-    def _set_likelihood_params(self, params: Dict[str, Any]):
+    def _set_likelihood_params(self, params: dict[str, Any]):
         for param in self.likelihood.collect_params().values():
             vec = params.get(param.name)
             if vec is not None:
                 param.set_data(vec)
 
-    def recompute_states(self, data: Dict[str, Any]):
+    def recompute_states(self, data: dict[str, Any]):
         self._recompute_states(data)
 
-    def _recompute_states(self, data: Dict[str, Any]):
+    def _recompute_states(self, data: dict[str, Any]):
         self.likelihood.data_precomputations(data)
         self._states = [self.likelihood.get_posterior_state(data)]
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return self.likelihood.get_params()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         self.likelihood.set_params(param_dict)
 
     def reset_params(self):

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/gpr_mcmc.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/gpr_mcmc.py
@@ -1,4 +1,5 @@
-from typing import Callable, Optional, List, Dict, Any
+from typing import Optional, Any
+from collections.abc import Callable
 import autograd.numpy as anp
 from autograd.builtins import isinstance
 from numpy.random import RandomState
@@ -50,14 +51,14 @@ class GPRegressionMCMC(GaussianProcessModel):
         self.build_kernel = build_kernel
 
     @property
-    def states(self) -> Optional[List[GaussProcPosteriorState]]:
+    def states(self) -> Optional[list[GaussProcPosteriorState]]:
         return self._states
 
     @property
     def number_samples(self) -> int:
         return self.mcmc_config.n_samples
 
-    def fit(self, data: Dict[str, Any]):
+    def fit(self, data: dict[str, Any]):
         features, targets = self._check_features_targets(
             features=data["features"], targets=data["targets"]
         )
@@ -96,7 +97,7 @@ class GPRegressionMCMC(GaussianProcessModel):
         )
         self._states = self._create_posterior_states(self.samples, features, targets)
 
-    def recompute_states(self, data: Dict[str, Any]):
+    def recompute_states(self, data: dict[str, Any]):
         """
         Supports fantasizing, in that targets can be a matrix. Then,
         ycols = targets.shape[1] must be a multiple of self.number_samples.

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/hypertune/gp_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/hypertune/gp_model.py
@@ -1,4 +1,5 @@
-from typing import Callable, Tuple, List, Optional, Dict, Any
+from typing import Optional, Any
+from collections.abc import Callable
 from dataclasses import dataclass
 import numpy as np
 
@@ -66,7 +67,7 @@ class HyperTuneModelMixin:
         """
         return self._bracket_distribution
 
-    def hypertune_ensemble_distribution(self) -> Optional[Dict[int, float]]:
+    def hypertune_ensemble_distribution(self) -> Optional[dict[int, float]]:
         """
         Distribution [theta_r] which is used to create an ensemble predictive
         distribution fed into the acquisition function.
@@ -78,10 +79,10 @@ class HyperTuneModelMixin:
     def fit_distributions(
         self,
         poster_state: PerResourcePosteriorState,
-        data: Dict[str, Any],
-        resource_attr_range: Tuple[int, int],
+        data: dict[str, Any],
+        resource_attr_range: tuple[int, int],
         random_state: np.random.RandomState,
-    ) -> Optional[Dict[int, float]]:
+    ) -> Optional[dict[int, float]]:
         ensemble_distribution = None
         args = self.hypertune_distribution_args
         (
@@ -159,7 +160,7 @@ class HyperTuneIndependentGPModel(IndependentGPPerResourceModel, HyperTuneModelM
         self,
         kernel: KernelFunction,
         mean_factory: Callable[[int], MeanFunction],
-        resource_attr_range: Tuple[int, int],
+        resource_attr_range: tuple[int, int],
         hypertune_distribution_args: HyperTuneDistributionArguments,
         target_transform: Optional[ScalarTargetTransform] = None,
         separate_noise_variances: bool = False,
@@ -186,7 +187,7 @@ class HyperTuneIndependentGPModel(IndependentGPPerResourceModel, HyperTuneModelM
             self, hypertune_distribution_args=hypertune_distribution_args
         )
 
-    def create_likelihood(self, rung_levels: List[int]):
+    def create_likelihood(self, rung_levels: list[int]):
         """
         Delayed creation of likelihood, needs to know rung levels of Hyperband
         scheduler.
@@ -206,13 +207,13 @@ class HyperTuneIndependentGPModel(IndependentGPPerResourceModel, HyperTuneModelM
         )
         self.reset_params()
 
-    def hypertune_ensemble_distribution(self) -> Optional[Dict[int, float]]:
+    def hypertune_ensemble_distribution(self) -> Optional[dict[int, float]]:
         if self._likelihood is not None:
             return self._likelihood.ensemble_distribution
         else:
             return None
 
-    def fit(self, data: Dict[str, Any]):
+    def fit(self, data: dict[str, Any]):
         super().fit(data)
         poster_state: IndependentGPPerResourcePosteriorState = self.states[0]
         ensemble_distribution = self.fit_distributions(
@@ -244,7 +245,7 @@ class HyperTuneJointGPModel(GaussianProcessRegression, HyperTuneModelMixin):
     def __init__(
         self,
         kernel: KernelFunction,
-        resource_attr_range: Tuple[int, int],
+        resource_attr_range: tuple[int, int],
         hypertune_distribution_args: HyperTuneDistributionArguments,
         mean: Optional[MeanFunction] = None,
         target_transform: Optional[ScalarTargetTransform] = None,
@@ -278,7 +279,7 @@ class HyperTuneJointGPModel(GaussianProcessRegression, HyperTuneModelMixin):
         self._likelihood = None
         self._rung_levels = None
 
-    def create_likelihood(self, rung_levels: List[int]):
+    def create_likelihood(self, rung_levels: list[int]):
         """
         Delayed creation of likelihood, needs to know rung levels of Hyperband
         scheduler.
@@ -297,13 +298,13 @@ class HyperTuneJointGPModel(GaussianProcessRegression, HyperTuneModelMixin):
         )
         self.reset_params()
 
-    def hypertune_ensemble_distribution(self) -> Optional[Dict[int, float]]:
+    def hypertune_ensemble_distribution(self) -> Optional[dict[int, float]]:
         if self._likelihood is not None:
             return self._likelihood.ensemble_distribution
         else:
             return None
 
-    def fit(self, data: Dict[str, Any]):
+    def fit(self, data: dict[str, Any]):
         super().fit(data)
         resource_attr_range = self._likelihood_kwargs["resource_attr_range"]
         poster_state = GaussProcPosteriorStateAndRungLevels(

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/hypertune/likelihood.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/hypertune/likelihood.py
@@ -1,4 +1,4 @@
-from typing import Dict, Tuple, Any, Optional
+from typing import Any, Optional
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.likelihood import (
     GaussianProcessMarginalLikelihood,
@@ -39,9 +39,9 @@ class HyperTuneIndependentGPMarginalLikelihood(
     def __init__(
         self,
         kernel: KernelFunction,
-        mean: Dict[int, MeanFunction],
-        resource_attr_range: Tuple[int, int],
-        ensemble_distribution: Dict[int, float],
+        mean: dict[int, MeanFunction],
+        resource_attr_range: tuple[int, int],
+        ensemble_distribution: dict[int, float],
         target_transform: Optional[ScalarTargetTransform] = None,
         separate_noise_variances: bool = False,
         initial_noise_variance=None,
@@ -64,14 +64,14 @@ class HyperTuneIndependentGPMarginalLikelihood(
         self.set_ensemble_distribution(ensemble_distribution)
 
     @property
-    def ensemble_distribution(self) -> Dict[int, float]:
+    def ensemble_distribution(self) -> dict[int, float]:
         return self._ensemble_distribution
 
-    def set_ensemble_distribution(self, distribution: Dict[int, float]):
+    def set_ensemble_distribution(self, distribution: dict[int, float]):
         assert_ensemble_distribution(distribution, set(self.mean.keys()))
         self._ensemble_distribution = distribution.copy()
 
-    def get_posterior_state(self, data: Dict[str, Any]) -> PosteriorState:
+    def get_posterior_state(self, data: dict[str, Any]) -> PosteriorState:
         GaussianProcessMarginalLikelihood.assert_data_entries(data)
         targets = self.target_transform(data["targets"])
         return HyperTuneIndependentGPPosteriorState(
@@ -99,8 +99,8 @@ class HyperTuneJointGPMarginalLikelihood(GaussianProcessMarginalLikelihood):
         self,
         kernel: KernelFunction,
         mean: MeanFunction,
-        resource_attr_range: Tuple[int, int],
-        ensemble_distribution: Dict[int, float],
+        resource_attr_range: tuple[int, int],
+        ensemble_distribution: dict[int, float],
         target_transform: Optional[ScalarTargetTransform] = None,
         initial_noise_variance=None,
         encoding_type=None,
@@ -119,13 +119,13 @@ class HyperTuneJointGPMarginalLikelihood(GaussianProcessMarginalLikelihood):
         self.set_ensemble_distribution(ensemble_distribution)
 
     @property
-    def ensemble_distribution(self) -> Dict[int, float]:
+    def ensemble_distribution(self) -> dict[int, float]:
         return self._ensemble_distribution
 
-    def set_ensemble_distribution(self, distribution: Dict[int, float]):
+    def set_ensemble_distribution(self, distribution: dict[int, float]):
         self._ensemble_distribution = distribution.copy()
 
-    def get_posterior_state(self, data: Dict[str, Any]) -> PosteriorState:
+    def get_posterior_state(self, data: dict[str, Any]) -> PosteriorState:
         GaussianProcessMarginalLikelihood.assert_data_entries(data)
         targets = self.target_transform(data["targets"])
         return HyperTuneJointGPPosteriorState(

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/hypertune/posterior_state.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/hypertune/posterior_state.py
@@ -1,5 +1,6 @@
 import numpy as np
-from typing import Dict, Tuple, Optional, Callable, Set
+from typing import Optional
+from collections.abc import Callable
 from numpy.random import RandomState
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.independent.posterior_state import (
@@ -27,7 +28,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.posterior_util
 
 
 def assert_ensemble_distribution(
-    distribution: Dict[int, float], all_resources: Set[int]
+    distribution: dict[int, float], all_resources: set[int]
 ):
     assert set(distribution.keys()).issubset(all_resources), (
         f"distribution.keys() = {set(distribution.keys())} must be subset "
@@ -39,7 +40,7 @@ def assert_ensemble_distribution(
 
 
 def _sample_hypertune_common(
-    ensemble_distribution: Dict[int, float],
+    ensemble_distribution: dict[int, float],
     sample_func: Callable[[int, int], np.ndarray],
     num_samples: int,
     random_state: Optional[RandomState] = None,
@@ -98,11 +99,11 @@ class HyperTuneIndependentGPPosteriorState(IndependentGPPerResourcePosteriorStat
         features: np.ndarray,
         targets: np.ndarray,
         kernel: KernelFunction,
-        mean: Dict[int, MeanFunction],
-        covariance_scale: Dict[int, np.ndarray],
+        mean: dict[int, MeanFunction],
+        covariance_scale: dict[int, np.ndarray],
         noise_variance: NoiseVariance,
-        resource_attr_range: Tuple[int, int],
-        ensemble_distribution: Dict[int, float],
+        resource_attr_range: tuple[int, int],
+        ensemble_distribution: dict[int, float],
         debug_log: bool = False,
     ):
         """
@@ -123,7 +124,7 @@ class HyperTuneIndependentGPPosteriorState(IndependentGPPerResourcePosteriorStat
         assert_ensemble_distribution(ensemble_distribution, set(mean.keys()))
         self.ensemble_distribution = ensemble_distribution
 
-    def predict(self, test_features: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def predict(self, test_features: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         means, variances = 0, 0
         for resource, theta in self.ensemble_distribution.items():
             _means, _variances = self._states[resource].predict(test_features)
@@ -213,7 +214,7 @@ class HyperTuneIndependentGPPosteriorState(IndependentGPPerResourcePosteriorStat
     def backward_gradient(
         self,
         input: np.ndarray,
-        head_gradients: Dict[str, np.ndarray],
+        head_gradients: dict[str, np.ndarray],
         mean_data: float,
         std_data: float,
     ) -> np.ndarray:
@@ -259,8 +260,8 @@ class HyperTuneJointGPPosteriorState(GaussProcPosteriorState):
         mean: MeanFunction,
         kernel: KernelFunctionWithCovarianceScale,
         noise_variance: np.ndarray,
-        resource_attr_range: Tuple[int, int],
-        ensemble_distribution: Dict[int, float],
+        resource_attr_range: tuple[int, int],
+        ensemble_distribution: dict[int, float],
         debug_log: bool = False,
     ):
         """
@@ -287,7 +288,7 @@ class HyperTuneJointGPPosteriorState(GaussProcPosteriorState):
         )
         return helper.extend_features_by_resource(test_features)
 
-    def predict(self, test_features: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def predict(self, test_features: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         means, variances = 0, 0
         for resource, theta in self.ensemble_distribution.items():
             features_ext = self._extend_features_by_resource(test_features, resource)
@@ -380,7 +381,7 @@ class HyperTuneJointGPPosteriorState(GaussProcPosteriorState):
     def backward_gradient(
         self,
         input: np.ndarray,
-        head_gradients: Dict[str, np.ndarray],
+        head_gradients: dict[str, np.ndarray],
         mean_data: float,
         std_data: float,
     ) -> np.ndarray:

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/hypertune/utils.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/hypertune/utils.py
@@ -1,7 +1,8 @@
 import numpy as np
 import autograd.numpy as anp
 from autograd.tracer import getval
-from typing import Optional, Tuple, List, Union, Dict, Callable, Any
+from typing import Optional, Union, Any
+from collections.abc import Callable
 from numpy.random import RandomState
 
 from syne_tune.optimizer.schedulers.searchers.utils.hp_ranges_impl import (
@@ -28,7 +29,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.kernel.base im
 
 
 class ExtendFeaturesByResourceMixin:
-    def __init__(self, resource: int, resource_attr_range: Tuple[int, int]):
+    def __init__(self, resource: int, resource_attr_range: tuple[int, int]):
         hp_range = HyperparameterRangeInteger(
             name="resource",
             lower_bound=resource_attr_range[0],
@@ -60,7 +61,7 @@ class PosteriorStateClampedResource(
         self,
         poster_state_extended: PosteriorStateWithSampleJoint,
         resource: int,
-        resource_attr_range: Tuple[int, int],
+        resource_attr_range: tuple[int, int],
     ):
         ExtendFeaturesByResourceMixin.__init__(self, resource, resource_attr_range)
         self._poster_state_extended = poster_state_extended
@@ -80,7 +81,7 @@ class PosteriorStateClampedResource(
     def neg_log_likelihood(self) -> anp.ndarray:
         return self._poster_state_extended.neg_log_likelihood()
 
-    def predict(self, test_features: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def predict(self, test_features: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         return self._poster_state_extended.predict(
             self.extend_features_by_resource(test_features)
         )
@@ -112,7 +113,7 @@ class PosteriorStateClampedResource(
     def backward_gradient(
         self,
         input: np.ndarray,
-        head_gradients: Dict[str, np.ndarray],
+        head_gradients: dict[str, np.ndarray],
         mean_data: float,
         std_data: float,
     ) -> np.ndarray:
@@ -133,7 +134,7 @@ class MeanFunctionClampedResource(MeanFunction, ExtendFeaturesByResourceMixin):
         self,
         mean_extended: MeanFunction,
         resource: int,
-        resource_attr_range: Tuple[int, int],
+        resource_attr_range: tuple[int, int],
         **kwargs,
     ):
         MeanFunction.__init__(self, **kwargs)
@@ -143,10 +144,10 @@ class MeanFunctionClampedResource(MeanFunction, ExtendFeaturesByResourceMixin):
     def param_encoding_pairs(self):
         return self._mean_extended.param_encoding_pairs()
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return self._mean_extended.get_params()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         self._mean_extended.set_params(param_dict)
 
     def forward(self, X):
@@ -158,7 +159,7 @@ class KernelFunctionClampedResource(KernelFunction, ExtendFeaturesByResourceMixi
         self,
         kernel_extended: KernelFunction,
         resource: int,
-        resource_attr_range: Tuple[int, int],
+        resource_attr_range: tuple[int, int],
         **kwargs,
     ):
         KernelFunction.__init__(self, dimension=kernel_extended.dimension - 1, **kwargs)
@@ -168,10 +169,10 @@ class KernelFunctionClampedResource(KernelFunction, ExtendFeaturesByResourceMixi
     def param_encoding_pairs(self):
         return self._kernel_extended.param_encoding_pairs()
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return self._kernel_extended.get_params()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         self._kernel_extended.set_params(param_dict)
 
     def diagonal(self, X):
@@ -193,7 +194,7 @@ class GaussProcPosteriorStateAndRungLevels(PosteriorStateWithSampleJoint):
     def __init__(
         self,
         poster_state: GaussProcPosteriorState,
-        rung_levels: List[int],
+        rung_levels: list[int],
     ):
         self._poster_state = poster_state
         self._rung_levels = rung_levels
@@ -217,7 +218,7 @@ class GaussProcPosteriorStateAndRungLevels(PosteriorStateWithSampleJoint):
     def neg_log_likelihood(self) -> anp.ndarray:
         return self._poster_state.neg_log_likelihood()
 
-    def predict(self, test_features: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def predict(self, test_features: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         return self._poster_state.predict(test_features)
 
     def sample_marginals(
@@ -247,7 +248,7 @@ class GaussProcPosteriorStateAndRungLevels(PosteriorStateWithSampleJoint):
     def backward_gradient(
         self,
         input: np.ndarray,
-        head_gradients: Dict[str, np.ndarray],
+        head_gradients: dict[str, np.ndarray],
         mean_data: float,
         std_data: float,
     ) -> np.ndarray:
@@ -259,7 +260,7 @@ class GaussProcPosteriorStateAndRungLevels(PosteriorStateWithSampleJoint):
         )
 
     @property
-    def rung_levels(self) -> List[int]:
+    def rung_levels(self) -> list[int]:
         return self._rung_levels
 
 
@@ -272,7 +273,7 @@ PerResourcePosteriorState = Union[
 def _posterior_state_for_rung_level(
     poster_state: PerResourcePosteriorState,
     resource: int,
-    resource_attr_range: Tuple[int, int],
+    resource_attr_range: tuple[int, int],
 ) -> Union[GaussProcPosteriorState, PosteriorStateClampedResource]:
     if isinstance(poster_state, IndependentGPPerResourcePosteriorState):
         return poster_state.state(resource)
@@ -286,9 +287,9 @@ def _posterior_state_for_rung_level(
 
 def hypertune_ranking_losses(
     poster_state: PerResourcePosteriorState,
-    data: Dict[str, Any],
+    data: dict[str, Any],
     num_samples: int,
-    resource_attr_range: Tuple[int, int],
+    resource_attr_range: tuple[int, int],
     random_state: Optional[RandomState] = None,
 ) -> np.ndarray:
     """
@@ -388,10 +389,10 @@ def hypertune_ranking_losses(
 
 
 def number_supported_levels_and_data_highest_level(
-    rung_levels: List[int],
-    data: Dict[str, Any],
-    resource_attr_range: Tuple[int, int],
-) -> Tuple[int, dict]:
+    rung_levels: list[int],
+    data: dict[str, Any],
+    resource_attr_range: tuple[int, int],
+) -> tuple[int, dict]:
     """
     Finds ``num_supp_levels`` as maximum such that
     rung levels up to there have ``>= 6`` labeled datapoints. The set
@@ -425,8 +426,8 @@ def number_supported_levels_and_data_highest_level(
 
 
 def _extract_data_at_resource(
-    data: Dict[str, Any], resource: int, resource_attr_range: Tuple[int, int]
-) -> Dict[str, Any]:
+    data: dict[str, Any], resource: int, resource_attr_range: tuple[int, int]
+) -> dict[str, Any]:
     features_ext = data["features"]
     targets = data["targets"]
     num_fantasies = targets.shape[1] if targets.ndim == 2 else 1
@@ -449,7 +450,7 @@ def _losses_for_maximum_rung_by_cross_validation(
     poster_state_for_fold: Callable[
         [np.ndarray, np.ndarray], PosteriorStateWithSampleJoint
     ],
-    data_max_resource: Dict[str, Any],
+    data_max_resource: dict[str, Any],
     num_samples: int,
     random_state: Optional[RandomState],
 ) -> np.ndarray:
@@ -508,7 +509,7 @@ def _losses_for_maximum_rung_by_cross_validation(
 
 def _losses_for_rung(
     poster_state: PosteriorStateWithSampleJoint,
-    data_max_resource: Dict[str, Any],
+    data_max_resource: dict[str, Any],
     num_samples: int,
     random_state: Optional[RandomState],
 ) -> np.ndarray:

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/independent/gpind_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/independent/gpind_model.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Callable, List, Tuple, Optional
+from typing import Optional
+from collections.abc import Callable
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.constants import (
     OptimizationConfig,
@@ -59,7 +60,7 @@ class IndependentGPPerResourceModel(GaussianProcessOptimizeModel):
         self,
         kernel: KernelFunction,
         mean_factory: Callable[[int], MeanFunction],
-        resource_attr_range: Tuple[int, int],
+        resource_attr_range: tuple[int, int],
         target_transform: Optional[ScalarTargetTransform] = None,
         separate_noise_variances: bool = False,
         initial_noise_variance: Optional[float] = None,
@@ -85,7 +86,7 @@ class IndependentGPPerResourceModel(GaussianProcessOptimizeModel):
         }
         self._likelihood = None  # Delayed creation
 
-    def create_likelihood(self, rung_levels: List[int]):
+    def create_likelihood(self, rung_levels: list[int]):
         """
         Delayed creation of likelihood, needs to know rung levels of Hyperband
         scheduler.

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/independent/likelihood.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/independent/likelihood.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Tuple, Any
+from typing import Optional, Any
 import numpy as np
 import autograd.numpy as anp
 
@@ -72,8 +72,8 @@ class IndependentGPPerResourceMarginalLikelihood(MarginalLikelihood):
     def __init__(
         self,
         kernel: KernelFunction,
-        mean: Dict[int, MeanFunction],
-        resource_attr_range: Tuple[int, int],
+        mean: dict[int, MeanFunction],
+        resource_attr_range: tuple[int, int],
         target_transform: Optional[ScalarTargetTransform] = None,
         separate_noise_variances: bool = False,
         initial_noise_variance: Optional[float] = None,
@@ -150,7 +150,7 @@ class IndependentGPPerResourceMarginalLikelihood(MarginalLikelihood):
             for resource, internal in self.covariance_scale_internal.items()
         }
 
-    def get_posterior_state(self, data: Dict[str, Any]) -> PosteriorState:
+    def get_posterior_state(self, data: dict[str, Any]) -> PosteriorState:
         GaussianProcessMarginalLikelihood.assert_data_entries(data)
         targets = self.target_transform(data["targets"])
         return IndependentGPPerResourcePosteriorState(
@@ -163,19 +163,19 @@ class IndependentGPPerResourceMarginalLikelihood(MarginalLikelihood):
             resource_attr_range=self.resource_attr_range,
         )
 
-    def forward(self, data: Dict[str, Any]):
+    def forward(self, data: dict[str, Any]):
         return self.get_posterior_state(
             data
         ).neg_log_likelihood() + self.target_transform.negative_log_jacobian(
             data["targets"]
         )
 
-    def _components(self) -> List[Tuple[str, MeanFunction]]:
+    def _components(self) -> list[tuple[str, MeanFunction]]:
         return [("kernel_", self.kernel), ("ytrans_", self.target_transform)] + [
             (f"mean{resource}_", mean) for resource, mean in self.mean.items()
         ]
 
-    def param_encoding_pairs(self) -> List[tuple]:
+    def param_encoding_pairs(self) -> list[tuple]:
         result = [
             x
             for _, component in self._components()
@@ -218,7 +218,7 @@ class IndependentGPPerResourceMarginalLikelihood(MarginalLikelihood):
         assert internal is not None, f"resource = {resource} not supported"
         self.encoding_covscale.set(internal, val)
 
-    def get_params(self) -> Dict[str, np.ndarray]:
+    def get_params(self) -> dict[str, np.ndarray]:
         result = dict()
         for pref, func in self._components():
             result.update({(pref + k): v for k, v in func.get_params().items()})
@@ -231,7 +231,7 @@ class IndependentGPPerResourceMarginalLikelihood(MarginalLikelihood):
             result["noise_variance"] = self._noise_variance()
         return result
 
-    def set_params(self, param_dict: Dict[str, np.ndarray]):
+    def set_params(self, param_dict: dict[str, np.ndarray]):
         for pref, func in self._components():
             len_pref = len(pref)
             stripped_dict = {
@@ -250,7 +250,7 @@ class IndependentGPPerResourceMarginalLikelihood(MarginalLikelihood):
         else:
             self._set_noise_variance(1, param_dict["noise_variance"])
 
-    def on_fit_start(self, data: Dict[str, Any]):
+    def on_fit_start(self, data: dict[str, Any]):
         GaussianProcessMarginalLikelihood.assert_data_entries(data)
         targets = data["targets"]
         assert (

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/independent/posterior_state.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/independent/posterior_state.py
@@ -1,4 +1,5 @@
-from typing import Dict, Tuple, Optional, Callable, Union
+from typing import Optional, Union
+from collections.abc import Callable
 import numpy as np
 import autograd.numpy as anp
 from numpy.random import RandomState
@@ -18,7 +19,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.mean import (
 )
 
 
-NoiseVariance = Union[np.ndarray, Dict[int, np.ndarray]]
+NoiseVariance = Union[np.ndarray, dict[int, np.ndarray]]
 
 
 class IndependentGPPerResourcePosteriorState(PosteriorStateWithSampleJoint):
@@ -39,10 +40,10 @@ class IndependentGPPerResourcePosteriorState(PosteriorStateWithSampleJoint):
         features: np.ndarray,
         targets: np.ndarray,
         kernel: KernelFunction,
-        mean: Dict[int, MeanFunction],
-        covariance_scale: Dict[int, np.ndarray],
+        mean: dict[int, MeanFunction],
+        covariance_scale: dict[int, np.ndarray],
         noise_variance: NoiseVariance,
-        resource_attr_range: Tuple[int, int],
+        resource_attr_range: tuple[int, int],
         debug_log: bool = False,
     ):
         """
@@ -92,10 +93,10 @@ class IndependentGPPerResourcePosteriorState(PosteriorStateWithSampleJoint):
         features: np.ndarray,
         targets: np.ndarray,
         kernel: KernelFunction,
-        mean: Dict[int, MeanFunction],
-        covariance_scale: Dict[int, np.ndarray],
-        noise_variance: Dict[int, np.ndarray],
-        resource_attr_range: Tuple[int, int],
+        mean: dict[int, MeanFunction],
+        covariance_scale: dict[int, np.ndarray],
+        noise_variance: dict[int, np.ndarray],
+        resource_attr_range: tuple[int, int],
         debug_log: bool = False,
     ):
         features, resources = decode_extended_features(features, resource_attr_range)
@@ -135,7 +136,7 @@ class IndependentGPPerResourcePosteriorState(PosteriorStateWithSampleJoint):
 
     # Different to ``sample_marginals``, ``sample_joint``, this method supports
     # ``autograd`` differentiation
-    def predict(self, test_features: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def predict(self, test_features: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         test_features, resources = decode_extended_features(
             test_features, self._resource_attr_range
         )
@@ -254,7 +255,7 @@ class IndependentGPPerResourcePosteriorState(PosteriorStateWithSampleJoint):
     def backward_gradient(
         self,
         input: np.ndarray,
-        head_gradients: Dict[str, np.ndarray],
+        head_gradients: dict[str, np.ndarray],
         mean_data: float,
         std_data: float,
     ) -> np.ndarray:

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/base.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/base.py
@@ -1,6 +1,6 @@
 import autograd.numpy as anp
 from autograd.tracer import getval
-from typing import Dict, Any
+from typing import Any
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.constants import (
     INITIAL_COVARIANCE_SCALE,
@@ -142,7 +142,7 @@ class SquaredDistance(Block):
 
         return anp.abs(D)
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         """
         Parameter keys are "inv_bw<k> "if ``dimension > 1``, and "inv_bw" if
         ``dimension == 1``.
@@ -156,7 +156,7 @@ class SquaredDistance(Block):
                 for k in range(inverse_bandwidths.size)
             }
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         dimension = self.encoding.dimension
         if dimension == 1:
             inverse_bandwidths = [param_dict["inv_bw"]]
@@ -272,13 +272,13 @@ class Matern52(KernelFunction):
         assert self.has_covariance_scale, "covariance_scale is fixed to 1"
         self.encoding.set(self.covariance_scale_internal, covariance_scale)
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         result = self.squared_distance.get_params()
         if self.has_covariance_scale:
             result["covariance_scale"] = self.get_covariance_scale()
         return result
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         self.squared_distance.set_params(param_dict)
         if self.has_covariance_scale:
             self.set_covariance_scale(param_dict["covariance_scale"])

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/cross_validation.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/cross_validation.py
@@ -1,6 +1,6 @@
 import autograd.numpy as anp
 from autograd.builtins import isinstance
-from typing import Dict, Any
+from typing import Any
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.kernel.base import (
     KernelFunction,
@@ -128,7 +128,7 @@ class CrossValidationKernelFunction(KernelFunction):
         cfg, _ = self._compute_terms(X)
         return self.mean_main(cfg)
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         result = dict()
         for pref, func in [
             ("kernelm_", self.kernel_main),
@@ -138,7 +138,7 @@ class CrossValidationKernelFunction(KernelFunction):
             result.update({(pref + k): v for k, v in func.get_params().items()})
         return result
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         for pref, func in [
             ("kernelm_", self.kernel_main),
             ("meanm_", self.mean_main),
@@ -163,8 +163,8 @@ class CrossValidationMeanFunction(MeanFunction):
     def param_encoding_pairs(self):
         return []
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return dict()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         pass

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/exponential_decay.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/exponential_decay.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any
+from typing import Optional, Any
 import autograd.numpy as anp
 from autograd.builtins import isinstance
 
@@ -263,7 +263,7 @@ class ExponentialDecayResourcesKernelFunction(KernelFunction):
 
         return anp.add(mean, anp.multiply(kappa, kr_pref))
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         """
         Parameter keys are "alpha", "mean_lam", "gamma", "delta" (only if not
         fixed to ``delta_fixed_value``), as well as those of ``self.kernel_x`` (prefix
@@ -280,7 +280,7 @@ class ExponentialDecayResourcesKernelFunction(KernelFunction):
 
         return result
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         for pref, func in [("kernelx_", self.kernel_x), ("meanx_", self.mean_x)]:
             len_pref = len(pref)
             stripped_dict = {
@@ -306,8 +306,8 @@ class ExponentialDecayResourcesMeanFunction(MeanFunction):
     def param_encoding_pairs(self):
         return []
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return dict()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         pass

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/fabolas.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/fabolas.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 import autograd.numpy as anp
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.kernel.base import (
@@ -105,12 +105,12 @@ class FabolasKernelFunction(KernelFunction):
             (self.u3_internal, self.encoding_u3),
         ]
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         values = list(self._get_pars(None))
         keys = ["u1", "u2", "u3"]
         return {k: anp.reshape(v, (1,))[0] for k, v in zip(keys, values)}
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         self.encoding_u12.set(self.u1_internal, param_dict["u1"])
         self.encoding_u12.set(self.u2_internal, param_dict["u2"])
         self.encoding_u3.set(self.u3_internal, param_dict["u3"])

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/freeze_thaw.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/freeze_thaw.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 import autograd.numpy as anp
 from autograd.builtins import isinstance
 from autograd.tracer import getval
@@ -203,7 +203,7 @@ class FreezeThawKernelFunction(KernelFunction):
         cfg, res, kappa, mean = self._compute_terms(X, alpha, mean_lam, ret_mean=True)
         return anp.add(mean, anp.multiply(kappa, gamma))
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         """
         Parameter keys are alpha, mean_lam, gamma, delta (only if not fixed
         to delta_fixed_value), as well as those of self.kernel_x (prefix
@@ -216,7 +216,7 @@ class FreezeThawKernelFunction(KernelFunction):
             result.update({(pref + k): v for k, v in func.get_params().items()})
         return result
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         for pref, func in [("kernelx_", self.kernel_x), ("meanx_", self.mean_x)]:
             len_pref = len(pref)
             stripped_dict = {
@@ -240,8 +240,8 @@ class FreezeThawMeanFunction(MeanFunction):
     def param_encoding_pairs(self):
         return []
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return dict()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         pass

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/product_kernel.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/product_kernel.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.kernel.base import (
     KernelFunction,
 )
@@ -69,14 +69,14 @@ class ProductKernelFunction(KernelFunction):
         """
         return self.kernel1.param_encoding_pairs() + self.kernel2.param_encoding_pairs()
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         result = dict()
         prefs = [k + "_" for k in self.name_prefixes]
         for pref, kernel in zip(prefs, [self.kernel1, self.kernel2]):
             result.update({(pref + k): v for k, v in kernel.get_params().items()})
         return result
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         prefs = [k + "_" for k in self.name_prefixes]
         for pref, kernel in zip(prefs, [self.kernel1, self.kernel2]):
             len_pref = len(pref)

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/range_kernel.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/range_kernel.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.kernel.base import (
     KernelFunction,
 )
@@ -55,8 +55,8 @@ class RangeKernelFunction(KernelFunction):
         """
         return self.kernel.param_encoding_pairs()
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return self.kernel.get_params()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         self.kernel.set_params(param_dict)

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/freeze_thaw.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/freeze_thaw.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any
+from typing import Any
 
 import numpy as np
 import autograd.numpy as anp
@@ -52,10 +52,10 @@ class ZeroKernel(KernelFunction):
     def param_encoding_pairs(self):
         return []
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return dict()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         pass
 
 
@@ -69,10 +69,10 @@ class ZeroMean(MeanFunction):
     def param_encoding_pairs(self):
         return []
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return dict()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         pass
 
 
@@ -125,10 +125,10 @@ class ExponentialDecayBaseKernelFunction(KernelFunction):
     def param_encoding_pairs(self):
         return self.kernel.param_encoding_pairs()
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return self.kernel.get_params()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         self.kernel.set_params(param_dict)
 
     def mean_function(self, X):
@@ -137,7 +137,7 @@ class ExponentialDecayBaseKernelFunction(KernelFunction):
         return self.kernel.mean_function(X)
 
 
-def logdet_cholfact_cov_resource(likelihood: Dict) -> float:
+def logdet_cholfact_cov_resource(likelihood: dict) -> float:
     """
     Computes the additional log(det(Lbar)) term. This is
     sum_i log(det(Lbar_i)), where Lbar_i is upper left submatrix of
@@ -156,7 +156,7 @@ def logdet_cholfact_cov_resource(likelihood: Dict) -> float:
     return _inner_product(log_diag[:dim], weights)
 
 
-def resource_kernel_likelihood_precomputations(targets: List[np.ndarray]) -> Dict:
+def resource_kernel_likelihood_precomputations(targets: list[np.ndarray]) -> dict:
     """
     Precomputations required by ``resource_kernel_likelihood_computations``.
 
@@ -200,11 +200,11 @@ def resource_kernel_likelihood_precomputations(targets: List[np.ndarray]) -> Dic
 # TODO: This code is complex. If it does not run faster than
 # ``resource_kernel_likelihood_slow_computations``, remove it.
 def resource_kernel_likelihood_computations(
-    precomputed: Dict,
+    precomputed: dict,
     res_kernel: ExponentialDecayBaseKernelFunction,
     noise_variance,
     skip_c_d: bool = False,
-) -> Dict:
+) -> dict:
     """
     Given ``precomputed`` from ``resource_kernel_likelihood_precomputations`` and
     resource kernel function ``res_kernel``, compute quantities required for
@@ -312,11 +312,11 @@ def resource_kernel_likelihood_computations(
 # TODO: It is not clear whether this code is slower, and it is certainly
 # simpler.
 def resource_kernel_likelihood_slow_computations(
-    targets: List[np.ndarray],
+    targets: list[np.ndarray],
     res_kernel: ExponentialDecayBaseKernelFunction,
     noise_variance,
     skip_c_d: bool = False,
-) -> Dict:
+) -> dict:
     """
     Naive implementation of ``resource_kernel_likelihood_computations``, which
     does not require precomputations, but is somewhat slower. Here, results are
@@ -372,11 +372,11 @@ def resource_kernel_likelihood_slow_computations(
 
 
 def predict_posterior_marginals_extended(
-    poster_state: Dict,
+    poster_state: dict,
     mean,
     kernel,
     test_features,
-    resources: List[int],
+    resources: list[int],
     res_kernel: ExponentialDecayBaseKernelFunction,
 ):
     """
@@ -413,7 +413,7 @@ def predict_posterior_marginals_extended(
 
 
 def sample_posterior_joint(
-    poster_state: Dict,
+    poster_state: dict,
     mean,
     kernel,
     feature,
@@ -424,7 +424,7 @@ def sample_posterior_joint(
     means_all,
     random_state: RandomState,
     num_samples: int = 1,
-) -> Dict:
+) -> dict:
     """
     Given ``poster_state`` for some data plus one additional configuration
     with data (``feature``, ``targets``), draw joint samples of unobserved

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/issm.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/issm.py
@@ -1,5 +1,3 @@
-from typing import List, Dict, Tuple
-
 import numpy as np
 import scipy.linalg as spl
 import autograd.numpy as anp
@@ -33,13 +31,13 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.config_ext impo
 
 def _prepare_data_internal(
     state: TuningJobState,
-    data_lst: List[Tuple[Configuration, List, str]],
+    data_lst: list[tuple[Configuration, list, str]],
     config_space_ext: ExtendedConfiguration,
     active_metric: str,
     do_fantasizing: bool,
     mean: float,
     std: float,
-) -> (List[Configuration], List[np.ndarray], List[str]):
+) -> (list[Configuration], list[np.ndarray], list[str]):
     r_min, r_max = config_space_ext.resource_attr_range
     configs = [x[0] for x in data_lst]
     trial_ids = [x[2] for x in data_lst]
@@ -119,7 +117,7 @@ def _prepare_data_internal(
     return configs, targets, trial_ids
 
 
-def _create_tuple(ev: TrialEvaluations, active_metric: str, config_for_trial: Dict):
+def _create_tuple(ev: TrialEvaluations, active_metric: str, config_for_trial: dict):
     metric_vals = ev.metrics[active_metric]
     assert isinstance(metric_vals, dict)
     observed = list(
@@ -136,7 +134,7 @@ def prepare_data(
     active_metric: str,
     normalize_targets: bool = False,
     do_fantasizing: bool = False,
-) -> Dict:
+) -> dict:
     """
     Prepares data in ``state`` for further processing. The entries
     ``configs``, ``targets`` of the result dict are lists of one entry per trial,
@@ -212,7 +210,7 @@ def prepare_data_with_pending(
     config_space_ext: ExtendedConfiguration,
     active_metric: str,
     normalize_targets: bool = False,
-) -> (Dict, Dict):
+) -> (dict, dict):
     """
     Similar to ``prepare_data`` with ``do_fantasizing=False``, but two dicts are
     returned, the first for trials without pending evaluations, the second
@@ -311,7 +309,7 @@ def prepare_data_with_pending(
     return results
 
 
-def issm_likelihood_precomputations(targets: List[np.ndarray], r_min: int) -> Dict:
+def issm_likelihood_precomputations(targets: list[np.ndarray], r_min: int) -> dict:
     """
     Precomputations required by ``issm_likelihood_computations``.
 
@@ -386,12 +384,12 @@ def _flatvec(a, _np=anp):
 
 
 def issm_likelihood_computations(
-    precomputed: Dict,
-    issm_params: Dict,
+    precomputed: dict,
+    issm_params: dict,
     r_min: int,
     r_max: int,
     skip_c_d: bool = False,
-) -> Dict:
+) -> dict:
     """
     Given ``precomputed`` from ``issm_likelihood_precomputations`` and ISSM
     parameters ``issm_params``, compute quantities required for inference and
@@ -526,8 +524,8 @@ def issm_likelihood_computations(
 
 
 def posterior_computations(
-    features, mean, kernel, issm_likelihood: Dict, noise_variance
-) -> Dict:
+    features, mean, kernel, issm_likelihood: dict, noise_variance
+) -> dict:
     """
     Computes posterior state (required for predictions) and negative log
     marginal likelihood (returned in ``criterion``), The latter is computed only
@@ -593,7 +591,7 @@ def posterior_computations(
     return result
 
 
-def predict_posterior_marginals(poster_state: Dict, mean, kernel, test_features):
+def predict_posterior_marginals(poster_state: dict, mean, kernel, test_features):
     """
     These are posterior marginals on the h variable, whereas the full model is
     for f_r = h + g_r (additive).
@@ -624,7 +622,7 @@ def predict_posterior_marginals(poster_state: Dict, mean, kernel, test_features)
 
 
 def sample_posterior_marginals(
-    poster_state: Dict,
+    poster_state: dict,
     mean,
     kernel,
     test_features,
@@ -648,12 +646,12 @@ def sample_posterior_marginals(
 
 
 def predict_posterior_marginals_extended(
-    poster_state: Dict,
+    poster_state: dict,
     mean,
     kernel,
     test_features,
-    resources: List[int],
-    issm_params: Dict,
+    resources: list[int],
+    issm_params: dict,
     r_min: int,
     r_max: int,
 ):
@@ -724,17 +722,17 @@ def predict_posterior_marginals_extended(
 
 
 def sample_posterior_joint(
-    poster_state: Dict,
+    poster_state: dict,
     mean,
     kernel,
     feature,
     targets: np.ndarray,
-    issm_params: Dict,
+    issm_params: dict,
     r_min: int,
     r_max: int,
     random_state: RandomState,
     num_samples: int = 1,
-) -> Dict:
+) -> dict:
     """
     Given ``poster_state`` for some data plus one additional configuration
     with data (``feature``, ``targets``, ``issm_params``), draw joint samples
@@ -866,12 +864,12 @@ def sample_posterior_joint(
 
 
 def issm_likelihood_slow_computations(
-    targets: List[np.ndarray],
-    issm_params: Dict,
+    targets: list[np.ndarray],
+    issm_params: dict,
     r_min: int,
     r_max: int,
     skip_c_d: bool = False,
-) -> Dict:
+) -> dict:
     """
     Naive implementation of ``issm_likelihood_computations``, which does not
     require precomputations, but is much slower. Here, results are computed
@@ -962,8 +960,8 @@ def issm_likelihood_slow_computations(
 
 
 def _update_posterior_internal(
-    poster_state: Dict, kernel, feature, d_new, s_new, r2_new
-) -> Dict:
+    poster_state: dict, kernel, feature, d_new, s_new, r2_new
+) -> dict:
     assert "r2vec" in poster_state and "r4vec" in poster_state
     features = poster_state["features"]
     r2vec = poster_state["r2vec"]
@@ -1003,8 +1001,8 @@ def _update_posterior_internal(
 
 
 def update_posterior_state(
-    poster_state: Dict, kernel, feature, d_new, s_new, r2_new
-) -> Dict:
+    poster_state: dict, kernel, feature, d_new, s_new, r2_new
+) -> dict:
     """
     Incremental update of posterior state, given data for one additional
     configuration. The new datapoint gives rise to a new row/column of the
@@ -1069,7 +1067,7 @@ def update_posterior_state(
 
 
 def update_posterior_pvec(
-    poster_state: Dict, kernel, feature, d_new, s_new, r2_new
+    poster_state: dict, kernel, feature, d_new, s_new, r2_new
 ) -> np.ndarray:
     """
     Part of ``update_posterior_state``, just returns the new p vector.

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/likelihood.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/likelihood.py
@@ -1,4 +1,4 @@
-from typing import Union, Optional, List, Dict, Any
+from typing import Union, Optional, Any
 import autograd.numpy as anp
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.likelihood import (
@@ -115,21 +115,21 @@ class GaussAdditiveMarginalLikelihood(MarginalLikelihood):
                 self.params, "noise_variance", self.encoding
             )
 
-    def get_posterior_state(self, data: Dict[str, Any]) -> PosteriorState:
+    def get_posterior_state(self, data: dict[str, Any]) -> PosteriorState:
         return self._type(
             data,
             **self._posterstate_kwargs,
             noise_variance=self.get_noise_variance(),
         )
 
-    def forward(self, data: Dict[str, Any]):
+    def forward(self, data: dict[str, Any]):
         assert not data["do_fantasizing"], (
             "data must not be for fantasizing. Call prepare_data with "
             + "do_fantasizing=False"
         )
         return super().forward(data)
 
-    def param_encoding_pairs(self) -> List[tuple]:
+    def param_encoding_pairs(self) -> list[tuple]:
         own_param_encoding_pairs = [(self.noise_variance_internal, self.encoding)]
         return (
             own_param_encoding_pairs
@@ -147,13 +147,13 @@ class GaussAdditiveMarginalLikelihood(MarginalLikelihood):
     def _set_noise_variance(self, val):
         self.encoding.set(self.noise_variance_internal, val)
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         result = {"noise_variance": self.get_noise_variance()}
         for pref, func in self._components:
             result.update({(pref + k): v for k, v in func.get_params().items()})
         return result
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         for pref, func in self._components:
             len_pref = len(pref)
             stripped_dict = {
@@ -162,11 +162,11 @@ class GaussAdditiveMarginalLikelihood(MarginalLikelihood):
             func.set_params(stripped_dict)
         self._set_noise_variance(param_dict["noise_variance"])
 
-    def data_precomputations(self, data: Dict[str, Any], overwrite: bool = False):
+    def data_precomputations(self, data: dict[str, Any], overwrite: bool = False):
         if overwrite or not self._type.has_precomputations(data):
             self._type.data_precomputations(data)
 
-    def on_fit_start(self, data: Dict[str, Any]):
+    def on_fit_start(self, data: dict[str, Any]):
         assert not data["do_fantasizing"], (
             "data must not be for fantasizing. Call prepare_data with "
             + "do_fantasizing=False"

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/model_params.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/model_params.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 import autograd.numpy as anp
 from autograd.tracer import getval
 
@@ -64,7 +64,7 @@ class ISSModelParameters(MeanFunction):
             gamma = encode_unwrap_parameter(self.gamma_internal, self.gamma_encoding)
             return anp.reshape(gamma, (1,))[0]
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         if self.gamma_is_one:
             return dict()
         else:
@@ -74,11 +74,11 @@ class ISSModelParameters(MeanFunction):
         assert not self.gamma_is_one, "Cannot set gamma (fixed to 1)"
         self.gamma_encoding.set(self.gamma_internal, val)
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         if not self.gamma_is_one:
             self.set_gamma(param_dict["gamma"])
 
-    def get_issm_params(self, features) -> Dict[str, Any]:
+    def get_issm_params(self, features) -> dict[str, Any]:
         """
         Given feature matrix X, returns ISSM parameters which configure the
         likelihood: alpha, beta vectors (size n), gamma scalar.
@@ -132,7 +132,7 @@ class IndependentISSModelParameters(ISSModelParameters):
         beta = encode_unwrap_parameter(self.beta_internal, self.beta_encoding)
         return anp.reshape(beta, (1,))[0]
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         _params = super().get_params()
         return dict(_params, alpha=self.get_alpha(), beta=self.get_beta())
 
@@ -142,12 +142,12 @@ class IndependentISSModelParameters(ISSModelParameters):
     def set_beta(self, val):
         self.beta_encoding.set(self.beta_internal, val)
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         super().set_params(param_dict)
         self.set_alpha(param_dict["alpha"])
         self.set_beta(param_dict["beta"])
 
-    def get_issm_params(self, features) -> Dict[str, Any]:
+    def get_issm_params(self, features) -> dict[str, Any]:
         n = getval(features.shape[0])
         one_vec = anp.ones((n,))
         return {

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/posterior_state.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/posterior_state.py
@@ -1,7 +1,7 @@
 import numpy as np
 import autograd.numpy as anp
 from autograd import grad
-from typing import Tuple, Dict, List, Optional, Any
+from typing import Optional, Any
 from numpy.random import RandomState
 import logging
 
@@ -117,7 +117,7 @@ class GaussProcAdditivePosteriorState(PosteriorState):
     def num_fantasies(self):
         return self.poster_state["pmat"].shape[1]
 
-    def _compute_posterior_state(self, data: Dict[str, Any], noise_variance, **kwargs):
+    def _compute_posterior_state(self, data: dict[str, Any], noise_variance, **kwargs):
         raise NotImplementedError()
 
     def neg_log_likelihood(self) -> anp.ndarray:
@@ -126,7 +126,7 @@ class GaussProcAdditivePosteriorState(PosteriorState):
         ), "neg_log_likelihood not defined for fantasizing posterior state"
         return self.poster_state["criterion"]
 
-    def predict(self, test_features: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def predict(self, test_features: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         """
         We compute marginals over f(x, r), where ``test_features`` are extended
         features.
@@ -167,7 +167,7 @@ class GaussProcAdditivePosteriorState(PosteriorState):
     def backward_gradient(
         self,
         input: np.ndarray,
-        head_gradients: Dict[str, np.ndarray],
+        head_gradients: dict[str, np.ndarray],
         mean_data: float,
         std_data: float,
     ) -> np.ndarray:
@@ -201,19 +201,19 @@ class GaussProcAdditivePosteriorState(PosteriorState):
 
     def _sample_curves_internal(
         self,
-        data: Dict[str, Any],
-        poster_state: Dict[str, Any],
+        data: dict[str, Any],
+        poster_state: dict[str, Any],
         num_samples: int = 1,
         random_state: Optional[RandomState] = None,
-    ) -> List[dict]:
+    ) -> list[dict]:
         raise NotImplementedError()
 
     def sample_curves(
         self,
-        data: Dict[str, Any],
+        data: dict[str, Any],
         num_samples: int = 1,
         random_state: Optional[RandomState] = None,
-    ) -> List[dict]:
+    ) -> list[dict]:
         """
         Given data from one or more configurations (as returned by
         ``issm.prepare_data``), for each config, sample a curve from the
@@ -244,7 +244,7 @@ class GaussProcAdditivePosteriorState(PosteriorState):
         )
 
     @staticmethod
-    def has_precomputations(data: Dict[str, Any]) -> bool:
+    def has_precomputations(data: dict[str, Any]) -> bool:
         raise NotImplementedError()
 
 
@@ -269,7 +269,7 @@ class IncrementalUpdateGPAdditivePosteriorState(GaussProcAdditivePosteriorState)
 
     def _prepare_update(
         self, feature: np.ndarray, targets: np.ndarray
-    ) -> Tuple[float, float, float]:
+    ) -> tuple[float, float, float]:
         """
         Helper method for ``update``. Returns new entries for d, s, r2 vectors.
 
@@ -281,7 +281,7 @@ class IncrementalUpdateGPAdditivePosteriorState(GaussProcAdditivePosteriorState)
 
     def _update_internal(
         self, feature: np.ndarray, targets: np.ndarray
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Update posterior state, given a single new datapoint. ``feature``,
         ``targets`` are like one entry of ``data``. The method returns a new
@@ -330,7 +330,7 @@ class IncrementalUpdateGPAdditivePosteriorState(GaussProcAdditivePosteriorState)
 
     def _sample_posterior_joint_for_config(
         self,
-        poster_state: Dict[str, Any],
+        poster_state: dict[str, Any],
         config: Configuration,
         feature: np.ndarray,
         targets: np.ndarray,
@@ -344,10 +344,10 @@ class IncrementalUpdateGPAdditivePosteriorState(GaussProcAdditivePosteriorState)
 
     def sample_and_update_for_pending(
         self,
-        data_pending: Dict[str, Any],
+        data_pending: dict[str, Any],
         sample_all_nonobserved: bool = False,
         random_state: Optional[RandomState] = None,
-    ) -> (List[np.ndarray], "IncrementalUpdateGPAdditivePosteriorState"):
+    ) -> (list[np.ndarray], "IncrementalUpdateGPAdditivePosteriorState"):
         """
         This function is needed for sampling fantasy targets, and also to
         support simulation-based scoring.
@@ -436,10 +436,10 @@ class GaussProcISSMPosteriorState(IncrementalUpdateGPAdditivePosteriorState):
         super().__init__(data, mean, kernel, noise_variance=noise_variance, **kwargs)
 
     @staticmethod
-    def has_precomputations(data: Dict[str, Any]) -> bool:
+    def has_precomputations(data: dict[str, Any]) -> bool:
         return all(k in data for k in ("ydims", "num_configs", "deltay", "logr"))
 
-    def _compute_posterior_state(self, data: Dict[str, Any], noise_variance, **kwargs):
+    def _compute_posterior_state(self, data: dict[str, Any], noise_variance, **kwargs):
         # Compute posterior state
         issm_params = self.iss_model.get_issm_params(data["features"])
         if self.has_precomputations(data):
@@ -464,7 +464,7 @@ class GaussProcISSMPosteriorState(IncrementalUpdateGPAdditivePosteriorState):
             noise_variance=noise_variance,
         )
 
-    def predict(self, test_features: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def predict(self, test_features: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         resource_attr_range = (self.r_min, self.r_max)
         features, resources = decode_extended_features(
             test_features, resource_attr_range=resource_attr_range
@@ -482,7 +482,7 @@ class GaussProcISSMPosteriorState(IncrementalUpdateGPAdditivePosteriorState):
         )
 
     @staticmethod
-    def data_precomputations(data: Dict[str, Any]):
+    def data_precomputations(data: dict[str, Any]):
         logger.info("Enhancing data dictionary by precomputed variables")
         data.update(
             issm_likelihood_precomputations(
@@ -492,11 +492,11 @@ class GaussProcISSMPosteriorState(IncrementalUpdateGPAdditivePosteriorState):
 
     def _sample_curves_internal(
         self,
-        data: Dict[str, Any],
-        poster_state: Dict[str, Any],
+        data: dict[str, Any],
+        poster_state: dict[str, Any],
         num_samples: int = 1,
         random_state: Optional[RandomState] = None,
-    ) -> List[dict]:
+    ) -> list[dict]:
         if random_state is None:
             random_state = np.random
         results = []
@@ -522,7 +522,7 @@ class GaussProcISSMPosteriorState(IncrementalUpdateGPAdditivePosteriorState):
 
     def _prepare_update(
         self, feature: np.ndarray, targets: np.ndarray
-    ) -> Tuple[float, float, float]:
+    ) -> tuple[float, float, float]:
         issm_params = self.iss_model.get_issm_params(feature.reshape((1, -1)))
         issm_likelihood = issm_likelihood_slow_computations(
             targets=[_colvec(targets, _np=np)],
@@ -587,10 +587,10 @@ class GaussProcExpDecayPosteriorState(IncrementalUpdateGPAdditivePosteriorState)
         )
 
     @staticmethod
-    def has_precomputations(data: Dict[str, Any]) -> bool:
+    def has_precomputations(data: dict[str, Any]) -> bool:
         return all(k in data for k in ("ydims", "num_configs", "yflat"))
 
-    def _compute_posterior_state(self, data: Dict[str, Any], noise_variance, **kwargs):
+    def _compute_posterior_state(self, data: dict[str, Any], noise_variance, **kwargs):
         # Compute posterior state
         if self.has_precomputations(data):
             issm_likelihood = resource_kernel_likelihood_computations(
@@ -620,7 +620,7 @@ class GaussProcExpDecayPosteriorState(IncrementalUpdateGPAdditivePosteriorState)
         self.poster_state["means_all"] = issm_likelihood["means_all"]
         self.poster_state["noise_variance"] = noise_variance
 
-    def predict(self, test_features: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def predict(self, test_features: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         resource_attr_range = (self.r_min, self.r_max)
         features, resources = decode_extended_features(
             test_features, resource_attr_range=resource_attr_range
@@ -635,16 +635,16 @@ class GaussProcExpDecayPosteriorState(IncrementalUpdateGPAdditivePosteriorState)
         )
 
     @staticmethod
-    def data_precomputations(data: Dict[str, Any]):
+    def data_precomputations(data: dict[str, Any]):
         data.update(resource_kernel_likelihood_precomputations(targets=data["targets"]))
 
     def _sample_curves_internal(
         self,
-        data: Dict[str, Any],
-        poster_state: Dict[str, Any],
+        data: dict[str, Any],
+        poster_state: dict[str, Any],
         num_samples: int = 1,
         random_state: Optional[RandomState] = None,
-    ) -> List[dict]:
+    ) -> list[dict]:
         assert "lfact_all" in poster_state
         if random_state is None:
             random_state = np.random
@@ -672,7 +672,7 @@ class GaussProcExpDecayPosteriorState(IncrementalUpdateGPAdditivePosteriorState)
 
     def _prepare_update(
         self, feature: np.ndarray, targets: np.ndarray
-    ) -> Tuple[float, float, float]:
+    ) -> tuple[float, float, float]:
         issm_likelihood = resource_kernel_likelihood_slow_computations(
             targets=[_colvec(targets, _np=np)],
             res_kernel=self.res_kernel,

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/mean.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/mean.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 import autograd.numpy as anp
 from autograd.tracer import getval
 
@@ -38,13 +38,13 @@ class MeanFunction(Block):
         """
         raise NotImplementedError
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         """
         :return: Dictionary with hyperparameter values
         """
         raise NotImplementedError
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         """
         :param param_dict: Dictionary with new hyperparameter values
         :return:
@@ -97,10 +97,10 @@ class ScalarMeanFunction(MeanFunction):
     def set_mean_value(self, mean_value):
         self.encoding.set(self.mean_value_internal, mean_value)
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return {"mean_value": self.get_mean_value()}
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         self.set_mean_value(param_dict["mean_value"])
 
 
@@ -114,8 +114,8 @@ class ZeroMeanFunction(MeanFunction):
     def param_encoding_pairs(self):
         return []
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return dict()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         pass

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/optimization_utils.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/optimization_utils.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 import numpy as np
 from scipy import optimize
 from autograd import value_and_grad
@@ -31,7 +31,7 @@ STARTING_POINT_RANDOMIZATION_STD = 1.0
 
 
 class ParamVecDictConverter:
-    def __init__(self, param_dict: Dict[str, Any]):
+    def __init__(self, param_dict: dict[str, Any]):
         self.param_dict = param_dict
         self.names = sorted(
             [name for name, value in param_dict.items() if value is not None]

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/posterior_state.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/posterior_state.py
@@ -2,7 +2,8 @@ import numpy as np
 import autograd.numpy as anp
 from autograd import grad
 from autograd.tracer import getval
-from typing import Tuple, Optional, Dict, Callable, Any
+from typing import Optional, Any
+from collections.abc import Callable
 from numpy.random import RandomState
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.kernel import (
@@ -46,7 +47,7 @@ class PosteriorState:
         """
         raise NotImplementedError
 
-    def predict(self, test_features: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def predict(self, test_features: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         """
         Computes marginal statistics (means, variances) for a number of test
         features.
@@ -75,7 +76,7 @@ class PosteriorState:
     def backward_gradient(
         self,
         input: np.ndarray,
-        head_gradients: Dict[str, np.ndarray],
+        head_gradients: dict[str, np.ndarray],
         mean_data: float,
         std_data: float,
     ) -> np.ndarray:
@@ -188,7 +189,7 @@ class GaussProcPosteriorState(PosteriorStateWithSampleJoint):
     def num_fantasies(self):
         return self.pred_mat.shape[1]
 
-    def _state_kwargs(self) -> Dict[str, Any]:
+    def _state_kwargs(self) -> dict[str, Any]:
         return {
             "features": self.features,
             "mean": self.mean,
@@ -204,7 +205,7 @@ class GaussProcPosteriorState(PosteriorStateWithSampleJoint):
         critval = negative_log_marginal_likelihood(self.chol_fact, self.pred_mat)
         return critval
 
-    def predict(self, test_features: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def predict(self, test_features: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         return predict_posterior_marginals(
             **self._state_kwargs(), test_features=test_features
         )
@@ -227,7 +228,7 @@ class GaussProcPosteriorState(PosteriorStateWithSampleJoint):
     def backward_gradient(
         self,
         input: np.ndarray,
-        head_gradients: Dict[str, np.ndarray],
+        head_gradients: dict[str, np.ndarray],
         mean_data: float,
         std_data: float,
     ) -> np.ndarray:
@@ -275,9 +276,9 @@ class GaussProcPosteriorState(PosteriorStateWithSampleJoint):
 
 
 def backward_gradient_given_predict(
-    predict_func: Callable[[np.ndarray], Tuple[np.ndarray, np.ndarray]],
+    predict_func: Callable[[np.ndarray], tuple[np.ndarray, np.ndarray]],
     input: np.ndarray,
-    head_gradients: Dict[str, np.ndarray],
+    head_gradients: dict[str, np.ndarray],
     mean_data: float,
     std_data: float,
 ) -> np.ndarray:

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/posterior_utils.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/posterior_utils.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from typing import Union
 import autograd.numpy as anp
 import autograd.scipy.linalg as aspl
 import numpy as np
@@ -25,7 +25,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.kernel import 
 
 
 KernelFunctionWithCovarianceScale = Union[
-    KernelFunction, Tuple[KernelFunction, np.ndarray]
+    KernelFunction, tuple[KernelFunction, np.ndarray]
 ]
 
 

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/slice.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/slice.py
@@ -1,4 +1,4 @@
-from typing import Callable, Tuple, List
+from collections.abc import Callable
 import numpy as np
 from numpy.random import RandomState
 
@@ -40,7 +40,7 @@ class SliceSampler:
 
     def sample(
         self, init_sample: np.ndarray, num_samples: int, burn: int, thin: int
-    ) -> List[np.ndarray]:
+    ) -> list[np.ndarray]:
         samples = []
         next_sample = init_sample
         for _ in range(num_samples):
@@ -60,7 +60,7 @@ def slice_sampler_step_out(
     scale: float,
     sliced_log_density: Callable[[float], float],
     random_state: RandomState,
-) -> Tuple[float, float]:
+) -> tuple[float, float]:
     r = random_state.rand()
     lower_bound = -r * scale
     upper_bound = lower_bound + scale

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/target_transform.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/target_transform.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 import autograd.numpy as anp
 from autograd.tracer import getval
 
@@ -70,10 +70,10 @@ class IdentityTargetTransform(ScalarTargetTransform):
     def param_encoding_pairs(self):
         return []
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return dict()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         pass
 
 
@@ -179,10 +179,10 @@ class BoxCoxTargetTransform(ScalarTargetTransform):
     def set_boxcox_lambda(self, boxcox_lambda):
         self.encoding.set(self.boxcox_lambda_internal, boxcox_lambda)
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return {BOXCOX_LAMBDA_NAME: self.get_boxcox_lambda()}
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         if not self._boxcox_lambda_fixed:
             self.set_boxcox_lambda(param_dict[BOXCOX_LAMBDA_NAME])
 

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/warping.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/warping.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, List, Dict, Any
+from typing import Optional, Any
 import autograd.numpy as anp
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.constants import (
@@ -58,7 +58,7 @@ class Warping(MeanFunction):
     def __init__(
         self,
         dimension: int,
-        coordinate_range: Optional[Tuple[int, int]] = None,
+        coordinate_range: Optional[tuple[int, int]] = None,
         encoding_type: str = DEFAULT_ENCODING,
         **kwargs,
     ):
@@ -143,7 +143,7 @@ class Warping(MeanFunction):
         else:
             return f"power_{kind}_{index}"
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         size = self.upper - self.lower
         just_one = size == 1
         param_dict = dict()
@@ -157,7 +157,7 @@ class Warping(MeanFunction):
             )
         return param_dict
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         size = self.upper - self.lower
         just_one = size == 1
         for kind in ("a", "b"):
@@ -171,7 +171,7 @@ class Warping(MeanFunction):
             self.encoding.set(warping_int, warping)
 
 
-def warpings_for_hyperparameters(hp_ranges: HyperparameterRanges) -> List[Warping]:
+def warpings_for_hyperparameters(hp_ranges: HyperparameterRanges) -> list[Warping]:
     """
     It is custom to warp hyperparameters which are not categorical. This
     function creates warpings based on your configuration space.
@@ -245,7 +245,7 @@ class WarpedKernel(KernelFunction):
         checked.
     """
 
-    def __init__(self, kernel: KernelFunction, warpings: List[Warping], **kwargs):
+    def __init__(self, kernel: KernelFunction, warpings: list[Warping], **kwargs):
         super().__init__(kernel.dimension, **kwargs)
         num_warpings = len(warpings)
         assert num_warpings > 0
@@ -291,14 +291,14 @@ class WarpedKernel(KernelFunction):
             x for warping in self.warpings for x in warping.param_encoding_pairs()
         ]
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         result = dict()
         blocks = [self.kernel] + self.warpings
         for pref, block in zip(self._prefixes, blocks):
             result.update({(pref + k): v for k, v in block.get_params().items()})
         return result
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         blocks = [self.kernel] + self.warpings
         for pref, block in zip(self._prefixes, blocks):
             len_pref = len(pref)

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost/cost_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost/cost_model.py
@@ -1,4 +1,3 @@
-from typing import List
 from dataclasses import dataclass
 
 from syne_tune.optimizer.schedulers.searchers.utils.common import Configuration
@@ -80,7 +79,7 @@ class CostModel:
         """
         pass
 
-    def sample_joint(self, candidates: List[Configuration]) -> List[CostValue]:
+    def sample_joint(self, candidates: list[Configuration]) -> list[CostValue]:
         """
         Draws cost values :math:`(c_0(x), c_1(x))` for candidates (non-extended).
 
@@ -120,11 +119,11 @@ class CostModel:
 
     def predict_times(
         self,
-        candidates: List[Configuration],
-        resources: List[int],
-        cost_values: List[CostValue],
+        candidates: list[Configuration],
+        resources: list[int],
+        cost_values: list[CostValue],
         start_time: float = 0,
-    ) -> List[float]:
+    ) -> list[float]:
         """
         Given configs :math:`x`, resource values :math:`r` and cost values returned
         by :meth:`sample_joint`, compute time predictions for when each config

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost/linear_cost_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost/linear_cost_model.py
@@ -1,4 +1,5 @@
-from typing import List, Callable, Optional, Dict, Tuple
+from typing import Optional
+from collections.abc import Callable
 import numpy as np
 from sklearn.linear_model import RidgeCV
 from enum import IntEnum
@@ -50,7 +51,7 @@ class LinearCostModel(CostModel):
         return INTERNAL_COST_NAME
 
     def feature_matrices(
-        self, candidates: List[Configuration]
+        self, candidates: list[Configuration]
     ) -> (np.ndarray, np.ndarray):
         """
         Has to be supplied by subclasses
@@ -107,7 +108,7 @@ class LinearCostModel(CostModel):
         self.weights1 = predictor.coef_[dim0:].reshape((-1, 1))
         self.alpha = predictor.alpha_
 
-    def sample_joint(self, candidates: List[Configuration]) -> List[CostValue]:
+    def sample_joint(self, candidates: list[Configuration]) -> list[CostValue]:
         assert self.weights0 is not None, "Must call 'update' before 'sample_joint'"
         features0, features1 = self.feature_matrices(candidates)
         c0_vals = np.matmul(features0, self.weights0).reshape((-1,))
@@ -124,7 +125,7 @@ class BiasOnlyLinearCostModel(LinearCostModel):
         super().__init__()
 
     def feature_matrices(
-        self, candidates: List[Configuration]
+        self, candidates: list[Configuration]
     ) -> (np.ndarray, np.ndarray):
         one_feats = np.ones((len(candidates), 1))
         return one_feats, one_feats
@@ -190,7 +191,7 @@ class MLPLinearCostModel(LinearCostModel):
         self.expected_hidden_layer_width = expected_hidden_layer_width
 
     def feature_matrices(
-        self, candidates: List[Configuration]
+        self, candidates: list[Configuration]
     ) -> (np.ndarray, np.ndarray):
         features1_1 = []
         features1_2 = []
@@ -251,7 +252,7 @@ class FixedLayersMLPCostModel(MLPLinearCostModel):
         self,
         num_inputs: int,
         num_outputs: int,
-        num_units_keys: List[str] = None,
+        num_units_keys: list[str] = None,
         bs_exponent: Optional[float] = None,
         extra_mlp: bool = False,
         c0_mlp_feature: bool = False,
@@ -277,7 +278,7 @@ class FixedLayersMLPCostModel(MLPLinearCostModel):
         )
 
     @staticmethod
-    def get_expected_hidden_layer_width(config_space: Dict, num_units_keys: List[str]):
+    def get_expected_hidden_layer_width(config_space: dict, num_units_keys: list[str]):
         """
         Constructs expected_hidden_layer_width function from the training
         evaluation function.
@@ -330,8 +331,8 @@ class NASBench201LinearCostModel(LinearCostModel):
 
     def __init__(
         self,
-        config_keys: Tuple[str, ...],
-        map_config_values: Dict[str, int],
+        config_keys: tuple[str, ...],
+        map_config_values: dict[str, int],
         conv_separate_features: bool,
         count_sum: bool,
     ):
@@ -341,11 +342,11 @@ class NASBench201LinearCostModel(LinearCostModel):
         self.conv_separate_features = conv_separate_features
         self.count_sum = count_sum
 
-    def _translate(self, config: Configuration) -> List[int]:
+    def _translate(self, config: Configuration) -> list[int]:
         return [self._map_config_values[config[name]] for name in self._config_keys]
 
     def feature_matrices(
-        self, candidates: List[Configuration]
+        self, candidates: list[Configuration]
     ) -> (np.ndarray, np.ndarray):
         features1_1 = []
         features1_2 = []

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost_fifo_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost_fifo_model.py
@@ -1,4 +1,3 @@
-from typing import Dict, List, Set
 import numpy as np
 import logging
 
@@ -55,10 +54,10 @@ class CostFixedResourcePredictor(BasePredictor):
         self._num_samples = num_samples
 
     @staticmethod
-    def keys_predict() -> Set[str]:
+    def keys_predict() -> set[str]:
         return {"mean"}
 
-    def predict(self, inputs: np.ndarray) -> List[Dict[str, np.ndarray]]:
+    def predict(self, inputs: np.ndarray) -> list[dict[str, np.ndarray]]:
         # Inputs are encoded. For cost models, need to decode them back
         # to candidates (not necessarily differentiable)
         # Note: Both ``inputs`` and ``hp_ranges`` may correspond to extended
@@ -84,20 +83,20 @@ class CostFixedResourcePredictor(BasePredictor):
         return [{"mean": np.mean(prediction_list, axis=0)}]
 
     def backward_gradient(
-        self, input: np.ndarray, head_gradients: List[Dict[str, np.ndarray]]
-    ) -> List[np.ndarray]:
+        self, input: np.ndarray, head_gradients: list[dict[str, np.ndarray]]
+    ) -> list[np.ndarray]:
         """
         The gradient contribution through the cost model is blocked.
 
         """
         return [np.zeros_like(input)]
 
-    def predict_mean_current_candidates(self) -> List[np.ndarray]:
+    def predict_mean_current_candidates(self) -> list[np.ndarray]:
         raise NotImplementedError()
 
     # We currently do not support cost models for the primary metric to be
     # optimized
-    def current_best(self) -> List[np.ndarray]:
+    def current_best(self) -> list[np.ndarray]:
         raise NotImplementedError()
 
 

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/estimator.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/estimator.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, Any, Optional, Union
+from typing import Any, Optional, Union
 
 import numpy as np
 
@@ -31,13 +31,13 @@ class Estimator:
     can be accessed with :meth:`get_params`, :meth:`set_params`.
     """
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         """
         :return: Current tunable model parameters
         """
         raise NotImplementedError()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         """
         :param param_dict: New model parameters
         """
@@ -87,7 +87,7 @@ class Estimator:
 # that work both in the standard case of a single output model and in the
 # multi-output case
 
-OutputEstimator = Union[Estimator, Dict[str, Estimator]]
+OutputEstimator = Union[Estimator, dict[str, Estimator]]
 
 
 @dataclass

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/gp_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/gp_model.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 import numpy as np
 import logging
 
@@ -85,7 +85,7 @@ class GaussProcPredictor(BasePredictor):
         self,
         state: TuningJobState,
         gpmodel: GPModel,
-        fantasy_samples: List[FantasizedPendingEvaluation],
+        fantasy_samples: list[FantasizedPendingEvaluation],
         active_metric: str = None,
         normalize_mean: float = 0.0,
         normalize_std: float = 1.0,
@@ -105,7 +105,7 @@ class GaussProcPredictor(BasePredictor):
         else:
             return super().hp_ranges_for_prediction()
 
-    def predict(self, inputs: np.ndarray) -> List[Dict[str, np.ndarray]]:
+    def predict(self, inputs: np.ndarray) -> list[dict[str, np.ndarray]]:
         predictions_list = []
         for post_mean, post_variance in self._gpmodel.predict(inputs):
             assert post_mean.shape[0] == inputs.shape[0], (
@@ -123,8 +123,8 @@ class GaussProcPredictor(BasePredictor):
         return predictions_list
 
     def backward_gradient(
-        self, input: np.ndarray, head_gradients: List[Dict[str, np.ndarray]]
-    ) -> List[np.ndarray]:
+        self, input: np.ndarray, head_gradients: list[dict[str, np.ndarray]]
+    ) -> list[np.ndarray]:
         poster_states = self.posterior_states
         assert (
             poster_states is not None
@@ -148,7 +148,7 @@ class GaussProcPredictor(BasePredictor):
         return isinstance(self._gpmodel, GPRegressionMCMC)
 
     @property
-    def posterior_states(self) -> Optional[List[PosteriorState]]:
+    def posterior_states(self) -> Optional[list[PosteriorState]]:
         return self._gpmodel.states
 
     def _current_best_filter_candidates(self, candidates):

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/gpiss_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/gpiss_model.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Optional
 import numpy as np
 import logging
 
@@ -63,7 +63,7 @@ class GaussProcAdditivePredictor(BasePredictor):
         self,
         state: TuningJobState,
         gpmodel: GaussianProcessLearningCurveModel,
-        fantasy_samples: List[FantasizedPendingEvaluation],
+        fantasy_samples: list[FantasizedPendingEvaluation],
         active_metric: str,
         filter_observed_data: Optional[ConfigurationFilter] = None,
         normalize_mean: float = 0.0,
@@ -75,7 +75,7 @@ class GaussProcAdditivePredictor(BasePredictor):
         self.std = normalize_std
         self.fantasy_samples = fantasy_samples
 
-    def predict(self, inputs: np.ndarray) -> List[Dict[str, np.ndarray]]:
+    def predict(self, inputs: np.ndarray) -> list[dict[str, np.ndarray]]:
         """
         Input features ``inputs`` are w.r.t. extended configs ``(x, r)``.
 
@@ -99,8 +99,8 @@ class GaussProcAdditivePredictor(BasePredictor):
         return predictions_list
 
     def backward_gradient(
-        self, input: np.ndarray, head_gradients: List[Dict[str, np.ndarray]]
-    ) -> List[np.ndarray]:
+        self, input: np.ndarray, head_gradients: list[dict[str, np.ndarray]]
+    ) -> list[np.ndarray]:
         poster_states = self.posterior_states
         assert (
             poster_states is not None
@@ -124,7 +124,7 @@ class GaussProcAdditivePredictor(BasePredictor):
         return False
 
     @property
-    def posterior_states(self) -> Optional[List[GaussProcAdditivePosteriorState]]:
+    def posterior_states(self) -> Optional[list[GaussProcAdditivePosteriorState]]:
         return self._gpmodel.states
 
 
@@ -243,7 +243,7 @@ class GaussProcAdditiveEstimator(Estimator):
         )
 
     def predictor_for_fantasy_samples(
-        self, state: TuningJobState, fantasy_samples: List[FantasizedPendingEvaluation]
+        self, state: TuningJobState, fantasy_samples: list[FantasizedPendingEvaluation]
     ) -> Predictor:
         """
         Same as ``model`` with ``fit_params=False``, but ``fantasy_samples`` are

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/meanstd_acqfunc.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/meanstd_acqfunc.py
@@ -1,5 +1,5 @@
 import numpy as np
-from typing import Dict, Tuple, Optional, Set, List
+from typing import Optional
 from dataclasses import dataclass
 import itertools
 
@@ -20,9 +20,9 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common import (
 # :class:`Predictor`.
 # Note: List sizes of different entries can be different. MCMC averaging
 # is done over the Cartesian product of these lists.
-PredictionsPerOutput = Dict[str, List[Dict[str, np.ndarray]]]
+PredictionsPerOutput = dict[str, list[dict[str, np.ndarray]]]
 
-SamplePredictionsPerOutput = Dict[str, Dict[str, np.ndarray]]
+SamplePredictionsPerOutput = dict[str, dict[str, np.ndarray]]
 
 
 @dataclass
@@ -45,12 +45,12 @@ class CurrentBestProvider:
     ``(0, 0, ..., 0)``).
     """
 
-    def __call__(self, positions: Tuple[int, ...]) -> Optional[np.ndarray]:
+    def __call__(self, positions: tuple[int, ...]) -> Optional[np.ndarray]:
         raise NotImplementedError
 
 
 class NoneCurrentBestProvider(CurrentBestProvider):
-    def __call__(self, positions: Tuple[int, ...]) -> Optional[np.ndarray]:
+    def __call__(self, positions: tuple[int, ...]) -> Optional[np.ndarray]:
         return None
 
 
@@ -60,13 +60,13 @@ class ActiveMetricCurrentBestProvider(CurrentBestProvider):
     active metric only.
     """
 
-    def __init__(self, active_metric_current_best: List[np.ndarray]):
+    def __init__(self, active_metric_current_best: list[np.ndarray]):
         self._active_metric_current_best = [
             v.reshape((1, -1)) for v in active_metric_current_best
         ]
         self._constant_list = len(active_metric_current_best) == 1
 
-    def __call__(self, positions: Tuple[int, ...]) -> Optional[np.ndarray]:
+    def __call__(self, positions: tuple[int, ...]) -> Optional[np.ndarray]:
         pos = positions[0] if not self._constant_list else 0
         return self._active_metric_current_best[pos]
 
@@ -94,7 +94,7 @@ class MeanStdAcquisitionFunction(AcquisitionFunction):
         if isinstance(predictor, Predictor):
             # Ignore active_metric
             predictor = dictionarize_objective(predictor)
-        assert isinstance(predictor, Dict)
+        assert isinstance(predictor, dict)
         self.predictor = predictor
         self.predictor_output_names = sorted(predictor.keys())
         self.active_metric = assign_active_metric(predictor, active_metric)
@@ -109,7 +109,7 @@ class MeanStdAcquisitionFunction(AcquisitionFunction):
         self._check_keys_predict_of_predictors()
         self._current_bests = None
 
-    def _output_to_keys_predict(self) -> Dict[str, Set[str]]:
+    def _output_to_keys_predict(self) -> dict[str, set[str]]:
         """
         Required ``keys_predict`` for each output model. The default requires
         each output model to return "mean" and "std".
@@ -218,8 +218,8 @@ class MeanStdAcquisitionFunction(AcquisitionFunction):
 
     @staticmethod
     def _add_head_gradients(
-        grad1: Dict[str, np.ndarray], grad2: Optional[Dict[str, np.ndarray]]
-    ) -> Dict[str, np.ndarray]:
+        grad1: dict[str, np.ndarray], grad2: Optional[dict[str, np.ndarray]]
+    ) -> dict[str, np.ndarray]:
         if grad2 is None:
             return grad1
         else:

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/meanstd_acqfunc_impl.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/meanstd_acqfunc_impl.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Set, List, Tuple
+from typing import Optional
 import logging
 import itertools
 
@@ -241,7 +241,7 @@ class EIpuAcquisitionFunction(MeanStdAcquisitionFunction):
     def _head_needs_current_best(self) -> bool:
         return True
 
-    def _output_to_keys_predict(self) -> Dict[str, Set[str]]:
+    def _output_to_keys_predict(self) -> dict[str, set[str]]:
         """
         The cost model may be deterministic, as the acquisition function
         only needs the mean.
@@ -321,7 +321,7 @@ class ConstraintCurrentBestProvider(CurrentBestProvider):
     Here, ``current_best`` depends on two predictors, for active and constraint metric.
     """
 
-    def __init__(self, current_best_list: List[np.ndarray], num_samples_active: int):
+    def __init__(self, current_best_list: list[np.ndarray], num_samples_active: int):
         list_size = len(current_best_list)
         assert list_size > 0 and list_size % num_samples_active == 0
         self._active_and_constraint_current_best = [
@@ -329,7 +329,7 @@ class ConstraintCurrentBestProvider(CurrentBestProvider):
         ]
         self._num_samples_active = num_samples_active
 
-    def __call__(self, positions: Tuple[int, ...]) -> Optional[np.ndarray]:
+    def __call__(self, positions: tuple[int, ...]) -> Optional[np.ndarray]:
         flat_pos = positions[1] * self._num_samples_active + positions[0]
         return self._active_and_constraint_current_best[flat_pos]
 

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/model_base.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/model_base.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional
 import numpy as np
 import logging
 
@@ -40,7 +40,7 @@ class BasePredictor(Predictor):
         self._filter_observed_data = filter_observed_data
         self._current_best = None
 
-    def predict_mean_current_candidates(self) -> List[np.ndarray]:
+    def predict_mean_current_candidates(self) -> list[np.ndarray]:
         """
         Returns the predictive mean (signal with key 'mean') at all current candidates
         in the state (observed, pending).
@@ -68,7 +68,7 @@ class BasePredictor(Predictor):
             all_means.append(means)
         return all_means
 
-    def current_best(self) -> List[np.ndarray]:
+    def current_best(self) -> list[np.ndarray]:
         if self._current_best is None:
             all_means = self.predict_mean_current_candidates()
             result = [np.min(means, axis=0) for means in all_means]

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/model_skipopt.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/model_skipopt.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.tuning_job_state import (
     TuningJobState,
@@ -130,7 +130,7 @@ class SkipNoMaxResourcePredicate(SkipOptimizationPredicate):
         self.lastrec_max_resource_cases = None
 
     def _num_max_resource_cases(self, state: TuningJobState):
-        def is_max_resource(metrics: Dict[str, Any]) -> int:
+        def is_max_resource(metrics: dict[str, Any]) -> int:
             return int(self.max_resource in metrics[self.metric_name])
 
         return sum(is_max_resource(ev.metrics) for ev in state.trials_evaluations)

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/model_transformer.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/model_transformer.py
@@ -1,4 +1,5 @@
-from typing import Dict, Optional, Callable, Union
+from typing import Optional, Union
+from collections.abc import Callable
 import logging
 import copy
 
@@ -40,7 +41,7 @@ def _assert_same_keys(dict1, dict2):
 # multi-output case
 
 SkipOptimizationOutputPredicate = Union[
-    SkipOptimizationPredicate, Dict[str, SkipOptimizationPredicate]
+    SkipOptimizationPredicate, dict[str, SkipOptimizationPredicate]
 ]
 
 
@@ -127,7 +128,7 @@ class ModelStateTransformer:
                     for output_name in estimator.keys()
                 }
             else:
-                assert isinstance(skip_optimization, Dict), (
+                assert isinstance(skip_optimization, dict), (
                     f"{skip_optimization} must be a Dict, consistently "
                     f"with {estimator}."
                 )

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/sklearn_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/sklearn_model.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional, List
+from typing import Any, Optional
 
 import numpy as np
 
@@ -36,13 +36,13 @@ class SKLearnPredictorWrapper(BasePredictor):
         super().__init__(state, active_metric)
         self.sklearn_predictor = sklearn_predictor
 
-    def predict(self, inputs: np.ndarray) -> List[Dict[str, np.ndarray]]:
+    def predict(self, inputs: np.ndarray) -> list[dict[str, np.ndarray]]:
         means, stddevs = self.sklearn_predictor.predict(X=inputs)
         return [{"mean": means, "std": stddevs}]
 
     def backward_gradient(
-        self, input: np.ndarray, head_gradients: List[Dict[str, np.ndarray]]
-    ) -> List[np.ndarray]:
+        self, input: np.ndarray, head_gradients: list[dict[str, np.ndarray]]
+    ) -> list[np.ndarray]:
         r"""
         Computes the gradient :math:`\nabla f(x)` for an acquisition
         function :math:`f(x)`, where :math:`x` is a single input point. This
@@ -81,10 +81,10 @@ class SKLearnEstimatorWrapper(Estimator):
         self.sklearn_estimator = sklearn_estimator
         self.target_metric = active_metric
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return self.sklearn_estimator.get_params()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         self.sklearn_estimator.set_params(param_dict)
 
     def fit_from_state(self, state: TuningJobState, update_params: bool) -> Predictor:

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/subsample_state_multi_fidelity.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/subsample_state_multi_fidelity.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Tuple
+from typing import Optional
 import copy
 from numpy.random import RandomState
 from operator import itemgetter
@@ -19,11 +19,11 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.models.model_transformer 
 from syne_tune.util import is_positive_integer
 
 
-ObservedData = List[Tuple[int, int, float]]
+ObservedData = list[tuple[int, int, float]]
 
 
 def _extract_observations(
-    trials_evaluations: List[TrialEvaluations],
+    trials_evaluations: list[TrialEvaluations],
 ) -> ObservedData:
     """
     Maps ``trials_evaluations`` to list of tuples :math:`(i, r, y_{i r})`, where
@@ -45,7 +45,7 @@ def _extract_observations(
     return all_data
 
 
-def _create_trials_evaluations(data: ObservedData) -> List[TrialEvaluations]:
+def _create_trials_evaluations(data: ObservedData) -> list[TrialEvaluations]:
     """Inverse of :func:`_extract_observations`
 
     :param data: List of tuples
@@ -166,7 +166,7 @@ class SubsampleMultiFidelityStateConverter(StateForModelConverter):
 
 
 def _sparsify_at_most_one_per_trial_and_group(
-    data: ObservedData, max_size: int, rung_levels: List[int]
+    data: ObservedData, max_size: int, rung_levels: list[int]
 ) -> ObservedData:
     r"""
     Define groups :math:`G_j = \{r_j + 1,\dots, r_j\}`, where math:`[r_j]` is

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/subsample_state_single_fidelity.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/subsample_state_single_fidelity.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Tuple
+from typing import Optional
 import copy
 from numpy.random import RandomState
 from operator import itemgetter
@@ -15,11 +15,11 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.models.model_transformer 
 )
 
 
-ObservedData = List[Tuple[int, float]]
+ObservedData = list[tuple[int, float]]
 
 
 def _extract_observations(
-    trials_evaluations: List[TrialEvaluations],
+    trials_evaluations: list[TrialEvaluations],
 ) -> ObservedData:
     """
     Maps ``trials_evaluations`` to list of tuples :math:`(i, y_i)`, where
@@ -34,7 +34,7 @@ def _extract_observations(
     ]
 
 
-def _create_trials_evaluations(data: ObservedData) -> List[TrialEvaluations]:
+def _create_trials_evaluations(data: ObservedData) -> list[TrialEvaluations]:
     """Inverse of :func:`_extract_observations`
 
     :param data: List of tuples

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/sklearn/estimator.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/sklearn/estimator.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 import numpy as np
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.sklearn.predictor import (
@@ -28,13 +28,13 @@ class SKLearnEstimator:
         """
         raise NotImplementedError
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         """
         :return: Current model hyperparameters
         """
         return dict()  # Default (estimator has no hyperparameters)
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         """
         :param param_dict: New model hyperparameters
         """

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/sklearn/predictor.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/sklearn/predictor.py
@@ -1,5 +1,3 @@
-from typing import Tuple, Dict
-
 import numpy as np
 
 
@@ -11,7 +9,7 @@ class SKLearnPredictor:
     This is only for predictors who return means and stddevs in :meth:`predict`.
     """
 
-    def predict(self, X: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def predict(self, X: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         """
         Returns signals which are statistics of the predictive distribution at
         input points ``inputs``.
@@ -23,7 +21,7 @@ class SKLearnPredictor:
         raise NotImplementedError
 
     def backward_gradient(
-        self, input: np.ndarray, head_gradients: Dict[str, np.ndarray]
+        self, input: np.ndarray, head_gradients: dict[str, np.ndarray]
     ) -> np.ndarray:
         r"""
         Needs to be implemented only if gradient-based local optimization of

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/base_classes.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/base_classes.py
@@ -1,15 +1,9 @@
 from typing import (
-    List,
-    Iterable,
-    Tuple,
     Optional,
-    Set,
-    Dict,
     Union,
-    Iterator,
-    Callable,
     Any,
 )
+from collections.abc import Iterable, Iterator, Callable
 import numpy as np
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common import (
@@ -49,7 +43,7 @@ def assign_active_metric(predictor, active_metric):
 
 
 class NextCandidatesAlgorithm:
-    def next_candidates(self) -> List[Configuration]:
+    def next_candidates(self) -> list[Configuration]:
         raise NotImplementedError
 
 
@@ -72,7 +66,7 @@ class Predictor:
             active_metric = INTERNAL_METRIC_NAME
         self.active_metric = active_metric
 
-    def keys_predict(self) -> Set[str]:
+    def keys_predict(self) -> set[str]:
         """Keys of signals returned by :meth:`predict`.
 
         Note: In order to work with :class:`AcquisitionFunction` implementations,
@@ -85,7 +79,7 @@ class Predictor:
         """
         return {"mean", "std"}
 
-    def predict(self, inputs: np.ndarray) -> List[Dict[str, np.ndarray]]:
+    def predict(self, inputs: np.ndarray) -> list[dict[str, np.ndarray]]:
         """
         Returns signals which are statistics of the predictive distribution at
         input points ``inputs``. By default:
@@ -114,7 +108,7 @@ class Predictor:
 
     def predict_candidates(
         self, candidates: Iterable[Configuration]
-    ) -> List[Dict[str, np.ndarray]]:
+    ) -> list[dict[str, np.ndarray]]:
         """Convenience variant of :meth:`predict`
 
         :param candidates: List of configurations
@@ -124,7 +118,7 @@ class Predictor:
             self.hp_ranges_for_prediction().to_ndarray_matrix(candidates)
         )
 
-    def current_best(self) -> List[np.ndarray]:
+    def current_best(self) -> list[np.ndarray]:
         """
         Returns the so-called incumbent, to be used in acquisition functions
         such as expected improvement. This is the minimum of predictive means
@@ -144,8 +138,8 @@ class Predictor:
         raise NotImplementedError
 
     def backward_gradient(
-        self, input: np.ndarray, head_gradients: List[Dict[str, np.ndarray]]
-    ) -> List[np.ndarray]:
+        self, input: np.ndarray, head_gradients: list[dict[str, np.ndarray]]
+    ) -> list[np.ndarray]:
         r"""
         Computes the gradient :math:`\nabla_x f(x)` for an acquisition
         function :math:`f(x)`, where :math:`x` is a single input point. This
@@ -169,7 +163,7 @@ class Predictor:
 # This is needed for multi-output BO methods such as legacy_constrained BO, where each output
 # is associated to a predictor. This type includes the Union with the standard
 # Predictor type for backward compatibility.
-OutputPredictor = Union[Predictor, Dict[str, Predictor]]
+OutputPredictor = Union[Predictor, dict[str, Predictor]]
 
 
 class ScoringFunction:
@@ -190,7 +184,7 @@ class ScoringFunction:
         self,
         candidates: Iterable[Configuration],
         predictor: Optional[OutputPredictor] = None,
-    ) -> List[float]:
+    ) -> list[float]:
         """
         :param candidates: Configurations for which scores are to be computed
         :param predictor: Overrides default  predictor
@@ -221,7 +215,7 @@ class AcquisitionFunction(ScoringFunction):
 
     def compute_acq_with_gradient(
         self, input: np.ndarray, predictor: Optional[OutputPredictor] = None
-    ) -> Tuple[float, np.ndarray]:
+    ) -> tuple[float, np.ndarray]:
         r"""
         For a single input point :math:`x`, compute acquisition function value
         :math:`f(x)` and gradient :math:`\nabla_x f(x)`.
@@ -236,7 +230,7 @@ class AcquisitionFunction(ScoringFunction):
         self,
         candidates: Iterable[Configuration],
         predictor: Optional[OutputPredictor] = None,
-    ) -> List[float]:
+    ) -> list[float]:
         if predictor is None:
             predictor = self.predictor
         if isinstance(predictor, dict):
@@ -312,7 +306,7 @@ class CandidateGenerator:
 
     def generate_candidates_en_bulk(
         self, num_cands: int, exclusion_list: Optional[ExclusionList] = None
-    ) -> List[Configuration]:
+    ) -> list[Configuration]:
         """
         :param num_cands: Number of candidates to generate
         :param exclusion_list: If given, these candidates must not be returned

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/bo_algorithm.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/bo_algorithm.py
@@ -1,4 +1,5 @@
-from typing import List, Tuple, Iterator, Optional
+from typing import Optional
+from collections.abc import Iterator
 import logging
 from dataclasses import dataclass
 import numpy as np
@@ -102,7 +103,7 @@ class BayesianOptimizationAlgorithm(NextCandidatesAlgorithm):
     # model changes are managed by ``pending_candidate_state_transformer``. The
     # model has to be passed to both ``initial_candidates_scorer`` and
     # ``local_optimizer``.
-    def next_candidates(self) -> List[Configuration]:
+    def next_candidates(self) -> list[Configuration]:
         if self.greedy_batch_selection:
             # Select batch greedily, one candidate at a time, updating the
             # model in between
@@ -265,7 +266,7 @@ class BayesianOptimizationAlgorithm(NextCandidatesAlgorithm):
 
 
 def _order_candidates(
-    candidates: List[Configuration],
+    candidates: list[Configuration],
     scoring_function: ScoringFunction,
     predictor: Optional[Predictor],
     with_scores: bool = False,
@@ -282,11 +283,11 @@ def _order_candidates(
 
 
 def _lazily_locally_optimize(
-    candidates: List[Configuration],
+    candidates: list[Configuration],
     local_optimizer: LocalOptimizer,
     hp_ranges: HyperparameterRanges,
     predictor: Optional[Predictor],
-) -> Iterator[Tuple[Configuration, Configuration]]:
+) -> Iterator[tuple[Configuration, Configuration]]:
     """
     Due to local deduplication we do not know in advance how many candidates
     we have to locally optimize, hence this helper to create a lazy generator
@@ -305,11 +306,11 @@ def _lazily_locally_optimize(
 # principle arise if ``sample_unique_candidates == False``. This does not work
 # if ``duplicate_detector`` is of type :class:`DuplicateDetectorNoDetection`.
 def _pick_from_locally_optimized(
-    candidates_with_optimization: Iterator[Tuple[Configuration, Configuration]],
+    candidates_with_optimization: Iterator[tuple[Configuration, Configuration]],
     exclusion_candidates: ExclusionList,
     num_candidates: int,
     duplicate_detector: DuplicateDetector,
-) -> List[Configuration]:
+) -> list[Configuration]:
     updated_excludelist = exclusion_candidates.copy()
     result = []
     for original_candidate, optimized_candidate in candidates_with_optimization:

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/bo_algorithm_components.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/bo_algorithm_components.py
@@ -1,4 +1,5 @@
-from typing import Iterable, List, Optional, Iterator
+from typing import Optional
+from collections.abc import Iterable, Iterator
 import numpy as np
 from scipy.optimize import fmin_l_bfgs_b
 import logging
@@ -48,7 +49,7 @@ class IndependentThompsonSampling(ScoringFunction):
         self,
         candidates: Iterable[Configuration],
         predictor: Optional[Predictor] = None,
-    ) -> List[float]:
+    ) -> list[float]:
         if predictor is None:
             predictor = self.predictor
         predictions_list = predictor.predict_candidates(candidates)
@@ -159,7 +160,7 @@ class RandomStatefulCandidateGenerator(CandidateGenerator):
 
     def generate_candidates_en_bulk(
         self, num_cands: int, exclusion_list=None
-    ) -> List[Configuration]:
+    ) -> list[Configuration]:
         if exclusion_list is None:
             return self.hp_ranges.random_configs(self.random_state, num_cands)
         else:
@@ -198,7 +199,7 @@ def generate_unique_candidates(
     candidates_generator: CandidateGenerator,
     num_candidates: int,
     exclusion_candidates: ExclusionList,
-) -> List[Configuration]:
+) -> list[Configuration]:
     exclusion_candidates = exclusion_candidates.copy()  # Copy
     result = []
     num_results = 0
@@ -249,7 +250,7 @@ class RandomFromSetCandidateGenerator(CandidateGenerator):
 
     def __init__(
         self,
-        base_set: List[Configuration],
+        base_set: list[Configuration],
         random_state: np.random.RandomState,
         ext_config: Optional[Configuration] = None,
     ):
@@ -267,7 +268,7 @@ class RandomFromSetCandidateGenerator(CandidateGenerator):
             config = self._extend_configs([self.base_set[pos]])[0]
             yield config
 
-    def _extend_configs(self, configs: List[Configuration]) -> List[Configuration]:
+    def _extend_configs(self, configs: list[Configuration]) -> list[Configuration]:
         if self._ext_config is None:
             return configs
         else:
@@ -275,7 +276,7 @@ class RandomFromSetCandidateGenerator(CandidateGenerator):
 
     def generate_candidates_en_bulk(
         self, num_cands: int, exclusion_list=None
-    ) -> List[Configuration]:
+    ) -> list[Configuration]:
         if num_cands >= self.num_base:
             if exclusion_list is None:
                 configs = self.base_set.copy()

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/utils/comparison_gpy.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/utils/comparison_gpy.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any
+from typing import Any
 import numpy as np
 import copy
 
@@ -98,7 +98,7 @@ def evaluate_blackbox(bb_func, inputs: np.ndarray) -> np.ndarray:
 # blackbox are done. This avoids silly errors.
 def sample_data(
     bb_cls, num_train: int, num_grid: int, expand_datadct: bool = True
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     bb_func = bb_cls()
     ss_limits = bb_func.search_space
     num_dims = len(ss_limits)
@@ -126,7 +126,7 @@ def sample_data(
     return data
 
 
-def expand_data(data: Dict[str, Any]) -> Dict[str, Any]:
+def expand_data(data: dict[str, Any]) -> dict[str, Any]:
     """
     Appends derived entries to data dict, which have non-elementary types.
     """
@@ -147,7 +147,7 @@ def expand_data(data: Dict[str, Any]) -> Dict[str, Any]:
 
 # Recall that inputs in data are encoded, so we have to decode them to their
 # native ranges for ``trials_evaluations``
-def data_to_state(data: Dict[str, Any]) -> TuningJobState:
+def data_to_state(data: dict[str, Any]) -> TuningJobState:
     configs, cs = decode_inputs(data["train_inputs"], data["ss_limits"])
     config_for_trial = {
         str(trial_id): config for trial_id, config in enumerate(configs)
@@ -163,7 +163,7 @@ def data_to_state(data: Dict[str, Any]) -> TuningJobState:
     )
 
 
-def decode_inputs(inputs: np.ndarray, ss_limits) -> (List[Configuration], Dict):
+def decode_inputs(inputs: np.ndarray, ss_limits) -> (list[Configuration], dict):
     cs_names = [f"x{i}" for i in range(len(ss_limits))]
     cs = {
         name: uniform(lower=lims["min"], upper=lims["max"])

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/utils/debug_log.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/utils/debug_log.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any
+from typing import Any
 import logging
 import numpy as np
 
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 __all__ = ["DebugLogPrinter"]
 
 
-def _param_dict_to_str(params: Dict[str, Any]) -> str:
+def _param_dict_to_str(params: dict[str, Any]) -> str:
     parts = []
     for name, param in params.items():
         if isinstance(param, float):
@@ -62,7 +62,7 @@ class DebugLogPrinter:
         msg = "\n".join(entries)
         self.block_info["final_config"] = msg
 
-    def _observed_trial_ids(self, state: TuningJobState) -> List[str]:
+    def _observed_trial_ids(self, state: TuningJobState) -> list[str]:
         trial_ids = []
         for ev in state.trials_evaluations:
             trial_id = ev.trial_id
@@ -75,7 +75,7 @@ class DebugLogPrinter:
                     trial_ids.append(trial_id)
         return trial_ids
 
-    def _pending_trial_ids(self, state: TuningJobState) -> List[str]:
+    def _pending_trial_ids(self, state: TuningJobState) -> list[str]:
         trial_ids = []
         for ev in state.pending_evaluations:
             trial_id = ev.trial_id
@@ -100,7 +100,7 @@ class DebugLogPrinter:
         msg = "Targets: " + str(targets.reshape((-1,)))
         self.block_info["targets"] = msg
 
-    def set_model_params(self, params: Dict[str, Any]):
+    def set_model_params(self, params: dict[str, Any]):
         assert self.get_config_type == "BO", "Need to be in 'BO' block"
         msg = "Model params: " + _param_dict_to_str(params)
         self.block_info["params"] = msg

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/utils/test_objects.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/utils/test_objects.py
@@ -4,7 +4,8 @@
 Object definitions that are used for testing.
 """
 
-from typing import Iterator, Tuple, Dict, List, Optional, Union
+from collections.abc import Iterator
+from typing import Optional, Union
 import numpy as np
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common import (
@@ -134,8 +135,8 @@ class Quadratic3d:
 
 
 def tuples_to_configs(
-    config_tpls: List[Tuple[Hyperparameter, ...]], hp_ranges: HyperparameterRanges
-) -> List[Configuration]:
+    config_tpls: list[tuple[Hyperparameter, ...]], hp_ranges: HyperparameterRanges
+) -> list[Configuration]:
     """
     Many unit tests write configs as tuples.
 
@@ -160,10 +161,10 @@ TupleOrDict = Union[tuple, dict]
 
 def create_tuning_job_state(
     hp_ranges: HyperparameterRanges,
-    cand_tuples: List[TupleOrDict],
-    metrics: List[Dict],
-    pending_tuples: Optional[List[TupleOrDict]] = None,
-    failed_tuples: Optional[List[TupleOrDict]] = None,
+    cand_tuples: list[TupleOrDict],
+    metrics: list[dict],
+    pending_tuples: Optional[list[TupleOrDict]] = None,
+    failed_tuples: Optional[list[TupleOrDict]] = None,
 ) -> TuningJobState:
     """
     Builds ``TuningJobState`` from basics, where configs are given as tuples or

--- a/syne_tune/optimizer/schedulers/searchers/bore/bore.py
+++ b/syne_tune/optimizer/schedulers/searchers/bore/bore.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any
+from typing import Optional, Any
 import time
 import xgboost
 import logging
@@ -58,8 +58,8 @@ class Bore(SingleObjectiveBaseSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        points_to_evaluate: Optional[List[Dict[str, Any]]] = None,
+        config_space: dict[str, Any],
+        points_to_evaluate: Optional[list[dict[str, Any]]] = None,
         random_seed: int = None,
         gamma: Optional[float] = 0.25,
         calibrate: Optional[bool] = False,
@@ -244,7 +244,7 @@ class Bore(SingleObjectiveBaseSearcher):
     def on_trial_complete(
         self,
         trial_id: int,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         metric: float,
         resource_level: int = None,
     ):

--- a/syne_tune/optimizer/schedulers/searchers/bore/legacy_bore.py
+++ b/syne_tune/optimizer/schedulers/searchers/bore/legacy_bore.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any
+from typing import Optional, Any
 import time
 import xgboost
 import logging
@@ -54,11 +54,11 @@ class LegacyBore(StochasticAndFilterDuplicatesSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
         allow_duplicates: Optional[bool] = None,
-        restrict_configurations: Optional[List[Dict[str, Any]]] = None,
+        restrict_configurations: Optional[list[dict[str, Any]]] = None,
         mode: Optional[str] = None,
         gamma: Optional[float] = None,
         calibrate: Optional[bool] = None,
@@ -262,9 +262,9 @@ class LegacyBore(StochasticAndFilterDuplicatesSearcher):
         )
         return True
 
-    def _update(self, trial_id: str, config: Dict[str, Any], result: Dict[str, Any]):
+    def _update(self, trial_id: str, config: dict[str, Any], result: dict[str, Any]):
         self.inputs.append(self._hp_ranges.to_ndarray(config))
         self.targets.append(result[self._metric])
 
-    def clone_from_state(self, state: Dict[str, Any]):
+    def clone_from_state(self, state: dict[str, Any]):
         raise NotImplementedError

--- a/syne_tune/optimizer/schedulers/searchers/bore/legacy_multi_fidelity_bore.py
+++ b/syne_tune/optimizer/schedulers/searchers/bore/legacy_multi_fidelity_bore.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any
+from typing import Optional, Any
 import logging
 import numpy as np
 
@@ -34,9 +34,9 @@ class LegacyMultiFidelityBore(LegacyBore):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
         allow_duplicates: Optional[bool] = None,
         mode: Optional[str] = None,
         gamma: Optional[float] = None,
@@ -102,7 +102,7 @@ class LegacyMultiFidelityBore(LegacyBore):
 
         return super()._train_model(train_data, train_targets)
 
-    def _update(self, trial_id: str, config: Dict[str, Any], result: Dict[str, Any]):
+    def _update(self, trial_id: str, config: dict[str, Any], result: dict[str, Any]):
         super()._update(trial_id=trial_id, config=config, result=result)
         resource_level = int(result[self.resource_attr])
         self.resource_levels.append(resource_level)

--- a/syne_tune/optimizer/schedulers/searchers/botorch/botorch_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/botorch/botorch_searcher.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any
+from typing import Optional, Any
 import logging
 
 import numpy as np
@@ -58,8 +58,8 @@ class BoTorchSearcher(SingleObjectiveBaseSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        points_to_evaluate: Optional[List[dict]] = None,
+        config_space: dict[str, Any],
+        points_to_evaluate: Optional[list[dict]] = None,
         num_init_random: int = 3,
         no_fantasizing: bool = False,
         max_num_observations: Optional[int] = 200,
@@ -87,7 +87,7 @@ class BoTorchSearcher(SingleObjectiveBaseSearcher):
     def on_trial_complete(
         self,
         trial_id: int,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         metric: float,
     ):
         trial_id = int(trial_id)
@@ -222,7 +222,7 @@ class BoTorchSearcher(SingleObjectiveBaseSearcher):
             warp_tf = None
         return SingleTaskGP(X_tensor, Y_tensor, input_transform=warp_tf)
 
-    def _config_to_feature_matrix(self, configs: List[dict]) -> Tensor:
+    def _config_to_feature_matrix(self, configs: list[dict]) -> Tensor:
         bounds = Tensor(self._hp_ranges.get_ndarray_bounds()).T
         X = Tensor(self._hp_ranges.to_ndarray_matrix(configs))
         return normalize(X, bounds)
@@ -230,14 +230,14 @@ class BoTorchSearcher(SingleObjectiveBaseSearcher):
     def objectives(self):
         return np.array(list(self.trial_observations.values()))
 
-    def _configs_with_results(self) -> List[dict]:
+    def _configs_with_results(self) -> list[dict]:
         return [
             config
             for trial, config in self.trial_configs.items()
             if not trial in self.pending_trials
         ]
 
-    def _configs_pending(self) -> List[dict]:
+    def _configs_pending(self) -> list[dict]:
         return [
             config
             for trial, config in self.trial_configs.items()

--- a/syne_tune/optimizer/schedulers/searchers/botorch/botorch_transfer_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/botorch/botorch_transfer_searcher.py
@@ -2,7 +2,7 @@ import copy
 import logging
 
 import numpy as np
-from typing import Optional, List, Dict, Any
+from typing import Optional, Any
 
 
 try:
@@ -34,7 +34,7 @@ def parse_value(val):
         return val
 
 
-def configs_from_df(df) -> List[dict]:
+def configs_from_df(df) -> list[dict]:
     return [
         {key: parse_value(df[key][ii]) for key in df.keys()} for ii in range(len(df))
     ]
@@ -45,7 +45,7 @@ class BoTorchTransfer(BoTorch):
         self,
         config_space: dict,
         metric: str,
-        transfer_learning_evaluations: Dict[str, LegacyTransferLearningTaskEvaluations],
+        transfer_learning_evaluations: dict[str, LegacyTransferLearningTaskEvaluations],
         new_task_id: Any,
         random_seed: Optional[int] = None,
         encode_tasks_ordinal: bool = False,
@@ -72,9 +72,9 @@ class BoTorchTransferSearcher(LegacyBoTorchSearcher):
         self,
         config_space: dict,
         metric: str,
-        transfer_learning_evaluations: Dict[str, LegacyTransferLearningTaskEvaluations],
+        transfer_learning_evaluations: dict[str, LegacyTransferLearningTaskEvaluations],
         new_task_id: Any,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
         allow_duplicates: bool = False,
         num_init_random: int = 0,
         encode_tasks_ordinal: bool = False,
@@ -139,7 +139,7 @@ class BoTorchTransferSearcher(LegacyBoTorchSearcher):
         return ext_config
 
     def _config_to_feature_matrix(
-        self, configs: List[dict], task_val: Optional[str] = None
+        self, configs: list[dict], task_val: Optional[str] = None
     ) -> Tensor:
         if task_val is None:
             task_val = self._new_task_id
@@ -169,7 +169,7 @@ class BoTorchTransferSearcher(LegacyBoTorchSearcher):
     def _config_from_ndarray(self, candidate) -> dict:
         return self._ext_hp_ranges.from_ndarray(candidate)
 
-    def _configs_with_results(self) -> List[dict]:
+    def _configs_with_results(self) -> list[dict]:
         # List of configs for which we have results
         this_task = [
             self._extend_config_with_task(config, self._new_task_id)

--- a/syne_tune/optimizer/schedulers/searchers/botorch/legacy_botorch_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/botorch/legacy_botorch_searcher.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any
+from typing import Optional, Any
 import logging
 
 import numpy as np
@@ -57,11 +57,11 @@ class LegacyBoTorchSearcher(StochasticAndFilterDuplicatesSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
         allow_duplicates: bool = False,
-        restrict_configurations: Optional[List[Dict[str, Any]]] = None,
+        restrict_configurations: Optional[list[dict[str, Any]]] = None,
         mode: str = "min",
         num_init_random: int = 3,
         no_fantasizing: bool = False,
@@ -91,13 +91,13 @@ class LegacyBoTorchSearcher(StochasticAndFilterDuplicatesSearcher):
         if "random_seed" in kwargs:
             random.manual_seed(kwargs["random_seed"])
 
-    def _update(self, trial_id: str, config: Dict[str, Any], result: Dict[str, Any]):
+    def _update(self, trial_id: str, config: dict[str, Any], result: dict[str, Any]):
         trial_id = int(trial_id)
         self.trial_observations[trial_id] = result[self._metric]
         if trial_id in self.pending_trials:
             self.pending_trials.remove(trial_id)
 
-    def clone_from_state(self, state: Dict[str, Any]):
+    def clone_from_state(self, state: dict[str, Any]):
         raise NotImplementedError
 
     def num_suggestions(self):
@@ -244,7 +244,7 @@ class LegacyBoTorchSearcher(StochasticAndFilterDuplicatesSearcher):
             warp_tf = None
         return SingleTaskGP(X_tensor, Y_tensor, input_transform=warp_tf)
 
-    def _config_to_feature_matrix(self, configs: List[dict]) -> Tensor:
+    def _config_to_feature_matrix(self, configs: list[dict]) -> Tensor:
         bounds = Tensor(self._hp_ranges.get_ndarray_bounds()).T
         X = Tensor(self._hp_ranges.to_ndarray_matrix(configs))
         return normalize(X, bounds)
@@ -270,21 +270,21 @@ class LegacyBoTorchSearcher(StochasticAndFilterDuplicatesSearcher):
         else:
             return self._get_random_config()
 
-    def _configs_with_results(self) -> List[dict]:
+    def _configs_with_results(self) -> list[dict]:
         return [
             config
             for trial, config in self.trial_configs.items()
             if not trial in self.pending_trials
         ]
 
-    def _configs_pending(self) -> List[dict]:
+    def _configs_pending(self) -> list[dict]:
         return [
             config
             for trial, config in self.trial_configs.items()
             if trial in self.pending_trials
         ]
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return [self._metric]
 
     def metric_mode(self) -> str:
@@ -298,9 +298,9 @@ class LegacyBotorchSearcher(LegacyBoTorchSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
         **kwargs,
     ):
         super().__init__(

--- a/syne_tune/optimizer/schedulers/searchers/conformal/conformal_quantile_regression_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/conformal/conformal_quantile_regression_searcher.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-from typing import Dict, Optional, List, Any
+from typing import Optional, Any
 
 import numpy as np
 import pandas as pd
@@ -25,9 +25,9 @@ logger = logging.getLogger(__name__)
 class ConformalQuantileRegression(SingleObjectiveBaseSearcher):
     def __init__(
         self,
-        config_space: Dict,
+        config_space: dict,
         random_seed: Optional[int] = None,
-        points_to_evaluate: Optional[List[Dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
         num_init_random_draws: int = 5,
         update_frequency: int = 1,
         max_fit_samples: int = None,
@@ -71,7 +71,7 @@ class ConformalQuantileRegression(SingleObjectiveBaseSearcher):
         self.surrogate_cls = surrogate_cls
         self.random_state = np.random.RandomState(self.random_seed)
 
-    def suggest(self, **kwargs) -> Optional[Dict[str, Any]]:
+    def suggest(self, **kwargs) -> Optional[dict[str, Any]]:
         config = self._next_points_to_evaluate()
 
         if config is None:
@@ -129,18 +129,18 @@ class ConformalQuantileRegression(SingleObjectiveBaseSearcher):
     def on_trial_complete(
         self,
         trial_id: int,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         metric: float,
         resource_level: int = None,
     ):
         self.trial_configs[trial_id] = config
         self.trial_results[trial_id].append(metric)
 
-    def sample_random(self) -> Dict:
+    def sample_random(self) -> dict:
         return {
             k: v.sample(random_state=self.random_state) if isinstance(v, Domain) else v
             for k, v in self.config_space.items()
         }
 
-    def configs_to_df(self, configs: List[Dict]) -> pd.DataFrame:
+    def configs_to_df(self, configs: list[dict]) -> pd.DataFrame:
         return pd.DataFrame(configs)

--- a/syne_tune/optimizer/schedulers/searchers/conformal/legacy_surrogate_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/conformal/legacy_surrogate_searcher.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-from typing import Dict, Optional, List
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -23,12 +23,12 @@ logger = logging.getLogger(__name__)
 class LegacySurrogateSearcher(StochasticSearcher):
     def __init__(
         self,
-        config_space: Dict,
+        config_space: dict,
         metric: str,
         mode: str = "min",
         num_init_random_draws: int = 5,
         update_frequency: int = 1,
-        points_to_evaluate: Optional[List[Dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
         max_fit_samples: int = None,
         random_seed: Optional[int] = None,
         **surrogate_kwargs,
@@ -132,22 +132,22 @@ class LegacySurrogateSearcher(StochasticSearcher):
         self.surrogate_model.fit(df_features=X, y=z)
 
     def on_trial_result(
-        self, trial_id: str, config: Dict, result: Dict, update: bool = True
+        self, trial_id: str, config: dict, result: dict, update: bool = True
     ):
         trial_id = int(trial_id)
         y = result[self.metric]
         self.trial_results[trial_id].append(y)
 
-    def sample_random(self) -> Dict:
+    def sample_random(self) -> dict:
         return {
             k: v.sample(random_state=self.random_state) if isinstance(v, Domain) else v
             for k, v in self.config_space.items()
         }
 
-    def configs_to_df(self, configs: List[Dict]) -> pd.DataFrame:
+    def configs_to_df(self, configs: list[dict]) -> pd.DataFrame:
         return pd.DataFrame(configs)
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return [self.metric]
 
     def metric_mode(self) -> str:

--- a/syne_tune/optimizer/schedulers/searchers/conformal/surrogate/conformalized_quantile_regression_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/conformal/surrogate/conformalized_quantile_regression_model.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Union, List, Dict
+from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -32,11 +32,11 @@ class ConformalQuantileCorrection:
 
 
 class ConformalizedGradientBoostingQuantileRegressor(GradientBoostingQuantileRegressor):
-    conformal_correction: Dict[float, ConformalQuantileCorrection] = None
+    conformal_correction: dict[float, ConformalQuantileCorrection] = None
 
     def __init__(
         self,
-        quantiles: Union[int, List[float]] = 9,
+        quantiles: Union[int, list[float]] = 9,
         valid_fraction: float = 0.10,
         verbose: bool = False,
         **kwargs

--- a/syne_tune/optimizer/schedulers/searchers/conformal/surrogate/quantile_regression_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/conformal/surrogate/quantile_regression_model.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, Union, List
+from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -10,7 +10,7 @@ from tqdm import tqdm
 
 @dataclass
 class QuantileRegressorPredictions:
-    quantiles: List[float]
+    quantiles: list[float]
     results_stacked: np.ndarray
 
     def results(self, quantile: float) -> np.ndarray:
@@ -25,7 +25,7 @@ class QuantileRegressorPredictions:
 
     @classmethod
     def from_quantile_results(
-        cls, quantiles: List[float], results: Dict[float, np.ndarray]
+        cls, quantiles: list[float], results: dict[float, np.ndarray]
     ):
         listres = [results[item] for item in quantiles]
         results_stacked = np.stack(listres, axis=1)
@@ -43,7 +43,7 @@ class QuantileRegressorPredictions:
 
 
 class QuantileRegressor:
-    quantiles: List[float]
+    quantiles: list[float]
 
     def predict(self, df_test: pd.DataFrame) -> QuantileRegressorPredictions:
         raise NotImplementedError()
@@ -52,7 +52,7 @@ class QuantileRegressor:
 class GradientBoostingQuantileRegressor(QuantileRegressor, GradientBoostingRegressor):
     def __init__(
         self,
-        quantiles: Union[int, List[float]] = 5,
+        quantiles: Union[int, list[float]] = 5,
         verbose: bool = False,
         valid_fraction: float = 0.0,
         **kwargs,

--- a/syne_tune/optimizer/schedulers/searchers/conformal/surrogate/quantile_regression_surrogate.py
+++ b/syne_tune/optimizer/schedulers/searchers/conformal/surrogate/quantile_regression_surrogate.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Dict, Optional
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -23,7 +23,7 @@ from syne_tune.optimizer.schedulers.transfer_learning.quantile_based.legacy_quan
 class QuantileRegressionSurrogateModel(SurrogateModel):
     def __init__(
         self,
-        config_space: Dict,
+        config_space: dict,
         mode: str,
         random_state: Optional[np.random.RandomState] = None,
         max_fit_samples: Optional[int] = None,

--- a/syne_tune/optimizer/schedulers/searchers/conformal/surrogate/surrogate_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/conformal/surrogate/surrogate_model.py
@@ -2,7 +2,7 @@ import logging
 
 import pandas as pd
 import numpy as np
-from typing import Dict, Optional, Tuple, List, Union
+from typing import Optional, Union
 
 from syne_tune.config_space import Domain
 
@@ -10,7 +10,7 @@ from syne_tune.config_space import Domain
 class SurrogateModel:
     def __init__(
         self,
-        config_space: Dict,
+        config_space: dict,
         mode: str,
         max_fit_samples: Optional[int] = None,
         random_state: Optional[np.random.RandomState] = None,
@@ -71,7 +71,7 @@ class SurrogateModel:
         z_pred = self._sampler()
         return z_pred
 
-    def predict(self, df_features: pd.DataFrame) -> Tuple[np.array, np.array]:
+    def predict(self, df_features: pd.DataFrame) -> tuple[np.array, np.array]:
         """
         :param df_features: input features to make predictions with shape (n, d)
         :return: predictions in the shape of (n,)
@@ -115,13 +115,13 @@ class SurrogateModel:
         self.df_candidates = self._configs_to_df(self.config_candidates)
         self._sampler = self._get_sampler(self.df_candidates)
 
-    def _sample_random(self) -> Dict:
+    def _sample_random(self) -> dict:
         return {
             k: v.sample(random_state=self.random_state) if isinstance(v, Domain) else v
             for k, v in self.config_space.items()
         }
 
-    def _configs_to_df(self, configs: List[Dict]) -> pd.DataFrame:
+    def _configs_to_df(self, configs: list[dict]) -> pd.DataFrame:
         return pd.DataFrame(configs)
 
     def _config_already_seen(self, config) -> bool:

--- a/syne_tune/optimizer/schedulers/searchers/kde/kde_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/kde/kde_searcher.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any, Tuple
+from typing import Optional, Any
 import logging
 import numpy as np
 import statsmodels.api as sm
@@ -62,8 +62,8 @@ class KernelDensityEstimator(SingleObjectiveBaseSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        points_to_evaluate: Optional[List[dict]] = None,
+        config_space: dict[str, Any],
+        points_to_evaluate: Optional[list[dict]] = None,
         num_min_data_points: Optional[int] = None,
         top_n_percent: int = 15,
         min_bandwidth: float = 1e-3,
@@ -195,7 +195,7 @@ class KernelDensityEstimator(SingleObjectiveBaseSearcher):
     def on_trial_complete(
         self,
         trial_id: int,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         metric: float,
     ):
         self.X.append(self._to_feature(config=config))
@@ -207,7 +207,7 @@ class KernelDensityEstimator(SingleObjectiveBaseSearcher):
             for k, v in self.config_space.items()
         }
 
-    def suggest(self, **kwargs) -> Optional[Dict[str, Any]]:
+    def suggest(self, **kwargs) -> Optional[dict[str, Any]]:
         suggestion = self._next_points_to_evaluate()
         if suggestion is None:
             if self.y:
@@ -291,7 +291,7 @@ class KernelDensityEstimator(SingleObjectiveBaseSearcher):
         return suggestion
 
     def _check_data_shape_and_good_size(
-        self, data_shape: Tuple[int, int]
+        self, data_shape: tuple[int, int]
     ) -> Optional[int]:
         """
         Determine size of data for "good" model (the rest of the data is for the
@@ -313,7 +313,7 @@ class KernelDensityEstimator(SingleObjectiveBaseSearcher):
 
     def _train_kde(
         self, train_data: np.ndarray, train_targets: np.ndarray
-    ) -> Optional[Tuple[Any, Any]]:
+    ) -> Optional[tuple[Any, Any]]:
         train_data = train_data.reshape((train_targets.size, -1))
         n_good = self._check_data_shape_and_good_size(train_data.shape)
         if n_good is None:

--- a/syne_tune/optimizer/schedulers/searchers/kde/legacy_kde_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/kde/legacy_kde_searcher.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any, Tuple
+from typing import Optional, Any
 import logging
 import numpy as np
 import statsmodels.api as sm
@@ -70,9 +70,9 @@ class LegacyKernelDensityEstimator(StochasticAndFilterDuplicatesSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
         allow_duplicates: Optional[bool] = None,
         mode: Optional[str] = None,
         num_min_data_points: Optional[int] = None,
@@ -239,13 +239,13 @@ class LegacyKernelDensityEstimator(StochasticAndFilterDuplicatesSearcher):
         ), "This searcher requires TrialSchedulerWithSearcher scheduler"
         super().configure_scheduler(scheduler)
 
-    def _to_objective(self, result: Dict[str, Any]) -> float:
+    def _to_objective(self, result: dict[str, Any]) -> float:
         if self._mode == "min":
             return result[self._metric]
         else:
             return -result[self._metric]
 
-    def _update(self, trial_id: str, config: Dict[str, Any], result: Dict[str, Any]):
+    def _update(self, trial_id: str, config: dict[str, Any], result: dict[str, Any]):
         self.X.append(self._to_feature(config=config))
         self.y.append(self._to_objective(result))
         if self._debug_log is not None:
@@ -257,7 +257,7 @@ class LegacyKernelDensityEstimator(StochasticAndFilterDuplicatesSearcher):
             msg = f"Update for trial_id {trial_id}: metric = {metric_val:.3f}"
             logger.info(msg)
 
-    def _get_config(self, **kwargs) -> Optional[Dict[str, Any]]:
+    def _get_config(self, **kwargs) -> Optional[dict[str, Any]]:
         suggestion = self._next_initial_config()
         if suggestion is None:
             if self.y:
@@ -343,7 +343,7 @@ class LegacyKernelDensityEstimator(StochasticAndFilterDuplicatesSearcher):
         return suggestion
 
     def _check_data_shape_and_good_size(
-        self, data_shape: Tuple[int, int]
+        self, data_shape: tuple[int, int]
     ) -> Optional[int]:
         """
         Determine size of data for "good" model (the rest of the data is for the
@@ -365,7 +365,7 @@ class LegacyKernelDensityEstimator(StochasticAndFilterDuplicatesSearcher):
 
     def _train_kde(
         self, train_data: np.ndarray, train_targets: np.ndarray
-    ) -> Optional[Tuple[Any, Any]]:
+    ) -> Optional[tuple[Any, Any]]:
         train_data = train_data.reshape((train_targets.size, -1))
         n_good = self._check_data_shape_and_good_size(train_data.shape)
         if n_good is None:
@@ -388,5 +388,5 @@ class LegacyKernelDensityEstimator(StochasticAndFilterDuplicatesSearcher):
 
         return bad_kde, good_kde
 
-    def clone_from_state(self, state: Dict[str, Any]):
+    def clone_from_state(self, state: dict[str, Any]):
         raise NotImplementedError

--- a/syne_tune/optimizer/schedulers/searchers/kde/legacy_multi_fidelity_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/kde/legacy_multi_fidelity_searcher.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, List, Any, Tuple
+from typing import Optional, Any
 import logging
 import numpy as np
 
@@ -30,9 +30,9 @@ class LegacyMultiFidelityKernelDensityEstimator(LegacyKernelDensityEstimator):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
         allow_duplicates: Optional[bool] = None,
         mode: Optional[str] = None,
         num_min_data_points: Optional[int] = None,
@@ -85,7 +85,7 @@ class LegacyMultiFidelityKernelDensityEstimator(LegacyKernelDensityEstimator):
 
     def _train_kde(
         self, train_data: np.ndarray, train_targets: np.ndarray
-    ) -> Optional[Tuple[Any, Any]]:
+    ) -> Optional[tuple[Any, Any]]:
         """
         Find the highest resource level so that the data only at that level is
         large enough to train KDE models both on the good part and the rest.
@@ -107,7 +107,7 @@ class LegacyMultiFidelityKernelDensityEstimator(LegacyKernelDensityEstimator):
             sub_targets = train_targets[indices]
             return super()._train_kde(sub_data, sub_targets)
 
-    def _update(self, trial_id: str, config: Dict, result: Dict):
+    def _update(self, trial_id: str, config: dict, result: dict):
         super()._update(trial_id=trial_id, config=config, result=result)
         resource_level = int(result[self.resource_attr])
         self.resource_levels.append(resource_level)

--- a/syne_tune/optimizer/schedulers/searchers/last_value_multi_fidelity_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/last_value_multi_fidelity_searcher.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-from typing import Dict, Optional, List, Any, Union
+from typing import Optional, Any, Union
 
 import numpy as np
 import pandas as pd
@@ -20,9 +20,9 @@ logger = logging.getLogger(__name__)
 class LastValueMultiFidelitySearcher(SingleObjectiveBaseSearcher):
     def __init__(
         self,
-        config_space: Dict,
+        config_space: dict,
         random_seed: Optional[int] = None,
-        points_to_evaluate: Optional[List[Dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
         num_init_random_draws: int = 5,
         update_frequency: int = 1,
         max_fit_samples: int = None,
@@ -75,7 +75,7 @@ class LastValueMultiFidelitySearcher(SingleObjectiveBaseSearcher):
             self.searcher_cls = searcher_cls
         self.searcher = None
 
-    def suggest(self, **kwargs) -> Optional[Dict[str, Any]]:
+    def suggest(self, **kwargs) -> Optional[dict[str, Any]]:
         config = self._next_points_to_evaluate()
 
         if config is None:
@@ -137,7 +137,7 @@ class LastValueMultiFidelitySearcher(SingleObjectiveBaseSearcher):
     def on_trial_complete(
         self,
         trial_id: int,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         metric: float,
         resource_level: int = None,
     ):
@@ -147,18 +147,18 @@ class LastValueMultiFidelitySearcher(SingleObjectiveBaseSearcher):
     def on_trial_result(
         self,
         trial_id: int,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         metric: float,
         resource_level: int = None,
     ):
         self.trial_configs[trial_id] = config
         self.trial_results[trial_id].append(metric)
 
-    def sample_random(self) -> Dict:
+    def sample_random(self) -> dict:
         return {
             k: v.sample(random_state=self.random_state) if isinstance(v, Domain) else v
             for k, v in self.config_space.items()
         }
 
-    def configs_to_df(self, configs: List[Dict]) -> pd.DataFrame:
+    def configs_to_df(self, configs: list[dict]) -> pd.DataFrame:
         return pd.DataFrame(configs)

--- a/syne_tune/optimizer/schedulers/searchers/legacy_constrained/constrained_gp_fifo_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/legacy_constrained/constrained_gp_fifo_searcher.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Dict, Any
+from typing import Optional, Any
 import logging
 
 from syne_tune.optimizer.schedulers.searchers.legacy_cost_aware.cost_aware_gp_fifo_searcher import (
@@ -36,9 +36,9 @@ class ConstrainedGPFIFOSearcher(MultiModelGPFIFOSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
         **kwargs,
     ):
         assert kwargs.get("constraint_attr") is not None, (
@@ -60,7 +60,7 @@ class ConstrainedGPFIFOSearcher(MultiModelGPFIFOSearcher):
         return kwargs_int
 
     def _copy_kwargs_to_kwargs_int(
-        self, kwargs_int: Dict[str, Any], kwargs: Dict[str, Any]
+        self, kwargs_int: dict[str, Any], kwargs: dict[str, Any]
     ):
         super()._copy_kwargs_to_kwargs_int(kwargs_int, kwargs)
         k = "constraint_attr"
@@ -70,7 +70,7 @@ class ConstrainedGPFIFOSearcher(MultiModelGPFIFOSearcher):
         self._constraint_attr = kwargs_int.pop("constraint_attr")
         super()._call_create_internal(kwargs_int)
 
-    def _update(self, trial_id: str, config: Dict[str, Any], result: Dict[str, Any]):
+    def _update(self, trial_id: str, config: dict[str, Any], result: dict[str, Any]):
         # We can call the superclass method, because
         # ``state_transformer.label_trial`` can be called two times
         # with parts of the metrics

--- a/syne_tune/optimizer/schedulers/searchers/legacy_cost_aware/cost_aware_gp_fifo_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/legacy_cost_aware/cost_aware_gp_fifo_searcher.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional, Dict, Any
+from typing import Optional, Any
 
 from syne_tune.optimizer.schedulers.searchers.legacy_gp_fifo_searcher import (
     GPFIFOSearcher,
@@ -92,9 +92,9 @@ class CostAwareGPFIFOSearcher(MultiModelGPFIFOSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
         **kwargs,
     ):
         assert kwargs.get("cost_attr") is not None, (

--- a/syne_tune/optimizer/schedulers/searchers/legacy_cost_aware/cost_aware_gp_multifidelity_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/legacy_cost_aware/cost_aware_gp_multifidelity_searcher.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Dict, Any
+from typing import Optional, Any
 import logging
 
 from syne_tune.optimizer.schedulers.searchers.legacy_gp_multifidelity_searcher import (
@@ -87,9 +87,9 @@ class CostAwareGPMultiFidelitySearcher(MultiModelGPMultiFidelitySearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
         **kwargs,
     ):
         assert kwargs.get("cost_attr") is not None, (

--- a/syne_tune/optimizer/schedulers/searchers/legacy_dyhpo/dyhpo_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/legacy_dyhpo/dyhpo_searcher.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any, Tuple
+from typing import Optional, Any
 import logging
 import numpy as np
 
@@ -42,7 +42,7 @@ INTERNAL_KEY = "RESERVED_KEY_31415927"
 
 # DEBUG:
 def _debug_print_info(
-    resource: int, scores: List[float], acq_function: EIAcquisitionFunction
+    resource: int, scores: list[float], acq_function: EIAcquisitionFunction
 ):
     msg_parts = [
         f"Summary scores [resource = {resource}]",
@@ -63,7 +63,7 @@ class MyGPMultiFidelitySearcher(GPMultiFidelitySearcher):
     :class:`~syne_tune.optimizer.schedulers.searchers.GPMultiFidelitySearcher`.
     """
 
-    def __init__(self, config_space: Dict[str, Any], **kwargs):
+    def __init__(self, config_space: dict[str, Any], **kwargs):
         assert (
             INTERNAL_KEY not in config_space
         ), f"Key {INTERNAL_KEY} must not be used in config_space (reserved)"
@@ -84,8 +84,8 @@ class MyGPMultiFidelitySearcher(GPMultiFidelitySearcher):
         return {INTERNAL_KEY: "dummy"}
 
     def _extended_configs_from_paused(
-        self, paused_trials: List[Tuple[str, int, int]], state: TuningJobState
-    ) -> List[Dict[str, Any]]:
+        self, paused_trials: list[tuple[str, int, int]], state: TuningJobState
+    ) -> list[dict[str, Any]]:
         return [
             self.config_space_ext.get(state.config_for_trial[trial_id], resource)
             for trial_id, _, resource in paused_trials
@@ -97,7 +97,7 @@ class MyGPMultiFidelitySearcher(GPMultiFidelitySearcher):
         min_resource: int,
         exclusion_candidates: ExclusionList,
         random_generator: CandidateGenerator,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         return [
             self.config_space_ext.get(config, min_resource)
             for config in random_generator.generate_candidates_en_bulk(
@@ -112,8 +112,8 @@ class MyGPMultiFidelitySearcher(GPMultiFidelitySearcher):
         end: int,
         predictor: BasePredictor,
         sorted_ind: np.ndarray,
-        configs_all: List[Dict[str, Any]],
-    ) -> (List[float], np.ndarray):
+        configs_all: list[dict[str, Any]],
+    ) -> (list[float], np.ndarray):
         def my_filter_observed_data(config: Configuration) -> bool:
             return self.config_space_ext.get_resource(config) == resource
 
@@ -140,11 +140,11 @@ class MyGPMultiFidelitySearcher(GPMultiFidelitySearcher):
 
     def score_paused_trials_and_new_configs(
         self,
-        paused_trials: List[Tuple[str, int, int]],
+        paused_trials: list[tuple[str, int, int]],
         min_resource: int,
         new_trial_id: str,
         skip_optimization: bool,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         See :meth:`DynamicHPOSearcher.score_paused_trials_and_new_configs`.
         If ``skip_optimization == True``, this is passed to the posterior state
@@ -295,9 +295,9 @@ class DynamicHPOSearcher(LegacyBaseSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
         **kwargs,
     ):
         mode = kwargs.get("mode")
@@ -337,8 +337,8 @@ class DynamicHPOSearcher(LegacyBaseSearcher):
     def on_trial_result(
         self,
         trial_id: str,
-        config: Dict[str, Any],
-        result: Dict[str, Any],
+        config: dict[str, Any],
+        result: dict[str, Any],
         update: bool,
     ):
         self._searcher_int.on_trial_result(trial_id, config, result, update)
@@ -368,10 +368,10 @@ class DynamicHPOSearcher(LegacyBaseSearcher):
 
     def score_paused_trials_and_new_configs(
         self,
-        paused_trials: List[Tuple[str, int, int]],
+        paused_trials: list[tuple[str, int, int]],
         min_resource: int,
         new_trial_id: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         This method computes acquisition scores for a number of extended
         configs :math:`(x, r)`. The acquisition score :math:`EI(x | r)` is
@@ -410,16 +410,16 @@ class DynamicHPOSearcher(LegacyBaseSearcher):
         self._previous_winner_new_trial = "config" in result
         return result
 
-    def get_state(self) -> Dict[str, Any]:
+    def get_state(self) -> dict[str, Any]:
         return {
             "searcher_int": self._searcher_int.get_state(),
             "previous_winner_new_trial": self._previous_winner_new_trial,
         }
 
-    def _restore_from_state(self, state: Dict[str, Any]):
+    def _restore_from_state(self, state: dict[str, Any]):
         raise NotImplementedError
 
-    def clone_from_state(self, state: Dict[str, Any]):
+    def clone_from_state(self, state: dict[str, Any]):
         searcher_int = self._searcher_int.clone_from_state(state["searcher_int"])
         return DynamicHPOSearcher(
             self.config_space,

--- a/syne_tune/optimizer/schedulers/searchers/legacy_dyhpo/hyperband_dyhpo.py
+++ b/syne_tune/optimizer/schedulers/searchers/legacy_dyhpo/hyperband_dyhpo.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any, Tuple
+from typing import Any
 from numpy.random import RandomState
 import logging
 from collections import Counter
@@ -82,8 +82,8 @@ class DyHPORungSystem(PromotionRungSystem):
 
     def __init__(
         self,
-        rung_levels: List[int],
-        promote_quantiles: List[float],
+        rung_levels: list[int],
+        promote_quantiles: list[float],
         metric: str,
         mode: str,
         resource_attr: str,
@@ -113,7 +113,7 @@ class DyHPORungSystem(PromotionRungSystem):
         self._schedule_records = []
 
     @staticmethod
-    def _check_rung_levels(rung_levels: List[int]):
+    def _check_rung_levels(rung_levels: list[int]):
         if len(rung_levels) > 1:
             rmin = rung_levels[0]
             step = rung_levels[1] - rmin
@@ -126,7 +126,7 @@ class DyHPORungSystem(PromotionRungSystem):
                     f"{rung_levels} is not recommended"
                 )
 
-    def _paused_trials_and_milestones(self) -> List[Tuple[str, int, int]]:
+    def _paused_trials_and_milestones(self) -> list[tuple[str, int, int]]:
         """
         Return list of all trials which are paused. Entries are
         ``(trial_id, pos, resource)``, where ``pos`` is the position of the trial
@@ -147,7 +147,7 @@ class DyHPORungSystem(PromotionRungSystem):
             next_level = level
         return paused_trials
 
-    def on_task_schedule(self, new_trial_id: str) -> Dict[str, Any]:
+    def on_task_schedule(self, new_trial_id: str) -> dict[str, Any]:
         """
         The main decision making happens here. We collect ``(trial_id, resource)``
         for all paused trials and call ``searcher``. The searcher scores all
@@ -212,14 +212,14 @@ class DyHPORungSystem(PromotionRungSystem):
         return ret_dict
 
     @property
-    def schedule_records(self) -> List[Tuple[str, int, int]]:
+    def schedule_records(self) -> list[tuple[str, int, int]]:
         return self._schedule_records
 
     @staticmethod
-    def summary_schedule_keys() -> List[str]:
+    def summary_schedule_keys() -> list[str]:
         return [key for key, _ in _SUMMARY_SCHEDULE_RECORDS]
 
-    def summary_schedule_records(self) -> Dict[str, Any]:
+    def summary_schedule_records(self) -> dict[str, Any]:
         histogram = Counter([x[1] for x in self._schedule_records])
         return {name: histogram[value] for name, value in _SUMMARY_SCHEDULE_RECORDS}
 

--- a/syne_tune/optimizer/schedulers/searchers/legacy_gp_fifo_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/legacy_gp_fifo_searcher.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any
+from typing import Optional, Any
 import logging
 
 from syne_tune.optimizer.schedulers.searchers.legacy_model_based_searcher import (
@@ -242,9 +242,9 @@ class GPFIFOSearcher(BayesianOptimizationSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        points_to_evaluate: Optional[List[Dict[str, Any]]] = None,
+        points_to_evaluate: Optional[list[dict[str, Any]]] = None,
         clone_from_state: bool = False,
         **kwargs,
     ):

--- a/syne_tune/optimizer/schedulers/searchers/legacy_gp_multifidelity_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/legacy_gp_multifidelity_searcher.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any
+from typing import Optional, Any
 import logging
 
 from syne_tune.optimizer.schedulers.searchers.legacy_gp_searcher_factory import (
@@ -125,9 +125,9 @@ class GPMultiFidelitySearcher(GPFIFOSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
         **kwargs,
     ):
         super().__init__(
@@ -176,12 +176,12 @@ class GPMultiFidelitySearcher(GPFIFOSearcher):
         return self.config_space_ext.get(config, resource)
 
     def _metric_val_update(
-        self, crit_val: float, result: Dict[str, Any]
+        self, crit_val: float, result: dict[str, Any]
     ) -> MetricValues:
         resource = result[self._resource_attr]
         return {str(resource): crit_val}
 
-    def _trial_id_string(self, trial_id: str, result: Dict[str, Any]):
+    def _trial_id_string(self, trial_id: str, result: dict[str, Any]):
         """
         For multi-fidelity, we also want to output the resource level
         """
@@ -234,7 +234,7 @@ class GPMultiFidelitySearcher(GPFIFOSearcher):
                     f"Score values computed at target_resource = {target_resource}"
                 )
 
-    def _postprocess_config(self, config: Dict[str, Any]) -> Dict[str, Any]:
+    def _postprocess_config(self, config: dict[str, Any]) -> dict[str, Any]:
         # If ``config`` is normal (not extended), nothing is removed
         return self.config_space_ext.remove_resource(config)
 

--- a/syne_tune/optimizer/schedulers/searchers/legacy_gp_searcher_factory.py
+++ b/syne_tune/optimizer/schedulers/searchers/legacy_gp_searcher_factory.py
@@ -1,4 +1,4 @@
-from typing import Set, Optional, Dict, Any
+from typing import Optional, Any
 import logging
 from functools import partial
 
@@ -205,7 +205,7 @@ def _create_gp_common(hp_ranges: HyperparameterRanges, **kwargs):
 
 def _create_gp_estimator(
     gpmodel,
-    result: Dict[str, Any],
+    result: dict[str, Any],
     hp_ranges_for_prediction: Optional[HyperparameterRanges],
     active_metric: Optional[str],
     **kwargs,
@@ -547,7 +547,7 @@ def _create_acq_function(**kwargs):
     return acquisition_function_factory(name, **af_kwargs)
 
 
-def gp_fifo_searcher_factory(**kwargs) -> Dict[str, Any]:
+def gp_fifo_searcher_factory(**kwargs) -> dict[str, Any]:
     """
     Returns ``kwargs`` for
     :meth:`~syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher._create_internal`,
@@ -578,7 +578,7 @@ def gp_fifo_searcher_factory(**kwargs) -> Dict[str, Any]:
     return dict(**result, acquisition_class=_create_acq_function(**kwargs))
 
 
-def gp_multifidelity_searcher_factory(**kwargs) -> Dict[str, Any]:
+def gp_multifidelity_searcher_factory(**kwargs) -> dict[str, Any]:
     """
     Returns ``kwargs`` for
     :meth:`~syne_tune.optimizer.schedulers.searchers.GPMultiFidelitySearcher._create_internal`,
@@ -617,7 +617,7 @@ def gp_multifidelity_searcher_factory(**kwargs) -> Dict[str, Any]:
     return kwargs_int
 
 
-def hypertune_searcher_factory(**kwargs) -> Dict[str, Any]:
+def hypertune_searcher_factory(**kwargs) -> dict[str, Any]:
     """
     Returns ``kwargs`` for
     :meth:`~syne_tune.optimizer.schedulers.searchers.legacy_hypertune.HyperTuneSearcher._create_internal`,
@@ -638,7 +638,7 @@ def hypertune_searcher_factory(**kwargs) -> Dict[str, Any]:
     return gp_multifidelity_searcher_factory(**kwargs, is_hypertune=True)
 
 
-def constrained_gp_fifo_searcher_factory(**kwargs) -> Dict[str, Any]:
+def constrained_gp_fifo_searcher_factory(**kwargs) -> dict[str, Any]:
     """
     Returns ``kwargs`` for
     :meth:`~syne_tune.optimizer.schedulers.searchers.legacy_constrained.ConstrainedGPFIFOSearcher._create_internal`,
@@ -689,7 +689,7 @@ def constrained_gp_fifo_searcher_factory(**kwargs) -> Dict[str, Any]:
     )
 
 
-def cost_aware_coarse_gp_fifo_searcher_factory(**kwargs) -> Dict[str, Any]:
+def cost_aware_coarse_gp_fifo_searcher_factory(**kwargs) -> dict[str, Any]:
     """
     Returns ``kwargs`` for
     :meth:`~syne_tune.optimizer.schedulers.searchers.legacy_cost_aware.CostAwareGPFIFOSearcher._create_internal`,
@@ -745,7 +745,7 @@ def cost_aware_coarse_gp_fifo_searcher_factory(**kwargs) -> Dict[str, Any]:
     )
 
 
-def cost_aware_fine_gp_fifo_searcher_factory(**kwargs) -> Dict[str, Any]:
+def cost_aware_fine_gp_fifo_searcher_factory(**kwargs) -> dict[str, Any]:
     """
     Returns ``kwargs`` for
     :meth:`~syne_tune.optimizer.schedulers.searchers.legacy_cost_aware.CostAwareGPFIFOSearcher._create_internal`,
@@ -809,7 +809,7 @@ def cost_aware_fine_gp_fifo_searcher_factory(**kwargs) -> Dict[str, Any]:
     )
 
 
-def cost_aware_gp_multifidelity_searcher_factory(**kwargs) -> Dict[str, Any]:
+def cost_aware_gp_multifidelity_searcher_factory(**kwargs) -> dict[str, Any]:
     """
     Returns ``kwargs`` for
     :meth:`~syne_tune.optimizer.schedulers.searchers.legacy_cost_aware.CostAwareGPMultiFidelitySearcher._create_internal`,
@@ -872,12 +872,12 @@ def cost_aware_gp_multifidelity_searcher_factory(**kwargs) -> Dict[str, Any]:
 
 
 def _common_defaults(
-    kwargs: Dict[str, Any],
+    kwargs: dict[str, Any],
     is_hyperband: bool,
     is_multi_output: bool = False,
     is_hypertune: bool = False,
     is_restrict_configs: bool = False,
-) -> (Set[str], dict, dict):
+) -> (set[str], dict, dict):
     mandatory = set()
 
     default_options = {
@@ -981,7 +981,7 @@ def _common_defaults(
     return mandatory, default_options, constraints
 
 
-def gp_fifo_searcher_defaults(kwargs: Dict[str, Any]) -> (Set[str], dict, dict):
+def gp_fifo_searcher_defaults(kwargs: dict[str, Any]) -> (set[str], dict, dict):
     """
     Returns ``mandatory``, ``default_options``, ``config_space`` for
     :func:`~syne_tune.optimizer.schedulers.searchers.utils.default_arguments.check_and_merge_defaults`
@@ -999,8 +999,8 @@ def gp_fifo_searcher_defaults(kwargs: Dict[str, Any]) -> (Set[str], dict, dict):
 
 
 def gp_multifidelity_searcher_defaults(
-    kwargs: Dict[str, Any]
-) -> (Set[str], dict, dict):
+    kwargs: dict[str, Any]
+) -> (set[str], dict, dict):
     """
     Returns ``mandatory``, ``default_options``, ``config_space`` for
     :func:`~syne_tune.optimizer.schedulers.searchers.utils.default_arguments.check_and_merge_defaults`
@@ -1017,7 +1017,7 @@ def gp_multifidelity_searcher_defaults(
     )
 
 
-def hypertune_searcher_defaults(kwargs: Dict[str, Any]) -> (Set[str], dict, dict):
+def hypertune_searcher_defaults(kwargs: dict[str, Any]) -> (set[str], dict, dict):
     """
     Returns ``mandatory``, ``default_options``, ``config_space`` for
     :func:`~syne_tune.optimizer.schedulers.searchers.utils.default_arguments.check_and_merge_defaults`
@@ -1036,8 +1036,8 @@ def hypertune_searcher_defaults(kwargs: Dict[str, Any]) -> (Set[str], dict, dict
 
 
 def constrained_gp_fifo_searcher_defaults(
-    kwargs: Dict[str, Any]
-) -> (Set[str], dict, dict):
+    kwargs: dict[str, Any]
+) -> (set[str], dict, dict):
     """
     Returns ``mandatory``, ``default_options``, ``config_space`` for
     :func:`~syne_tune.optimizer.schedulers.searchers.utils.default_arguments.check_and_merge_defaults` to be applied to ``search_options`` for
@@ -1055,8 +1055,8 @@ def constrained_gp_fifo_searcher_defaults(
 
 
 def cost_aware_gp_fifo_searcher_defaults(
-    kwargs: Dict[str, Any]
-) -> (Set[str], dict, dict):
+    kwargs: dict[str, Any]
+) -> (set[str], dict, dict):
     """
     Returns ``mandatory``, ``default_options``, ``config_space`` for
     :func:`~syne_tune.optimizer.schedulers.searchers.utils.default_arguments.check_and_merge_defaults`
@@ -1075,8 +1075,8 @@ def cost_aware_gp_fifo_searcher_defaults(
 
 
 def cost_aware_gp_multifidelity_searcher_defaults(
-    kwargs: Dict[str, Any]
-) -> (Set[str], dict, dict):
+    kwargs: dict[str, Any]
+) -> (set[str], dict, dict):
     """
     Returns ``mandatory``, ``default_options``, ``config_space`` for
     :func:`~syne_tune.optimizer.schedulers.searchers.utils.default_arguments.check_and_merge_defaults`

--- a/syne_tune/optimizer/schedulers/searchers/legacy_gp_searcher_utils.py
+++ b/syne_tune/optimizer/schedulers/searchers/legacy_gp_searcher_utils.py
@@ -1,5 +1,7 @@
 from collections import Counter
-from typing import Callable, Dict, Any
+from collections.abc import Callable
+from typing import Any
+
 from dataclasses import dataclass
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.tuning_job_state import (
@@ -41,7 +43,7 @@ SUPPORTED_INITIAL_SCORING = {"thompson_indep", "acq_func"}
 DEFAULT_INITIAL_SCORING = "thompson_indep"
 
 
-def encode_state(state: TuningJobState) -> Dict[str, Any]:
+def encode_state(state: TuningJobState) -> dict[str, Any]:
     trials_evaluations = [
         {"trial_id": x.trial_id, "metrics": x.metrics} for x in state.trials_evaluations
     ]
@@ -61,7 +63,7 @@ def encode_state(state: TuningJobState) -> Dict[str, Any]:
 
 
 def decode_state(
-    enc_state: Dict[str, Any], hp_ranges: HyperparameterRanges
+    enc_state: dict[str, Any], hp_ranges: HyperparameterRanges
 ) -> TuningJobState:
     trials_evaluations = [
         TrialEvaluations(**x) for x in enc_state["trials_evaluations"]
@@ -80,9 +82,9 @@ def decode_state(
 
 def _get_trial_id(
     hp_ranges: HyperparameterRanges,
-    config: Dict[str, Any],
-    config_for_trial: Dict[str, Any],
-    trial_for_config: Dict[str, Any],
+    config: dict[str, Any],
+    config_for_trial: dict[str, Any],
+    trial_for_config: dict[str, Any],
 ) -> str:
     match_str = hp_ranges.config_to_match_string(config, skip_last=True)
     trial_id = trial_for_config.get(match_str)
@@ -94,7 +96,7 @@ def _get_trial_id(
 
 
 def decode_state_from_old_encoding(
-    enc_state: Dict[str, Any], hp_ranges: HyperparameterRanges
+    enc_state: dict[str, Any], hp_ranges: HyperparameterRanges
 ) -> TuningJobState:
     """
     Decodes ``TuningJobState`` from encoding done for the old definition of
@@ -223,7 +225,7 @@ SUPPORTED_RESOURCE_FOR_ACQUISITION = {"bohb", "first", "final"}
 
 
 def resource_for_acquisition_factory(
-    kwargs: Dict[str, Any], hp_ranges: HyperparameterRanges
+    kwargs: dict[str, Any], hp_ranges: HyperparameterRanges
 ) -> ResourceForAcquisitionMap:
     resource_acq = kwargs.get("resource_acq", "bohb")
     assert (

--- a/syne_tune/optimizer/schedulers/searchers/legacy_hypertune/hypertune_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/legacy_hypertune/hypertune_searcher.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 import logging
 
 from syne_tune.optimizer.schedulers.searchers import GPMultiFidelitySearcher
@@ -84,7 +84,7 @@ class HyperTuneSearcher(GPMultiFidelitySearcher):
         """
         return self.hp_ranges
 
-    def _postprocess_config(self, config: Dict[str, Any]) -> Dict[str, Any]:
+    def _postprocess_config(self, config: dict[str, Any]) -> dict[str, Any]:
         """
         Different to :class:`GPMultiFidelitySearcher`, we need non-extended
         configs here.

--- a/syne_tune/optimizer/schedulers/searchers/legacy_model_based_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/legacy_model_based_searcher.py
@@ -1,5 +1,5 @@
 import time
-from typing import Optional, Type, Dict, Any, List
+from typing import Optional, Type, Any
 import logging
 import numpy as np
 import copy
@@ -118,7 +118,7 @@ class ModelBasedSearcher(StochasticSearcher):
         filter_observed_data: Optional[ConfigurationFilter] = None,
         state_converter: Optional[StateForModelConverter] = None,
         allow_duplicates: bool = False,
-        restrict_configurations: List[Dict[str, Any]] = None,
+        restrict_configurations: list[dict[str, Any]] = None,
     ):
         self.hp_ranges = hp_ranges
         self.num_initial_candidates = num_initial_candidates
@@ -188,7 +188,7 @@ class ModelBasedSearcher(StochasticSearcher):
             logger.info("\n".join(msg_parts))
 
     def _copy_kwargs_to_kwargs_int(
-        self, kwargs_int: Dict[str, Any], kwargs: Dict[str, Any]
+        self, kwargs_int: dict[str, Any], kwargs: dict[str, Any]
     ):
         """Copies extra arguments not dealt with by ``gp_fifo_searcher_factory``
 
@@ -219,15 +219,15 @@ class ModelBasedSearcher(StochasticSearcher):
         return self._hp_ranges_in_state()
 
     def _metric_val_update(
-        self, crit_val: float, result: Dict[str, Any]
+        self, crit_val: float, result: dict[str, Any]
     ) -> MetricValues:
         return crit_val
 
     def on_trial_result(
         self,
         trial_id: str,
-        config: Dict[str, Any],
-        result: Dict[str, Any],
+        config: dict[str, Any],
+        result: dict[str, Any],
         update: bool,
     ):
         # If both ``cost_attr`` and ``resource_attr`` are given, cost data (if
@@ -249,13 +249,13 @@ class ModelBasedSearcher(StochasticSearcher):
         if update:
             self._update(trial_id, config, result)
 
-    def _trial_id_string(self, trial_id: str, result: Dict[str, Any]):
+    def _trial_id_string(self, trial_id: str, result: dict[str, Any]):
         """
         For multi-fidelity, we also want to output the resource level
         """
         return trial_id
 
-    def _update(self, trial_id: str, config: Dict[str, Any], result: Dict[str, Any]):
+    def _update(self, trial_id: str, config: dict[str, Any], result: dict[str, Any]):
         metric_val = result[self._metric]
         # Reject NaN or infinite values
         if np.isnan(metric_val) or np.isinf(metric_val):
@@ -364,7 +364,7 @@ class ModelBasedSearcher(StochasticSearcher):
                 )
         return config, pick_random
 
-    def get_config(self, **kwargs) -> Optional[Dict[str, Any]]:
+    def get_config(self, **kwargs) -> Optional[dict[str, Any]]:
         """
         Runs Bayesian optimization in order to suggest the next config to evaluate.
 
@@ -424,7 +424,7 @@ class ModelBasedSearcher(StochasticSearcher):
     def set_params(self, param_dict):
         self.state_transformer.set_params(param_dict)
 
-    def get_state(self) -> Dict[str, Any]:
+    def get_state(self) -> dict[str, Any]:
         """
         The mutable state consists of the GP model parameters, the
         ``TuningJobState``, and the ``skip_optimization`` predicate (which can have a
@@ -445,7 +445,7 @@ class ModelBasedSearcher(StochasticSearcher):
             state["restrict_configurations"] = self._restrict_configurations
         return state
 
-    def _restore_from_state(self, state: Dict[str, Any]):
+    def _restore_from_state(self, state: dict[str, Any]):
         super()._restore_from_state(state)
         self.state_transformer.set_params(state["model_params"])
         self._restrict_configurations = state.get("restrict_configurations")
@@ -536,7 +536,7 @@ class BayesianOptimizationSearcher(ModelBasedSearcher):
             estimator.configure_scheduler(scheduler)
 
     def register_pending(
-        self, trial_id: str, config: Optional[Dict[str, Any]] = None, milestone=None
+        self, trial_id: str, config: Optional[dict[str, Any]] = None, milestone=None
     ):
         """
         Registers trial as pending. This means the corresponding evaluation
@@ -553,7 +553,7 @@ class BayesianOptimizationSearcher(ModelBasedSearcher):
     def _fix_resource_attribute(self, **kwargs):
         pass
 
-    def _postprocess_config(self, config: Dict[str, Any]) -> Dict[str, Any]:
+    def _postprocess_config(self, config: dict[str, Any]) -> dict[str, Any]:
         return config
 
     def _create_random_generator(self) -> CandidateGenerator:
@@ -576,7 +576,7 @@ class BayesianOptimizationSearcher(ModelBasedSearcher):
 
     def _update_restrict_configurations(
         self,
-        new_configs: List[Dict[str, Any]],
+        new_configs: list[dict[str, Any]],
         random_generator: RandomFromSetCandidateGenerator,
     ):
         # ``random_generator`` maintains all positions returned during the
@@ -656,7 +656,7 @@ class BayesianOptimizationSearcher(ModelBasedSearcher):
         batch_size: int,
         num_init_candidates_for_batch: Optional[int] = None,
         **kwargs,
-    ) -> List[Configuration]:
+    ) -> list[Configuration]:
         """
         Asks for a batch of ``batch_size`` configurations to be suggested. This
         is roughly equivalent to calling ``get_config`` ``batch_size`` times,
@@ -771,7 +771,7 @@ class BayesianOptimizationSearcher(ModelBasedSearcher):
         # future get_config calls)
         self.state_transformer.mark_trial_failed(trial_id)
 
-    def _new_searcher_kwargs_for_clone(self) -> Dict[str, Any]:
+    def _new_searcher_kwargs_for_clone(self) -> dict[str, Any]:
         """
         Helper method for ``clone_from_state``. Args need to be extended
         by ``estimator``, ``init_state``, ``skip_optimization``, and others

--- a/syne_tune/optimizer/schedulers/searchers/legacy_random_grid_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/legacy_random_grid_searcher.py
@@ -1,7 +1,7 @@
 import logging
 from collections import OrderedDict
 from itertools import product
-from typing import Optional, List, Dict, Union, Any
+from typing import Optional, Union, Any
 
 import numpy as np
 
@@ -41,13 +41,13 @@ class LegacyRandomSearcher(StochasticAndFilterDuplicatesSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        metric: Union[List[str], str],
-        points_to_evaluate: Optional[List[dict]] = None,
+        config_space: dict[str, Any],
+        metric: Union[list[str], str],
+        points_to_evaluate: Optional[list[dict]] = None,
         debug_log: Union[bool, DebugLogPrinter] = False,
         resource_attr: Optional[str] = None,
         allow_duplicates: Optional[bool] = None,
-        restrict_configurations: Optional[List[Dict[str, Any]]] = None,
+        restrict_configurations: Optional[list[dict[str, Any]]] = None,
         **kwargs,
     ):
         super().__init__(
@@ -112,7 +112,7 @@ class LegacyRandomSearcher(StochasticAndFilterDuplicatesSearcher):
             logger.warning(msg)
         return new_config
 
-    def _update(self, trial_id: str, config: Dict[str, Any], result: Dict[str, Any]):
+    def _update(self, trial_id: str, config: dict[str, Any], result: dict[str, Any]):
         if self._debug_log is not None:
             if self._resource_attr is not None:
                 # For HyperbandScheduler, also add the resource attribute
@@ -126,7 +126,7 @@ class LegacyRandomSearcher(StochasticAndFilterDuplicatesSearcher):
                 msg += f"{result[self._metric]:.3f}"
             logger.info(msg)
 
-    def clone_from_state(self, state: Dict[str, Any]):
+    def clone_from_state(self, state: dict[str, Any]):
         new_searcher = LegacyRandomSearcher(
             self.config_space,
             metric=self._metric,
@@ -171,10 +171,10 @@ class GridSearcher(StochasticSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        points_to_evaluate: Optional[List[dict]] = None,
-        num_samples: Optional[Dict[str, int]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
+        num_samples: Optional[dict[str, int]] = None,
         shuffle_config: bool = True,
         allow_duplicates: bool = False,
         **kwargs,
@@ -198,7 +198,7 @@ class GridSearcher(StochasticSearcher):
         self._all_initial_configs = ExclusionList(self._hp_ranges)
 
     def _validate_config_space(
-        self, config_space: Dict[str, Any], num_samples: Optional[Dict[str, int]]
+        self, config_space: dict[str, Any], num_samples: Optional[dict[str, int]]
     ):
         """
         Validates ``config_space`` from two aspects: first, that all
@@ -337,7 +337,7 @@ class GridSearcher(StochasticSearcher):
                 self._all_initial_configs = ExclusionList(self._hp_ranges)
         return candidate
 
-    def get_state(self) -> Dict[str, Any]:
+    def get_state(self) -> dict[str, Any]:
         state = dict(
             super().get_state(),
             next_index=self._next_index,
@@ -345,7 +345,7 @@ class GridSearcher(StochasticSearcher):
         )
         return state
 
-    def clone_from_state(self, state: Dict[str, Any]):
+    def clone_from_state(self, state: dict[str, Any]):
         new_searcher = GridSearcher(
             config_space=self.config_space,
             num_samples=self.num_samples,
@@ -355,11 +355,11 @@ class GridSearcher(StochasticSearcher):
         new_searcher._restore_from_state(state)
         return new_searcher
 
-    def _restore_from_state(self, state: Dict[str, Any]):
+    def _restore_from_state(self, state: dict[str, Any]):
         super()._restore_from_state(state)
         self._next_index = state["next_index"]
         self._all_initial_configs = ExclusionList(self._hp_ranges)
         self._all_initial_configs.clone_from_state(state["all_initial_configs"])
 
-    def _update(self, trial_id: str, config: Dict[str, Any], result: Dict[str, Any]):
+    def _update(self, trial_id: str, config: dict[str, Any], result: dict[str, Any]):
         pass

--- a/syne_tune/optimizer/schedulers/searchers/legacy_regularized_evolution.py
+++ b/syne_tune/optimizer/schedulers/searchers/legacy_regularized_evolution.py
@@ -2,7 +2,7 @@ import copy
 import logging
 
 from collections import deque
-from typing import Optional, List, Dict, Any, Union
+from typing import Optional, Any, Union
 from dataclasses import dataclass
 
 from syne_tune.optimizer.schedulers.searchers import StochasticSearcher
@@ -17,9 +17,9 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class PopulationElement:
-    result: Dict[str, Any] = None
+    result: dict[str, Any] = None
     score: int = 0
-    config: Dict[str, Any] = None
+    config: dict[str, Any] = None
 
 
 class LegacyRegularizedEvolution(StochasticSearcher):
@@ -49,8 +49,8 @@ class LegacyRegularizedEvolution(StochasticSearcher):
     def __init__(
         self,
         config_space,
-        metric: Union[List[str], str],
-        points_to_evaluate: Optional[List[dict]] = None,
+        metric: Union[list[str], str],
+        points_to_evaluate: Optional[list[dict]] = None,
         population_size: int = 100,
         sample_size: int = 10,
         **kwargs,
@@ -79,7 +79,7 @@ class LegacyRegularizedEvolution(StochasticSearcher):
             if isinstance(domain, Domain) and len(domain) != 1
         ]
 
-    def _mutate_config(self, config: Dict[str, Any]) -> Dict[str, Any]:
+    def _mutate_config(self, config: dict[str, Any]) -> dict[str, Any]:
         child_config = copy.deepcopy(config)
         config_ms = self._hp_ranges.config_to_match_string(config)
         # Sample mutation until a different configuration is found
@@ -104,7 +104,7 @@ class LegacyRegularizedEvolution(StochasticSearcher):
 
         return child_config
 
-    def _sample_random_config(self) -> Dict[str, Any]:
+    def _sample_random_config(self) -> dict[str, Any]:
         return sample_random_configuration(self._hp_ranges, self.random_state)
 
     def get_config(self, **kwargs) -> Optional[dict]:
@@ -124,7 +124,7 @@ class LegacyRegularizedEvolution(StochasticSearcher):
 
         return config
 
-    def _update(self, trial_id: str, config: Dict[str, Any], result: Dict[str, Any]):
+    def _update(self, trial_id: str, config: dict[str, Any], result: dict[str, Any]):
         score = result[self._metric]
 
         if self._mode == "max":
@@ -148,5 +148,5 @@ class LegacyRegularizedEvolution(StochasticSearcher):
         ), "This searcher requires TrialSchedulerWithSearcher scheduler"
         super().configure_scheduler(scheduler)
 
-    def clone_from_state(self, state: Dict[str, Any]):
+    def clone_from_state(self, state: dict[str, Any]):
         raise NotImplementedError

--- a/syne_tune/optimizer/schedulers/searchers/legacy_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/legacy_searcher.py
@@ -1,6 +1,6 @@
 import logging
 import numpy as np
-from typing import Optional, List, Tuple, Dict, Any, Union
+from typing import Optional, Any, Union
 
 from syne_tune.config_space import (
     Domain,
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 def _impute_default_config(
-    default_config: Configuration, config_space: Dict[str, Any]
+    default_config: Configuration, config_space: dict[str, Any]
 ) -> Configuration:
     """Imputes missing values in ``default_config`` by mid-point rule
 
@@ -94,17 +94,17 @@ def _non_default_config(hp_range: Domain) -> Hyperparameter:
     return midpoint
 
 
-def _to_tuple(config: Dict[str, Any], keys: List) -> Tuple:
+def _to_tuple(config: dict[str, Any], keys: list) -> tuple:
     return tuple(config[k] for k in keys)
 
 
-def _sorted_keys(config_space: Dict[str, Any]) -> List[str]:
+def _sorted_keys(config_space: dict[str, Any]) -> list[str]:
     return sorted(k for k, v in config_space.items() if isinstance(v, Domain))
 
 
 def impute_points_to_evaluate(
-    points_to_evaluate: Optional[List[Dict[str, Any]]], config_space: Dict[str, Any]
-) -> List[Dict[str, Any]]:
+    points_to_evaluate: Optional[list[dict[str, Any]]], config_space: dict[str, Any]
+) -> list[dict[str, Any]]:
     """
     Transforms ``points_to_evaluate`` argument to
     :class:`~syne_tune.optimizer.schedulers.searchers.BaseSearcher`. Each
@@ -165,10 +165,10 @@ class LegacyBaseSearcher:
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        metric: Union[List[str], str],
-        points_to_evaluate: Optional[List[Dict[str, Any]]] = None,
-        mode: Union[List[str], str] = "min",
+        config_space: dict[str, Any],
+        metric: Union[list[str], str],
+        points_to_evaluate: Optional[list[dict[str, Any]]] = None,
+        mode: Union[list[str], str] = "min",
     ):
         self.config_space = config_space
         assert metric is not None, "Argument 'metric' is required"
@@ -202,7 +202,7 @@ class LegacyBaseSearcher:
         if hasattr(scheduler, "mode"):
             self._mode = getattr(scheduler, "mode")
 
-    def _next_initial_config(self) -> Optional[Dict[str, Any]]:
+    def _next_initial_config(self) -> Optional[dict[str, Any]]:
         """
         :return: Next entry from remaining ``points_to_evaluate`` (popped
             from front), or None
@@ -212,7 +212,7 @@ class LegacyBaseSearcher:
         else:
             return None  # No more initial configs
 
-    def get_config(self, **kwargs) -> Optional[Dict[str, Any]]:
+    def get_config(self, **kwargs) -> Optional[dict[str, Any]]:
         """Suggest a new configuration.
 
         Note: Query :meth:`_next_initial_config` for initial configs to return
@@ -231,8 +231,8 @@ class LegacyBaseSearcher:
     def on_trial_result(
         self,
         trial_id: str,
-        config: Dict[str, Any],
-        result: Dict[str, Any],
+        config: dict[str, Any],
+        result: dict[str, Any],
         update: bool,
     ):
         """Inform searcher about result
@@ -253,7 +253,7 @@ class LegacyBaseSearcher:
         if update:
             self._update(trial_id, config, result)
 
-    def _update(self, trial_id: str, config: Dict[str, Any], result: Dict[str, Any]):
+    def _update(self, trial_id: str, config: dict[str, Any], result: dict[str, Any]):
         """Update surrogate model with result
 
         :param trial_id: See :meth:`~syne_tune.optimizer.schedulers.TrialScheduler.on_trial_result`
@@ -265,7 +265,7 @@ class LegacyBaseSearcher:
     def register_pending(
         self,
         trial_id: str,
-        config: Optional[Dict[str, Any]] = None,
+        config: Optional[dict[str, Any]] = None,
         milestone: Optional[int] = None,
     ):
         """
@@ -329,7 +329,7 @@ class LegacyBaseSearcher:
         """
         return dict()
 
-    def get_state(self) -> Dict[str, Any]:
+    def get_state(self) -> dict[str, Any]:
         """
         Together with :meth:`clone_from_state`, this is needed in order to
         store and re-create the mutable state of the searcher.
@@ -339,7 +339,7 @@ class LegacyBaseSearcher:
         """
         return {"points_to_evaluate": self._points_to_evaluate}
 
-    def clone_from_state(self, state: Dict[str, Any]):
+    def clone_from_state(self, state: dict[str, Any]):
         """
         Together with :meth:`get_state`, this is needed in order to store and
         re-create the mutable state of the searcher.
@@ -354,7 +354,7 @@ class LegacyBaseSearcher:
         """
         raise NotImplementedError
 
-    def _restore_from_state(self, state: Dict[str, Any]):
+    def _restore_from_state(self, state: dict[str, Any]):
         self._points_to_evaluate = state["points_to_evaluate"].copy()
 
     @property

--- a/syne_tune/optimizer/schedulers/searchers/multi_fidelity_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/multi_fidelity_searcher.py
@@ -1,7 +1,7 @@
 import logging
 from collections import defaultdict
 
-from typing import Dict, Any, Optional, List, Union
+from typing import Any, Optional, Union
 
 from syne_tune.optimizer.schedulers.searchers.searcher import BaseSearcher
 from syne_tune.optimizer.schedulers.searchers.single_objective_searcher import (
@@ -30,9 +30,9 @@ class IndependentMultiFidelitySearcher(BaseSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         searcher_cls: Optional[Union[str, SingleObjectiveBaseSearcher]] = "kde",
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
         random_seed: Optional[int] = None,
         searcher_kwargs: dict[str, Any] = None,
     ):
@@ -61,7 +61,7 @@ class IndependentMultiFidelitySearcher(BaseSearcher):
             )
         )
 
-    def suggest(self, **kwargs) -> Optional[Dict[str, Any]]:
+    def suggest(self, **kwargs) -> Optional[dict[str, Any]]:
         """Suggest a new configuration.
 
         Note: Query :meth:`_next_points_to_evaluate` for initial configs to return
@@ -92,7 +92,7 @@ class IndependentMultiFidelitySearcher(BaseSearcher):
     def on_trial_result(
         self,
         trial_id: int,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         metric: float,
         resource_level: int,
     ):
@@ -111,7 +111,7 @@ class IndependentMultiFidelitySearcher(BaseSearcher):
     def on_trial_complete(
         self,
         trial_id: int,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         metric: float,
         resource_level: int,
     ):

--- a/syne_tune/optimizer/schedulers/searchers/random_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/random_searcher.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, List, Dict, Any
+from typing import Optional, Any
 
 from syne_tune.optimizer.schedulers.searchers.searcher import BaseSearcher
 from syne_tune.optimizer.schedulers.searchers.single_objective_searcher import (
@@ -26,8 +26,8 @@ class RandomSearcher(SingleObjectiveBaseSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        points_to_evaluate: Optional[List[dict]] = None,
+        config_space: dict[str, Any],
+        points_to_evaluate: Optional[list[dict]] = None,
         random_seed: int = None,
     ):
         super().__init__(
@@ -55,8 +55,8 @@ class MultiObjectiveRandomSearcher(BaseSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        points_to_evaluate: Optional[List[dict]] = None,
+        config_space: dict[str, Any],
+        points_to_evaluate: Optional[list[dict]] = None,
         random_seed: int = None,
     ):
         super().__init__(

--- a/syne_tune/optimizer/schedulers/searchers/regularized_evolution.py
+++ b/syne_tune/optimizer/schedulers/searchers/regularized_evolution.py
@@ -4,7 +4,7 @@ import logging
 import numpy as np
 
 from collections import deque
-from typing import Optional, List, Dict, Any
+from typing import Optional, Any
 from dataclasses import dataclass
 
 from syne_tune.config_space import config_space_size, non_constant_hyperparameter_keys
@@ -19,16 +19,16 @@ logger = logging.getLogger(__name__)
 @dataclass
 class PopulationElement:
     score: float = 0
-    config: Dict[str, Any] = None
-    results: List[float] = None
+    config: dict[str, Any] = None
+    results: list[float] = None
 
 
 def mutate_config(
-    config: Dict[str, Any],
-    config_space: Dict[str, Any],
+    config: dict[str, Any],
+    config_space: dict[str, Any],
     rng: np.random.RandomState,
     num_try: int = 1000,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
 
     child_config = copy.deepcopy(config)
     hp_name = rng.choice(non_constant_hyperparameter_keys(config_space))
@@ -44,8 +44,8 @@ def mutate_config(
 
 
 def sample_random_config(
-    config_space: Dict[str, Any], rng: np.random.RandomState
-) -> Dict[str, Any]:
+    config_space: dict[str, Any], rng: np.random.RandomState
+) -> dict[str, Any]:
     return {
         k: v.sample() if hasattr(v, "sample") else v for k, v in config_space.items()
     }
@@ -76,7 +76,7 @@ class RegularizedEvolution(SingleObjectiveBaseSearcher):
     def __init__(
         self,
         config_space,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
         population_size: int = 100,
         sample_size: int = 10,
         random_seed: int = None,
@@ -118,7 +118,7 @@ class RegularizedEvolution(SingleObjectiveBaseSearcher):
     def on_trial_complete(
         self,
         trial_id: int,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         metric: float,
     ):
         # Add element to the population

--- a/syne_tune/optimizer/schedulers/searchers/searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/searcher.py
@@ -2,7 +2,7 @@ import logging
 import numpy as np
 
 from copy import deepcopy
-from typing import Optional, List, Dict, Any
+from typing import Optional, Any
 
 logger = logging.getLogger(__name__)
 
@@ -19,8 +19,8 @@ class BaseSearcher:
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        points_to_evaluate: Optional[List[Dict[str, Any]]] = None,
+        config_space: dict[str, Any],
+        points_to_evaluate: Optional[list[dict[str, Any]]] = None,
         random_seed: int = None,
     ):
         self.config_space = config_space
@@ -34,7 +34,7 @@ class BaseSearcher:
         else:
             self.random_seed = random_seed
 
-    def _next_points_to_evaluate(self) -> Optional[Dict[str, Any]]:
+    def _next_points_to_evaluate(self) -> Optional[dict[str, Any]]:
         """
         :return: Next entry from remaining ``points_to_evaluate`` (popped
             from front), or None
@@ -44,7 +44,7 @@ class BaseSearcher:
         else:
             return None  # No more initial configs
 
-    def suggest(self, **kwargs) -> Optional[Dict[str, Any]]:
+    def suggest(self, **kwargs) -> Optional[dict[str, Any]]:
         """Suggest a new configuration.
 
         Note: Query :meth:`_next_points_to_evaluate` for initial configs to return
@@ -63,8 +63,8 @@ class BaseSearcher:
     def on_trial_result(
         self,
         trial_id: int,
-        config: Dict[str, Any],
-        metrics: List[float],
+        config: dict[str, Any],
+        metrics: list[float],
     ):
         """Inform searcher about result
 
@@ -95,8 +95,8 @@ class BaseSearcher:
     def on_trial_complete(
         self,
         trial_id: int,
-        config: Dict[str, Any],
-        metrics: List[float],
+        config: dict[str, Any],
+        metrics: list[float],
     ):
         """Inform searcher about result
 

--- a/syne_tune/optimizer/schedulers/searchers/searcher_base.py
+++ b/syne_tune/optimizer/schedulers/searchers/searcher_base.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any, List, Union
+from typing import Optional, Any, Union
 import logging
 import numpy as np
 
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 MAX_RETRIES = 100
 
 
-def extract_random_seed(**kwargs) -> (int, Dict[str, Any]):
+def extract_random_seed(**kwargs) -> (int, dict[str, Any]):
     key = "random_seed_generator"
     generator = kwargs.get(key)
     if generator is not None:
@@ -34,7 +34,7 @@ def sample_random_configuration(
     hp_ranges: HyperparameterRanges,
     random_state: np.random.RandomState,
     exclusion_list: Optional[ExclusionList] = None,
-) -> Optional[Dict[str, Any]]:
+) -> Optional[dict[str, Any]]:
     """
     Samples a configuration from ``config_space`` at random.
 
@@ -73,9 +73,9 @@ class StochasticSearcher(LegacyBaseSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        metric: Union[List[str], str],
-        points_to_evaluate: Optional[List[Dict[str, Any]]] = None,
+        config_space: dict[str, Any],
+        metric: Union[list[str], str],
+        points_to_evaluate: Optional[list[dict[str, Any]]] = None,
         **kwargs,
     ):
         super().__init__(
@@ -87,13 +87,13 @@ class StochasticSearcher(LegacyBaseSearcher):
         random_seed, _ = extract_random_seed(**kwargs)
         self.random_state = np.random.RandomState(random_seed)
 
-    def get_state(self) -> Dict[str, Any]:
+    def get_state(self) -> dict[str, Any]:
         return dict(
             super().get_state(),
             random_state=self.random_state.get_state(),
         )
 
-    def _restore_from_state(self, state: Dict[str, Any]):
+    def _restore_from_state(self, state: dict[str, Any]):
         super()._restore_from_state(state)
         self.random_state.set_state(state["random_state"])
 
@@ -102,10 +102,10 @@ class StochasticSearcher(LegacyBaseSearcher):
 
     def _filter_points_to_evaluate(
         self,
-        restrict_configurations: List[Dict[str, Any]],
+        restrict_configurations: list[dict[str, Any]],
         hp_ranges: HyperparameterRanges,
         allow_duplicates: bool,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """
         Used to support ``restrict_configurations`` in subclasses. Configs in
         ``_points_to_evaluate`` are removed if not in ``restrict_configurations``.
@@ -195,11 +195,11 @@ class StochasticAndFilterDuplicatesSearcher(StochasticSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        metric: Union[List[str], str],
-        points_to_evaluate: Optional[List[Dict[str, Any]]] = None,
+        config_space: dict[str, Any],
+        metric: Union[list[str], str],
+        points_to_evaluate: Optional[list[dict[str, Any]]] = None,
         allow_duplicates: Optional[bool] = None,
-        restrict_configurations: Optional[List[Dict[str, Any]]] = None,
+        restrict_configurations: Optional[list[dict[str, Any]]] = None,
         **kwargs,
     ):
         super().__init__(
@@ -231,20 +231,20 @@ class StochasticAndFilterDuplicatesSearcher(StochasticSearcher):
     def allow_duplicates(self) -> bool:
         return self._allow_duplicates
 
-    def should_not_suggest(self, config: Dict[str, Any]) -> bool:
+    def should_not_suggest(self, config: dict[str, Any]) -> bool:
         """
         :param config: Configuration
         :return: :meth:`get_config` should not suggest this configuration?
         """
         return self._excl_list.contains(config)
 
-    def _get_config(self, **kwargs) -> Optional[Dict[str, Any]]:
+    def _get_config(self, **kwargs) -> Optional[dict[str, Any]]:
         """
         Child classes implement this instead of :meth:`get_config`.
         """
         raise NotImplementedError
 
-    def get_config(self, **kwargs) -> Optional[Dict[str, Any]]:
+    def get_config(self, **kwargs) -> Optional[dict[str, Any]]:
         new_config = self._get_config(**kwargs)
         if not self._allow_duplicates and new_config is not None:
             self._excl_list.add(new_config)
@@ -266,7 +266,7 @@ class StochasticAndFilterDuplicatesSearcher(StochasticSearcher):
 
     def _get_random_config(
         self, exclusion_list: Optional[ExclusionList] = None
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[dict[str, Any]]:
         """
         Child classes should use this helper method in order to draw a configuration at
         random.
@@ -288,7 +288,7 @@ class StochasticAndFilterDuplicatesSearcher(StochasticSearcher):
 
     def _get_random_config_from_restrict_configurations(
         self, exclusion_list: ExclusionList
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[dict[str, Any]]:
         config = None
         if self._restrict_configurations:
             for _ in range(MAX_RETRIES):
@@ -310,7 +310,7 @@ class StochasticAndFilterDuplicatesSearcher(StochasticSearcher):
     def register_pending(
         self,
         trial_id: str,
-        config: Optional[Dict[str, Any]] = None,
+        config: Optional[dict[str, Any]] = None,
         milestone: Optional[int] = None,
     ):
         super().register_pending(trial_id, config, milestone)
@@ -328,7 +328,7 @@ class StochasticAndFilterDuplicatesSearcher(StochasticSearcher):
             # Blacklist this configuration
             self._excl_list.add(self._config_for_trial_id[trial_id])
 
-    def get_state(self) -> Dict[str, Any]:
+    def get_state(self) -> dict[str, Any]:
         state = super().get_state()
         state["excl_list"] = self._excl_list.get_state()
         if self._allow_duplicates:
@@ -337,7 +337,7 @@ class StochasticAndFilterDuplicatesSearcher(StochasticSearcher):
             state["restrict_configurations"] = self._restrict_configurations
         return state
 
-    def _restore_from_state(self, state: Dict[str, Any]):
+    def _restore_from_state(self, state: dict[str, Any]):
         super()._restore_from_state(state)
         self._excl_list = ExclusionList(self._hp_ranges)
         self._excl_list.clone_from_state(state["excl_list"])

--- a/syne_tune/optimizer/schedulers/searchers/searcher_callback.py
+++ b/syne_tune/optimizer/schedulers/searchers/searcher_callback.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 import logging
 
 from syne_tune.backend.trial_status import Trial
@@ -68,7 +68,7 @@ class StoreResultsAndModelParamsCallback(StoreResultsCallback):
         self._searcher = _get_model_based_searcher(tuner)
 
     def on_trial_result(
-        self, trial: Trial, status: str, result: Dict[str, Any], decision: str
+        self, trial: Trial, status: str, result: dict[str, Any], decision: str
     ):
         result = _extended_result(self._searcher, result)
         super().on_trial_result(trial, status, result, decision)
@@ -92,7 +92,7 @@ class SimulatorAndModelParamsCallback(SimulatorCallback):
         self._searcher = _get_model_based_searcher(tuner)
 
     def on_trial_result(
-        self, trial: Trial, status: str, result: Dict[str, Any], decision: str
+        self, trial: Trial, status: str, result: dict[str, Any], decision: str
     ):
         result = _extended_result(self._searcher, result)
         super().on_trial_result(trial, status, result, decision)

--- a/syne_tune/optimizer/schedulers/searchers/searcher_factory.py
+++ b/syne_tune/optimizer/schedulers/searchers/searcher_factory.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 
 from syne_tune.optimizer.schedulers.searchers.bore import Bore
 from syne_tune.optimizer.schedulers.searchers.botorch.botorch_searcher import (
@@ -25,7 +25,7 @@ searcher_cls_dict = {
 
 
 def searcher_factory(
-    searcher_name: str, config_space: Dict[str, Any], **searcher_kwargs
+    searcher_name: str, config_space: dict[str, Any], **searcher_kwargs
 ) -> BaseSearcher:
     assert (
         searcher_name in searcher_cls_dict

--- a/syne_tune/optimizer/schedulers/searchers/single_objective_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/single_objective_searcher.py
@@ -1,6 +1,6 @@
 import logging
 
-from typing import Dict, Any
+from typing import Any
 
 from syne_tune.optimizer.schedulers.searchers.searcher import BaseSearcher
 
@@ -15,7 +15,7 @@ class SingleObjectiveBaseSearcher(BaseSearcher):
     def on_trial_result(
         self,
         trial_id: int,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         metric: float,
     ):
         """Inform searcher about result
@@ -37,7 +37,7 @@ class SingleObjectiveBaseSearcher(BaseSearcher):
     def on_trial_complete(
         self,
         trial_id: int,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         metric: float,
     ):
         """Inform searcher about result

--- a/syne_tune/optimizer/schedulers/searchers/sklearn/sklearn_surrogate_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/sklearn/sklearn_surrogate_searcher.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, List, Dict, Any
+from typing import Optional, Any
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.models.meanstd_acqfunc_impl import (
     EIAcquisitionFunction,
@@ -58,15 +58,15 @@ class SKLearnSurrogateSearcher(BayesianOptimizationSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         estimator: SKLearnEstimator,
-        points_to_evaluate: Optional[List[Dict[str, Any]]] = None,
+        points_to_evaluate: Optional[list[dict[str, Any]]] = None,
         scoring_class: Optional[ScoringFunctionConstructor] = None,
         num_initial_candidates: int = DEFAULT_NUM_INITIAL_CANDIDATES,
         num_initial_random_choices: int = DEFAULT_NUM_INITIAL_RANDOM_EVALUATIONS,
         allow_duplicates: bool = False,
-        restrict_configurations: Optional[List[Dict[str, Any]]] = None,
+        restrict_configurations: Optional[list[dict[str, Any]]] = None,
         clone_from_state: bool = False,
         **kwargs,
     ):

--- a/syne_tune/optimizer/schedulers/searchers/utils/common.py
+++ b/syne_tune/optimizer/schedulers/searchers/utils/common.py
@@ -1,9 +1,10 @@
-from typing import Union, Dict, Callable
+from typing import Union
+from collections.abc import Callable
 
 
 Hyperparameter = Union[str, int, float]
 
-Configuration = Dict[str, Hyperparameter]
+Configuration = dict[str, Hyperparameter]
 
 # Type of ``filter_observed_data``, which is (optionally) used to filter the
 # observed data in ``TuningJobState.trials_evaluations`` when determining

--- a/syne_tune/optimizer/schedulers/searchers/utils/default_arguments.py
+++ b/syne_tune/optimizer/schedulers/searchers/utils/default_arguments.py
@@ -1,4 +1,4 @@
-from typing import Set, Tuple, Dict, Optional, Any
+from typing import Optional, Any
 import logging
 import numbers
 
@@ -66,7 +66,7 @@ class IntegerOrNone(Integer):
 
 
 class Categorical(CheckType):
-    def __init__(self, choices: Tuple[str, ...]):
+    def __init__(self, choices: tuple[str, ...]):
         self.choices = set(choices)
 
     def assert_valid(self, key: str, value):
@@ -95,12 +95,12 @@ class Dictionary(CheckType):
 
 
 def check_and_merge_defaults(
-    options: Dict[str, Any],
-    mandatory: Set[str],
-    default_options: Dict[str, Any],
-    constraints: Optional[Dict[str, CheckType]] = None,
+    options: dict[str, Any],
+    mandatory: set[str],
+    default_options: dict[str, Any],
+    constraints: Optional[dict[str, CheckType]] = None,
     dict_name: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     First, check that all keys in mandatory appear in options. Second, create
     result_options by merging ``options`` and ``default_options``, where entries in
@@ -154,7 +154,7 @@ def check_and_merge_defaults(
     return result_options
 
 
-def filter_by_key(options: Dict[str, Any], remove_keys: Set[str]) -> Dict[str, Any]:
+def filter_by_key(options: dict[str, Any], remove_keys: set[str]) -> dict[str, Any]:
     """
     Filter options by removing entries whose keys are in ``remove_keys``.
     Used to filter kwargs passed to a constructor, before passing it to
@@ -167,6 +167,6 @@ def filter_by_key(options: Dict[str, Any], remove_keys: Set[str]) -> Dict[str, A
     return {k: v for k, v in options.items() if k not in remove_keys}
 
 
-def assert_no_invalid_options(options: Dict[str, Any], all_keys: Set[str], name: str):
+def assert_no_invalid_options(options: dict[str, Any], all_keys: set[str], name: str):
     for k in options:
         assert k in all_keys, "{}: Invalid argument '{}'".format(name, k)

--- a/syne_tune/optimizer/schedulers/searchers/utils/exclusion_list.py
+++ b/syne_tune/optimizer/schedulers/searchers/utils/exclusion_list.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any, List, Union, Set
+from typing import Optional, Any, Union
 
 from syne_tune.config_space import config_space_size
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.tuning_job_state import (
@@ -27,7 +27,7 @@ class ExclusionList:
     def __init__(
         self,
         hp_ranges: HyperparameterRanges,
-        configurations: Optional[Union[List[Configuration], Set[str]]] = None,
+        configurations: Optional[Union[list[Configuration], set[str]]] = None,
     ):
         self.hp_ranges = hp_ranges
         keys = self.hp_ranges.internal_keys
@@ -71,13 +71,13 @@ class ExclusionList:
             self.excl_set
         ) >= self.configspace_size
 
-    def get_state(self) -> Dict[str, Any]:
+    def get_state(self) -> dict[str, Any]:
         return {
             "excl_set": list(self.excl_set),
             "keys": self.keys,
         }
 
-    def clone_from_state(self, state: Dict[str, Any]):
+    def clone_from_state(self, state: dict[str, Any]):
         self.keys = state["keys"]
         self.excl_set = set(state["excl_set"])
 

--- a/syne_tune/optimizer/schedulers/searchers/utils/hp_ranges.py
+++ b/syne_tune/optimizer/schedulers/searchers/utils/hp_ranges.py
@@ -1,4 +1,5 @@
-from typing import Tuple, List, Iterable, Dict, Optional, Any
+from typing import Optional, Any
+from collections.abc import Iterable
 import numpy as np
 from numpy.random import RandomState
 
@@ -14,7 +15,7 @@ from syne_tune.optimizer.schedulers.searchers.utils.common import (
 )
 
 
-def _filter_constant_hyperparameters(config_space: Dict[str, Any]) -> Dict[str, Any]:
+def _filter_constant_hyperparameters(config_space: dict[str, Any]) -> dict[str, Any]:
     nonconst_keys = set(non_constant_hyperparameter_keys(config_space))
     return {k: v for k, v in config_space.items() if k in nonconst_keys}
 
@@ -65,11 +66,11 @@ class HyperparameterRanges:
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         name_last_pos: Optional[str] = None,
         value_for_last_pos=None,
         active_config_space: Optional[dict] = None,
-        prefix_keys: Optional[List[str]] = None,
+        prefix_keys: Optional[list[str]] = None,
     ):
         self.config_space = _filter_constant_hyperparameters(config_space)
         self.name_last_pos = name_last_pos
@@ -77,7 +78,7 @@ class HyperparameterRanges:
         self._set_internal_keys(prefix_keys)
         self._set_active_config_space(active_config_space)
 
-    def _set_internal_keys(self, prefix_keys: Optional[List[str]]):
+    def _set_internal_keys(self, prefix_keys: Optional[list[str]]):
         keys = sorted(self.config_space.keys())
         if prefix_keys is not None:
             pk_set = set(prefix_keys)
@@ -94,7 +95,7 @@ class HyperparameterRanges:
             keys = keys[:pos] + keys[(pos + 1) :] + [self.name_last_pos]
         self._internal_keys = keys
 
-    def _set_active_config_space(self, active_config_space: Dict[str, Any]):
+    def _set_active_config_space(self, active_config_space: dict[str, Any]):
         if active_config_space is None:
             self.active_config_space = dict()
             self._config_space_for_sampling = self.config_space
@@ -105,7 +106,7 @@ class HyperparameterRanges:
                 self.config_space, **active_config_space
             )
 
-    def _assert_sub_config_space(self, active_config_space: Dict[str, Any]):
+    def _assert_sub_config_space(self, active_config_space: dict[str, Any]):
         for k, v in active_config_space.items():
             assert (
                 k in self.config_space
@@ -121,11 +122,11 @@ class HyperparameterRanges:
                 assert check, f"active_config_space[{k}] has different {name}"
 
     @property
-    def internal_keys(self) -> List[str]:
+    def internal_keys(self) -> list[str]:
         return self._internal_keys
 
     @property
-    def config_space_for_sampling(self) -> Dict[str, Any]:
+    def config_space_for_sampling(self) -> dict[str, Any]:
         return self._config_space_for_sampling
 
     def to_ndarray(self, config: Configuration) -> np.ndarray:
@@ -164,7 +165,7 @@ class HyperparameterRanges:
         raise NotImplementedError
 
     @property
-    def encoded_ranges(self) -> Dict[str, Tuple[int, int]]:
+    def encoded_ranges(self) -> dict[str, tuple[int, int]]:
         """
         Encoded ranges are ``[0, 1]`` or closed subintervals thereof, in case
         ``active_config_space`` is used.
@@ -205,10 +206,10 @@ class HyperparameterRanges:
 
     def _random_configs(
         self, random_state: RandomState, num_configs: int
-    ) -> List[Configuration]:
+    ) -> list[Configuration]:
         return [self._random_config(random_state) for _ in range(num_configs)]
 
-    def random_configs(self, random_state, num_configs: int) -> List[Configuration]:
+    def random_configs(self, random_state, num_configs: int) -> list[Configuration]:
         """Draws random configurations
 
         :param random_state: Random state
@@ -220,7 +221,7 @@ class HyperparameterRanges:
             for config in self._random_configs(random_state, num_configs)
         ]
 
-    def get_ndarray_bounds(self) -> List[Tuple[float, float]]:
+    def get_ndarray_bounds(self) -> list[tuple[float, float]]:
         """
         :return: List of ``(lower, upper)`` bounds for each dimension in
             encoded vector representation.
@@ -237,8 +238,8 @@ class HyperparameterRanges:
         return len(self.config_space)
 
     def filter_for_last_pos_value(
-        self, configs: List[Configuration]
-    ) -> List[Configuration]:
+        self, configs: list[Configuration]
+    ) -> list[Configuration]:
         """
         If ``is_attribute_fixed``, ``configs`` is filtered by removing
         entries whose ``name_last_pos attribute`` value is different from
@@ -258,9 +259,9 @@ class HyperparameterRanges:
     def config_to_tuple(
         self,
         config: Configuration,
-        keys: Optional[List[str]] = None,
+        keys: Optional[list[str]] = None,
         skip_last: bool = False,
-    ) -> Tuple[Hyperparameter, ...]:
+    ) -> tuple[Hyperparameter, ...]:
         """
         :param config: Configuration
         :param keys: Overrides ``_internal_keys``
@@ -277,8 +278,8 @@ class HyperparameterRanges:
 
     def tuple_to_config(
         self,
-        config_tpl: Tuple[Hyperparameter, ...],
-        keys: Optional[List[str]] = None,
+        config_tpl: tuple[Hyperparameter, ...],
+        keys: Optional[list[str]] = None,
         skip_last: bool = False,
     ) -> Configuration:
         """Reverse of :meth:`config_to_tuple`.
@@ -299,7 +300,7 @@ class HyperparameterRanges:
     def config_to_match_string(
         self,
         config: Configuration,
-        keys: Optional[List[str]] = None,
+        keys: Optional[list[str]] = None,
         skip_last: bool = False,
     ) -> str:
         """

--- a/syne_tune/optimizer/schedulers/searchers/utils/hp_ranges_factory.py
+++ b/syne_tune/optimizer/schedulers/searchers/utils/hp_ranges_factory.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, List
+from typing import Optional
 import logging
 
 from syne_tune.optimizer.schedulers.searchers.utils.hp_ranges import (
@@ -12,11 +12,11 @@ logger = logging.getLogger(__name__)
 
 
 def make_hyperparameter_ranges(
-    config_space: Dict,
+    config_space: dict,
     name_last_pos: Optional[str] = None,
     value_for_last_pos=None,
-    active_config_space: Optional[Dict] = None,
-    prefix_keys: Optional[List[str]] = None,
+    active_config_space: Optional[dict] = None,
+    prefix_keys: Optional[list[str]] = None,
 ) -> HyperparameterRanges:
     """Default method to create :class:`HyperparameterRanges` from ``config_space``
 

--- a/syne_tune/optimizer/schedulers/searchers/utils/hp_ranges_impl.py
+++ b/syne_tune/optimizer/schedulers/searchers/utils/hp_ranges_impl.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Dict, List, Any, Optional, Union
+from typing import Any, Optional, Union
 import numpy as np
 
 from syne_tune.config_space import (
@@ -43,7 +43,7 @@ class HyperparameterRange:
     def ndarray_size(self) -> int:
         return 1
 
-    def get_ndarray_bounds(self) -> List[Tuple[float, float]]:
+    def get_ndarray_bounds(self) -> list[tuple[float, float]]:
         raise NotImplementedError
 
 
@@ -151,7 +151,7 @@ class HyperparameterRangeContinuous(HyperparameterRange):
             )
         return False
 
-    def get_ndarray_bounds(self) -> List[Tuple[float, float]]:
+    def get_ndarray_bounds(self) -> list[tuple[float, float]]:
         return self._ndarray_bounds
 
 
@@ -232,7 +232,7 @@ class HyperparameterRangeInteger(HyperparameterRange):
             )
         return False
 
-    def get_ndarray_bounds(self) -> List[Tuple[float, float]]:
+    def get_ndarray_bounds(self) -> list[tuple[float, float]]:
         return self._continuous_range.get_ndarray_bounds()
 
 
@@ -334,7 +334,7 @@ class HyperparameterRangeFiniteRange(HyperparameterRange):
             )
         return False
 
-    def get_ndarray_bounds(self) -> List[Tuple[float, float]]:
+    def get_ndarray_bounds(self) -> list[tuple[float, float]]:
         return self._range_int.get_ndarray_bounds()
 
 
@@ -346,7 +346,7 @@ class HyperparameterRangeCategorical(HyperparameterRange):
     :param choices: Values parameter can take
     """
 
-    def __init__(self, name: str, choices: Tuple[Any, ...]):
+    def __init__(self, name: str, choices: tuple[Any, ...]):
         super().__init__(name)
         self._assert_choices(choices)
         self.choices = list(choices)
@@ -360,7 +360,7 @@ class HyperparameterRangeCategorical(HyperparameterRange):
         ), f"value = {value} has type {type(value)}, must be str, int, or float"
 
     @staticmethod
-    def _assert_choices(choices: Tuple[Any, ...]):
+    def _assert_choices(choices: tuple[Any, ...]):
         assert len(choices) > 0
         HyperparameterRangeCategorical._assert_value_type(choices[0])
         value_type = type(choices[0])
@@ -370,7 +370,7 @@ class HyperparameterRangeCategorical(HyperparameterRange):
 
     @staticmethod
     def _assert_choices_and_active_choices(
-        choices: Tuple[Any, ...], active_choices: Optional[Tuple[Any, ...]] = None
+        choices: tuple[Any, ...], active_choices: Optional[tuple[Any, ...]] = None
     ) -> Optional[int]:
         HyperparameterRangeCategorical._assert_choices(choices)
         firstpos = None
@@ -414,8 +414,8 @@ class HyperparameterRangeCategoricalNonBinary(HyperparameterRangeCategorical):
     def __init__(
         self,
         name: str,
-        choices: Tuple[Any, ...],
-        active_choices: Tuple[Any, ...] = None,
+        choices: tuple[Any, ...],
+        active_choices: tuple[Any, ...] = None,
     ):
         super().__init__(name, choices)
         if active_choices is None:
@@ -454,7 +454,7 @@ class HyperparameterRangeCategoricalNonBinary(HyperparameterRangeCategorical):
         assert len(cand_ndarray) == self.num_choices, (cand_ndarray, self)
         return self.choices[int(np.argmax(cand_ndarray))]
 
-    def get_ndarray_bounds(self) -> List[Tuple[float, float]]:
+    def get_ndarray_bounds(self) -> list[tuple[float, float]]:
         return self._ndarray_bounds
 
 
@@ -471,8 +471,8 @@ class HyperparameterRangeCategoricalBinary(HyperparameterRangeCategorical):
     def __init__(
         self,
         name: str,
-        choices: Tuple[Any, ...],
-        active_choices: Tuple[Any, ...] = None,
+        choices: tuple[Any, ...],
+        active_choices: tuple[Any, ...] = None,
     ):
         assert len(choices) == 2, (
             f"len(choices) = {len(choices)}, must be 2. Use "
@@ -514,7 +514,7 @@ class HyperparameterRangeCategoricalBinary(HyperparameterRangeCategorical):
         assert len(cand_ndarray) == 1
         return self.choices[self._range_int.from_ndarray(cand_ndarray)]
 
-    def get_ndarray_bounds(self) -> List[Tuple[float, float]]:
+    def get_ndarray_bounds(self) -> list[tuple[float, float]]:
         return self._range_int.get_ndarray_bounds()
 
 
@@ -532,8 +532,8 @@ class HyperparameterRangeOrdinalEqual(HyperparameterRangeCategorical):
     def __init__(
         self,
         name: str,
-        choices: Tuple[Any, ...],
-        active_choices: Optional[Tuple[Any, ...]] = None,
+        choices: tuple[Any, ...],
+        active_choices: Optional[tuple[Any, ...]] = None,
     ):
         super().__init__(name, choices)
         active_lower_bound = self._assert_choices_and_active_choices(
@@ -562,7 +562,7 @@ class HyperparameterRangeOrdinalEqual(HyperparameterRangeCategorical):
         assert len(cand_ndarray) == 1
         return self.choices[self._range_int.from_ndarray(cand_ndarray)]
 
-    def get_ndarray_bounds(self) -> List[Tuple[float, float]]:
+    def get_ndarray_bounds(self) -> list[tuple[float, float]]:
         return self._range_int.get_ndarray_bounds()
 
     def __eq__(self, other) -> bool:
@@ -588,9 +588,9 @@ class HyperparameterRangeOrdinalNearestNeighbor(HyperparameterRangeCategorical):
     def __init__(
         self,
         name: str,
-        choices: Tuple[Any, ...],
+        choices: tuple[Any, ...],
         log_scale: bool = False,
-        active_choices: Optional[Tuple[Any, ...]] = None,
+        active_choices: Optional[tuple[Any, ...]] = None,
     ):
         assert len(choices) > 1, "Use HyperparameterRangeOrdinalEqual"
         super().__init__(name, choices)
@@ -606,8 +606,8 @@ class HyperparameterRangeOrdinalNearestNeighbor(HyperparameterRangeCategorical):
         )
 
     def _get_active_bounds(
-        self, active_choices: Optional[Tuple[Any, ...]]
-    ) -> Tuple[Optional[float], Optional[float]]:
+        self, active_choices: Optional[tuple[Any, ...]]
+    ) -> tuple[Optional[float], Optional[float]]:
         if active_choices is None:
             return None, None
         else:
@@ -650,7 +650,7 @@ class HyperparameterRangeOrdinalNearestNeighbor(HyperparameterRangeCategorical):
         assert len(cand_ndarray) == 1
         return self._domain_int.cast_int(self._range_int.from_ndarray(cand_ndarray))
 
-    def get_ndarray_bounds(self) -> List[Tuple[float, float]]:
+    def get_ndarray_bounds(self) -> list[tuple[float, float]]:
         return self._range_int.get_ndarray_bounds()
 
     def __eq__(self, other) -> bool:
@@ -677,11 +677,11 @@ class HyperparameterRangesImpl(HyperparameterRanges):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         name_last_pos: str = None,
         value_for_last_pos=None,
-        active_config_space: Dict[str, Any] = None,
-        prefix_keys: Optional[List[str]] = None,
+        active_config_space: dict[str, Any] = None,
+        prefix_keys: Optional[list[str]] = None,
     ):
         super().__init__(
             config_space,
@@ -783,10 +783,10 @@ class HyperparameterRangesImpl(HyperparameterRanges):
         return self.tuple_to_config(tuple(hps))
 
     @property
-    def encoded_ranges(self) -> Dict[str, Tuple[int, int]]:
+    def encoded_ranges(self) -> dict[str, tuple[int, int]]:
         return self._encoded_ranges
 
-    def get_ndarray_bounds(self) -> List[Tuple[float, float]]:
+    def get_ndarray_bounds(self) -> list[tuple[float, float]]:
         bounds = [
             x for hp_range in self._hp_ranges for x in hp_range.get_ndarray_bounds()
         ]
@@ -810,7 +810,7 @@ class HyperparameterRangesImpl(HyperparameterRanges):
 
 def decode_extended_features(
     features_ext: np.ndarray,
-    resource_attr_range: Tuple[int, int],
+    resource_attr_range: tuple[int, int],
 ) -> (np.ndarray, np.ndarray):
     """
     Given matrix of features from extended configs, corresponding to

--- a/syne_tune/optimizer/schedulers/single_fidelity_scheduler.py
+++ b/syne_tune/optimizer/schedulers/single_fidelity_scheduler.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any, Union, List
+from typing import Optional, Any, Union
 import logging
 
 from syne_tune.backend.trial_status import Trial
@@ -41,8 +41,8 @@ class SingleFidelityScheduler(TrialScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        metrics: List[str],
+        config_space: dict[str, Any],
+        metrics: list[str],
         do_minimize: Optional[bool] = True,
         searcher: Optional[Union[str, BaseSearcher]] = "random_search",
         random_seed: int = None,
@@ -77,7 +77,7 @@ class SingleFidelityScheduler(TrialScheduler):
         self.searcher.on_trial_error(trial.trial_id)
         logger.warning(f"trial_id {trial.trial_id}: Evaluation failed!")
 
-    def on_trial_result(self, trial: Trial, result: Dict[str, Any]) -> str:
+    def on_trial_result(self, trial: Trial, result: dict[str, Any]) -> str:
         """Called on each intermediate result reported by a trial.
 
         At this point, the trial scheduler can make a decision by returning
@@ -96,7 +96,7 @@ class SingleFidelityScheduler(TrialScheduler):
         self.searcher.on_trial_result(trial.trial_id, config, metric)
         return SchedulerDecision.CONTINUE
 
-    def on_trial_complete(self, trial: Trial, result: Dict[str, Any]):
+    def on_trial_complete(self, trial: Trial, result: dict[str, Any]):
         """Notification for the completion of trial.
 
         Note that :meth:`on_trial_result` is called with the same result before.
@@ -112,7 +112,7 @@ class SingleFidelityScheduler(TrialScheduler):
         ]
         self.searcher.on_trial_complete(trial.trial_id, config, metric)
 
-    def metadata(self) -> Dict[str, Any]:
+    def metadata(self) -> dict[str, Any]:
         """
         :return: Metadata for the scheduler
         """
@@ -125,7 +125,7 @@ class SingleFidelityScheduler(TrialScheduler):
         metadata["metric_mode"] = self.metric_mode()
         return metadata
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return self.metrics
 
     def metric_mode(self) -> str:

--- a/syne_tune/optimizer/schedulers/single_objective_scheduler.py
+++ b/syne_tune/optimizer/schedulers/single_objective_scheduler.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any, Union
+from typing import Optional, Any, Union
 import logging
 
 from syne_tune.optimizer.schedulers.searchers.single_objective_searcher import (
@@ -30,7 +30,7 @@ class SingleObjectiveScheduler(SingleFidelityScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         do_minimize: Optional[bool] = True,
         searcher: Optional[Union[str, SingleObjectiveBaseSearcher]] = "random_search",

--- a/syne_tune/optimizer/schedulers/smac_scheduler.py
+++ b/syne_tune/optimizer/schedulers/smac_scheduler.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, List, Dict, Any
+from typing import Optional, Any
 
 from ConfigSpace import Configuration
 from smac import Scenario, HyperparameterOptimizationFacade
@@ -20,7 +20,7 @@ from syne_tune.config_space import Domain, Integer, is_log_space, Float
 
 
 def to_smac_configspace(
-    config_space: Dict[str, Domain], random_seed: int
+    config_space: dict[str, Domain], random_seed: int
 ) -> CS.ConfigurationSpace:
     cs = CS.ConfigurationSpace(seed=random_seed)
     for hp_name, hp in config_space.items():
@@ -60,7 +60,7 @@ def to_smac_configspace(
 class SMACScheduler(TrialScheduler):
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         do_minimize: Optional[bool] = True,
         points_to_evaluate=None,
@@ -110,7 +110,7 @@ class SMACScheduler(TrialScheduler):
         )
         self.trial_info = {}
 
-    def on_trial_complete(self, trial: Trial, result: Dict[str, Any]):
+    def on_trial_complete(self, trial: Trial, result: dict[str, Any]):
         info = self.trial_info[trial.trial_id]
         cost = result[self.metric]
         if not self.do_minimize:
@@ -145,10 +145,10 @@ class SMACScheduler(TrialScheduler):
         # Avoid serialization issues with swig
         return None
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return [self.metric]
 
-    def metadata(self) -> Dict[str, Any]:
+    def metadata(self) -> dict[str, Any]:
         """
         :return: Metadata for the scheduler
         """

--- a/syne_tune/optimizer/schedulers/synchronous/dehb.py
+++ b/syne_tune/optimizer/schedulers/synchronous/dehb.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Tuple, Dict, Any
+from typing import Optional, Any
 import logging
 import numpy as np
 from dataclasses import dataclass
@@ -221,8 +221,8 @@ class DifferentialEvolutionHyperbandScheduler(SynchronousHyperbandCommon):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        rungs_first_bracket: List[Tuple[int, int]],
+        config_space: dict[str, Any],
+        rungs_first_bracket: list[tuple[int, int]],
         num_brackets_per_iteration: Optional[int] = None,
         **kwargs,
     ):
@@ -231,7 +231,7 @@ class DifferentialEvolutionHyperbandScheduler(SynchronousHyperbandCommon):
 
     def _create_internal(
         self,
-        rungs_first_bracket: List[Tuple[int, int]],
+        rungs_first_bracket: list[tuple[int, int]],
         num_brackets_per_iteration: Optional[int] = None,
         **kwargs,
     ):
@@ -291,7 +291,7 @@ class DifferentialEvolutionHyperbandScheduler(SynchronousHyperbandCommon):
         self._rung_levels = [level for _, level in rungs_first_bracket]
 
     @property
-    def rung_levels(self) -> List[int]:
+    def rung_levels(self) -> list[int]:
         return self._rung_levels
 
     @property
@@ -526,7 +526,7 @@ class DifferentialEvolutionHyperbandScheduler(SynchronousHyperbandCommon):
         result_failed.metric_val = np.NAN
         self.bracket_manager.on_result((ext_slot.bracket_id, result_failed))
 
-    def on_trial_result(self, trial: Trial, result: Dict[str, Any]) -> str:
+    def on_trial_result(self, trial: Trial, result: dict[str, Any]) -> str:
         trial_id = trial.trial_id
         if trial_id in self._trial_to_pending_slot:
             ext_slot = self._trial_to_pending_slot[trial_id]
@@ -577,7 +577,7 @@ class DifferentialEvolutionHyperbandScheduler(SynchronousHyperbandCommon):
         return trial_decision
 
     def _extract_from_result(
-        self, trial_id: int, result: Dict[str, Any]
+        self, trial_id: int, result: dict[str, Any]
     ) -> (float, int):
         metric_vals = []
         for name in (self.metric, self._resource_attr):
@@ -659,7 +659,7 @@ class DifferentialEvolutionHyperbandScheduler(SynchronousHyperbandCommon):
             logger.info(msg)
         return self._de_mutation(parent_trial_ids)
 
-    def _de_mutation(self, parent_trial_ids: List[int]) -> np.ndarray:
+    def _de_mutation(self, parent_trial_ids: list[int]) -> np.ndarray:
         """
         Corresponds to rand/1 mutation strategy of DE.
         """
@@ -740,7 +740,7 @@ class DifferentialEvolutionHyperbandScheduler(SynchronousHyperbandCommon):
                 "on_trial_error call is ignored"
             )
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return [self.metric]
 
     def metric_mode(self) -> str:

--- a/syne_tune/optimizer/schedulers/synchronous/dehb_bracket.py
+++ b/syne_tune/optimizer/schedulers/synchronous/dehb_bracket.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Tuple
+from typing import Optional
 
 from syne_tune.optimizer.schedulers.synchronous.hyperband_bracket import (
     SynchronousBracket,
@@ -21,7 +21,7 @@ class DifferentialEvolutionHyperbandBracket(SynchronousBracket):
 
     def __init__(
         self,
-        rungs: List[Tuple[int, int]],
+        rungs: list[tuple[int, int]],
         mode: str,
     ):
         self.assert_check_rungs(rungs)
@@ -36,7 +36,7 @@ class DifferentialEvolutionHyperbandBracket(SynchronousBracket):
 
     def _current_rung_and_level(
         self,
-    ) -> (List[Tuple[Optional[int], Optional[float]]], int):
+    ) -> (list[tuple[Optional[int], Optional[float]]], int):
         return self._rungs[self.current_rung]
 
     def size_of_current_rung(self) -> int:
@@ -46,7 +46,7 @@ class DifferentialEvolutionHyperbandBracket(SynchronousBracket):
         rung, _ = self._rungs[rung_index]
         return rung[slot_index][0]
 
-    def top_list_for_previous_rung(self) -> List[int]:
+    def top_list_for_previous_rung(self) -> list[int]:
         """
         Returns list of trial_ids corresponding to best scoring entries
         in rung below the currently active one (which must not be the base
@@ -58,5 +58,5 @@ class DifferentialEvolutionHyperbandBracket(SynchronousBracket):
             rung=previous_rung, new_len=self.size_of_current_rung(), mode=self._mode
         )[0]
 
-    def _promote_trials_at_rung_complete(self) -> List[int]:
+    def _promote_trials_at_rung_complete(self) -> list[int]:
         return []

--- a/syne_tune/optimizer/schedulers/synchronous/dehb_bracket_manager.py
+++ b/syne_tune/optimizer/schedulers/synchronous/dehb_bracket_manager.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Optional
+from typing import Optional
 
 from syne_tune.optimizer.schedulers.synchronous.hyperband_bracket_manager import (
     SynchronousHyperbandBracketManager,
@@ -28,7 +28,7 @@ class DifferentialEvolutionHyperbandBracketManager(SynchronousHyperbandBracketMa
 
     def __init__(
         self,
-        rungs_first_bracket: List[Tuple[int, int]],
+        rungs_first_bracket: list[tuple[int, int]],
         mode: str,
         num_brackets_per_iteration: Optional[int] = None,
     ):

--- a/syne_tune/optimizer/schedulers/synchronous/hyperband.py
+++ b/syne_tune/optimizer/schedulers/synchronous/hyperband.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Set, Dict, Any, Tuple
+from typing import Optional, Any
 import logging
 import numpy as np
 
@@ -75,8 +75,8 @@ class SynchronousHyperbandCommon(
     """
 
     def _create_internal_common(
-        self, skip_searchers: Optional[Set[str]] = None, **kwargs
-    ) -> Dict[str, Any]:
+        self, skip_searchers: Optional[set[str]] = None, **kwargs
+    ) -> dict[str, Any]:
         self.metric = kwargs.get("metric")
         assert self.metric is not None, (
             "Argument 'metric' is mandatory. Pass the name of the metric "
@@ -230,7 +230,7 @@ class SynchronousHyperbandScheduler(
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         bracket_rungs: RungSystemsPerBracket,
         **kwargs,
     ):
@@ -263,7 +263,7 @@ class SynchronousHyperbandScheduler(
         self._trials_checkpoints_can_be_removed = []
 
     @property
-    def rung_levels(self) -> List[int]:
+    def rung_levels(self) -> list[int]:
         return self._rung_levels
 
     @property
@@ -334,7 +334,7 @@ class SynchronousHyperbandScheduler(
             self._report_as_failed(bracket_id, slot_in_rung)
         return suggestion
 
-    def _on_result(self, result: Tuple[int, SlotInRung]):
+    def _on_result(self, result: tuple[int, SlotInRung]):
         trials_not_promoted = self.bracket_manager.on_result(result)
         if trials_not_promoted is not None:
             self._trials_checkpoints_can_be_removed.extend(trials_not_promoted)
@@ -349,7 +349,7 @@ class SynchronousHyperbandScheduler(
         )
         self._on_result((bracket_id, result_failed))
 
-    def on_trial_result(self, trial: Trial, result: Dict[str, Any]) -> str:
+    def on_trial_result(self, trial: Trial, result: dict[str, Any]) -> str:
         trial_id = trial.trial_id
         if trial_id in self._trial_to_pending_slot:
             bracket_id, slot_in_rung = self._trial_to_pending_slot[trial_id]
@@ -421,13 +421,13 @@ class SynchronousHyperbandScheduler(
                 "on_trial_error call is ignored"
             )
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return [self.metric]
 
     def metric_mode(self) -> str:
         return self.mode
 
-    def trials_checkpoints_can_be_removed(self) -> List[int]:
+    def trials_checkpoints_can_be_removed(self) -> list[int]:
         result = self._trials_checkpoints_can_be_removed
         self._trials_checkpoints_can_be_removed = []
         return result

--- a/syne_tune/optimizer/schedulers/synchronous/hyperband_bracket.py
+++ b/syne_tune/optimizer/schedulers/synchronous/hyperband_bracket.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Tuple
+from typing import Optional
 from operator import itemgetter
 import numpy as np
 from dataclasses import dataclass
@@ -43,7 +43,7 @@ class SynchronousBracket:
         self.current_rung = 0
 
     @staticmethod
-    def assert_check_rungs(rungs: List[Tuple[int, int]]):
+    def assert_check_rungs(rungs: list[tuple[int, int]]):
         assert len(rungs) > 0, "There must be at least one rung"
         sizes, levels = zip(*rungs)
         assert is_positive_integer(
@@ -66,7 +66,7 @@ class SynchronousBracket:
 
     def _current_rung_and_level(
         self,
-    ) -> (List[Tuple[Optional[int], Optional[float]]], int):
+    ) -> (list[tuple[Optional[int], Optional[float]]], int):
         raise NotImplementedError
 
     def num_pending_slots(self) -> int:
@@ -96,7 +96,7 @@ class SynchronousBracket:
             metric_val=None,
         )
 
-    def on_result(self, result: SlotInRung) -> Optional[List[int]]:
+    def on_result(self, result: SlotInRung) -> Optional[list[int]]:
         """
         Provides result for slot previously requested by ``next_free_slot``.
         Here, ``result.metric`` is written to the slot in order to make it
@@ -146,7 +146,7 @@ class SynchronousBracket:
     def _assert_on_result_trial_id(self, result: SlotInRung, trial_id: int):
         pass
 
-    def _promote_trials_at_rung_complete(self) -> List[int]:
+    def _promote_trials_at_rung_complete(self) -> list[int]:
         """
         This is called when a rung has just been filled in :meth:`on_result`,
         and this is not the final rung of the bracket. It opens a new rung
@@ -166,7 +166,7 @@ class SynchronousHyperbandBracket(SynchronousBracket):
     slots in the lowest not fully occupied rung can be filled.
     """
 
-    def __init__(self, rungs: List[Tuple[int, int]], mode: str):
+    def __init__(self, rungs: list[tuple[int, int]], mode: str):
         """
         :param rungs: List of ``(rung_size, level)``, where ``level`` is rung
             (resource) level, ``rung_size`` is rung size (number of slots).
@@ -188,14 +188,14 @@ class SynchronousHyperbandBracket(SynchronousBracket):
 
     def _current_rung_and_level(
         self,
-    ) -> (List[Tuple[Optional[int], Optional[float]]], int):
+    ) -> (list[tuple[Optional[int], Optional[float]]], int):
         return self._rungs[self.current_rung]
 
     def _assert_on_result_trial_id(self, result: SlotInRung, trial_id: int):
         if trial_id is not None:
             assert result.trial_id == trial_id, (result, trial_id)
 
-    def _promote_trials_at_rung_complete(self) -> List[int]:
+    def _promote_trials_at_rung_complete(self) -> list[int]:
         pos = self.current_rung
         new_len, milestone = self._rungs[pos]
         previous_rung, _ = self._rungs[pos - 1]
@@ -210,8 +210,8 @@ class SynchronousHyperbandBracket(SynchronousBracket):
 
 
 def get_top_list(
-    rung: List[Tuple[int, float]], new_len: int, mode: str
-) -> (List[int], List[int]):
+    rung: list[tuple[int, float]], new_len: int, mode: str
+) -> (list[int], list[int]):
     """
     Returns list of IDs of trials of len ``new_len`` which should be promoted,
     because they performed best. We also return the list of IDs of the remaining

--- a/syne_tune/optimizer/schedulers/synchronous/hyperband_bracket_manager.py
+++ b/syne_tune/optimizer/schedulers/synchronous/hyperband_bracket_manager.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Optional, List
+from typing import Optional
 import copy
 
 from syne_tune.optimizer.schedulers.synchronous.hyperband_bracket import (
@@ -94,7 +94,7 @@ class SynchronousHyperbandBracketManager:
         )
         return bracket_id
 
-    def next_job(self) -> Tuple[int, SlotInRung]:
+    def next_job(self) -> tuple[int, SlotInRung]:
         """
         Called by scheduler to request a new job. Jobs are preferentially
         assigned to the primary bracket, which has the lowest id among all
@@ -126,7 +126,7 @@ class SynchronousHyperbandBracketManager:
         assert slot_in_rung is not None, "Newly created bracket has to have a free slot"
         return bracket_id, slot_in_rung
 
-    def on_result(self, result: Tuple[int, SlotInRung]) -> Optional[List[int]]:
+    def on_result(self, result: tuple[int, SlotInRung]) -> Optional[list[int]]:
         """
         Called by scheduler to provide result for previously requested job.
         See :meth:`next_job`.

--- a/syne_tune/optimizer/schedulers/synchronous/hyperband_impl.py
+++ b/syne_tune/optimizer/schedulers/synchronous/hyperband_impl.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 
 from syne_tune.optimizer.schedulers.scheduler_searcher import TrialSchedulerWithSearcher
 from syne_tune.optimizer.schedulers.synchronous.hyperband import (
@@ -104,7 +104,7 @@ class SynchronousGeometricHyperbandScheduler(SynchronousHyperbandScheduler):
     :type searcher_data: str, optional
     """
 
-    def __init__(self, config_space: Dict[str, Any], **kwargs):
+    def __init__(self, config_space: dict[str, Any], **kwargs):
         TrialSchedulerWithSearcher.__init__(self, config_space, **kwargs)
         # Additional parameters to determine rung systems
         kwargs = check_and_merge_defaults(
@@ -206,7 +206,7 @@ class GeometricDifferentialEvolutionHyperbandScheduler(
     :type support_pause_resume: bool, optional
     """
 
-    def __init__(self, config_space: Dict[str, Any], **kwargs):
+    def __init__(self, config_space: dict[str, Any], **kwargs):
         TrialSchedulerWithSearcher.__init__(self, config_space, **kwargs)
         # Additional parameters to determine rung systems
         kwargs = check_and_merge_defaults(

--- a/syne_tune/optimizer/schedulers/synchronous/hyperband_rung_system.py
+++ b/syne_tune/optimizer/schedulers/synchronous/hyperband_rung_system.py
@@ -1,11 +1,11 @@
-from typing import List, Tuple, Optional
+from typing import Optional
 import numpy as np
 import logging
 
 logger = logging.getLogger(__name__)
 
 
-RungSystemsPerBracket = List[List[Tuple[int, int]]]
+RungSystemsPerBracket = list[list[tuple[int, int]]]
 
 
 class SynchronousHyperbandRungSystem:

--- a/syne_tune/optimizer/schedulers/transfer_learning/__init__.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/__init__.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -24,9 +24,9 @@ class LegacyTransferLearningTaskEvaluations:
             (num_evals, num_seeds, num_fidelities, num_objectives)
     """
 
-    configuration_space: Dict
+    configuration_space: dict
     hyperparameters: pd.DataFrame
-    objectives_names: List[str]
+    objectives_names: list[str]
     objectives_evaluations: np.array
 
     def __post_init__(self):
@@ -56,7 +56,7 @@ class LegacyTransferLearningTaskEvaluations:
 
     def top_k_hyperparameter_configurations(
         self, k: int, mode: str, objective: str
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """
         Returns the best k hyperparameter configurations.
         :param k: The number of top hyperparameters to return.
@@ -83,9 +83,9 @@ class LegacyTransferLearningTaskEvaluations:
 class LegacyTransferLearningMixin:
     def __init__(
         self,
-        config_space: Dict,
-        transfer_learning_evaluations: Dict[str, LegacyTransferLearningTaskEvaluations],
-        metric_names: List[str],
+        config_space: dict,
+        transfer_learning_evaluations: dict[str, LegacyTransferLearningTaskEvaluations],
+        metric_names: list[str],
         **kwargs,
     ):
         """
@@ -104,9 +104,9 @@ class LegacyTransferLearningMixin:
 
     def _check_consistency(
         self,
-        config_space: Dict,
-        transfer_learning_evaluations: Dict[str, LegacyTransferLearningTaskEvaluations],
-        metric_names: List[str],
+        config_space: dict,
+        transfer_learning_evaluations: dict[str, LegacyTransferLearningTaskEvaluations],
+        metric_names: list[str],
     ):
         for task, evals in transfer_learning_evaluations.items():
             for key in config_space.keys():
@@ -119,16 +119,16 @@ class LegacyTransferLearningMixin:
                 f"evaluations objectives {evals.objectives_names}"
             )
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return self._metric_names
 
     def top_k_hyperparameter_configurations_per_task(
         self,
-        transfer_learning_evaluations: Dict[str, LegacyTransferLearningTaskEvaluations],
+        transfer_learning_evaluations: dict[str, LegacyTransferLearningTaskEvaluations],
         num_hyperparameters_per_task: int,
         mode: str,
         metric: str,
-    ) -> Dict[str, List[Dict[str, Any]]]:
+    ) -> dict[str, list[dict[str, Any]]]:
         """
         Returns the best hyperparameter configurations for each task.
         :param transfer_learning_evaluations: Set of candidates to choose from.

--- a/syne_tune/optimizer/schedulers/transfer_learning/bounding_box.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/bounding_box.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Dict, Callable, Optional, Any
+from typing import Optional, Any
+from collections.abc import Callable
 
 import pandas as pd
 
@@ -71,9 +72,9 @@ class BoundingBox(TransferLearningMixin, SingleObjectiveScheduler):
     def __init__(
         self,
         scheduler_fun: Callable[[dict, str, bool, int], SingleObjectiveScheduler],
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        transfer_learning_evaluations: Dict[str, TransferLearningTaskEvaluations],
+        transfer_learning_evaluations: dict[str, TransferLearningTaskEvaluations],
         do_minimize: Optional[bool] = True,
         num_hyperparameters_per_task: int = 1,
         random_seed: int = None,
@@ -97,11 +98,11 @@ class BoundingBox(TransferLearningMixin, SingleObjectiveScheduler):
 
     def _compute_box(
         self,
-        config_space: Dict[str, Any],
-        transfer_learning_evaluations: Dict[str, TransferLearningTaskEvaluations],
+        config_space: dict[str, Any],
+        transfer_learning_evaluations: dict[str, TransferLearningTaskEvaluations],
         do_minimize: bool,
         num_hyperparameters_per_task: int,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         top_k_per_task = self.top_k_hyperparameter_configurations_per_task(
             transfer_learning_evaluations=transfer_learning_evaluations,
             num_hyperparameters_per_task=num_hyperparameters_per_task,
@@ -142,7 +143,7 @@ class BoundingBox(TransferLearningMixin, SingleObjectiveScheduler):
     def on_trial_add(self, trial: Trial):
         self.scheduler.on_trial_add(trial)
 
-    def on_trial_complete(self, trial: Trial, result: Dict[str, Any]):
+    def on_trial_complete(self, trial: Trial, result: dict[str, Any]):
         self.scheduler.on_trial_complete(trial, result)
 
     def on_trial_remove(self, trial: Trial):
@@ -151,7 +152,7 @@ class BoundingBox(TransferLearningMixin, SingleObjectiveScheduler):
     def on_trial_error(self, trial: Trial):
         self.scheduler.on_trial_error(trial)
 
-    def on_trial_result(self, trial: Trial, result: Dict[str, Any]) -> str:
+    def on_trial_result(self, trial: Trial, result: dict[str, Any]) -> str:
         return self.scheduler.on_trial_result(trial, result)
 
     def metric_mode(self) -> str:

--- a/syne_tune/optimizer/schedulers/transfer_learning/legacy_bounding_box.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/legacy_bounding_box.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Dict, Callable, Optional, Any
+from typing import Optional, Any
+from collections.abc import Callable
 
 import pandas as pd
 
@@ -67,9 +68,9 @@ class LegacyBoundingBox(LegacyTransferLearningMixin, LegacyTrialScheduler):
     def __init__(
         self,
         scheduler_fun: Callable[[dict, str, str], LegacyTrialScheduler],
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        transfer_learning_evaluations: Dict[str, LegacyTransferLearningTaskEvaluations],
+        transfer_learning_evaluations: dict[str, LegacyTransferLearningTaskEvaluations],
         mode: Optional[str] = None,
         num_hyperparameters_per_task: int = 1,
     ):
@@ -96,12 +97,12 @@ class LegacyBoundingBox(LegacyTransferLearningMixin, LegacyTrialScheduler):
 
     def _compute_box(
         self,
-        config_space: Dict[str, Any],
-        transfer_learning_evaluations: Dict[str, LegacyTransferLearningTaskEvaluations],
+        config_space: dict[str, Any],
+        transfer_learning_evaluations: dict[str, LegacyTransferLearningTaskEvaluations],
         mode: str,
         num_hyperparameters_per_task: int,
         metric: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         top_k_per_task = self.top_k_hyperparameter_configurations_per_task(
             transfer_learning_evaluations=transfer_learning_evaluations,
             num_hyperparameters_per_task=num_hyperparameters_per_task,
@@ -143,7 +144,7 @@ class LegacyBoundingBox(LegacyTransferLearningMixin, LegacyTrialScheduler):
     def on_trial_add(self, trial: Trial):
         self.scheduler.on_trial_add(trial)
 
-    def on_trial_complete(self, trial: Trial, result: Dict[str, Any]):
+    def on_trial_complete(self, trial: Trial, result: dict[str, Any]):
         self.scheduler.on_trial_complete(trial, result)
 
     def on_trial_remove(self, trial: Trial):
@@ -152,7 +153,7 @@ class LegacyBoundingBox(LegacyTransferLearningMixin, LegacyTrialScheduler):
     def on_trial_error(self, trial: Trial):
         self.scheduler.on_trial_error(trial)
 
-    def on_trial_result(self, trial: Trial, result: Dict[str, Any]) -> str:
+    def on_trial_result(self, trial: Trial, result: dict[str, Any]) -> str:
         return self.scheduler.on_trial_result(trial, result)
 
     def metric_mode(self) -> str:

--- a/syne_tune/optimizer/schedulers/transfer_learning/legacy_zero_shot.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/legacy_zero_shot.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Optional, Any
+from typing import Optional, Any
 
 import pandas as pd
 import xgboost
@@ -44,9 +44,9 @@ class LegacyZeroShotTransfer(LegacyTransferLearningMixin, StochasticSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        transfer_learning_evaluations: Dict[str, LegacyTransferLearningTaskEvaluations],
+        transfer_learning_evaluations: dict[str, LegacyTransferLearningTaskEvaluations],
         mode: str = "min",
         sort_transfer_learning_evaluations: bool = True,
         use_surrogates: bool = False,
@@ -108,10 +108,10 @@ class LegacyZeroShotTransfer(LegacyTransferLearningMixin, StochasticSearcher):
 
     def _create_surrogate_transfer_learning_evaluations(
         self,
-        config_space: Dict[str, Any],
-        transfer_learning_evaluations: Dict[str, LegacyTransferLearningTaskEvaluations],
+        config_space: dict[str, Any],
+        transfer_learning_evaluations: dict[str, LegacyTransferLearningTaskEvaluations],
         metric: str,
-    ) -> Dict[str, LegacyTransferLearningTaskEvaluations]:
+    ) -> dict[str, LegacyTransferLearningTaskEvaluations]:
         """
         Creates transfer_learning_evaluations where each configuration is evaluated on each task using surrogate models.
         """
@@ -165,7 +165,7 @@ class LegacyZeroShotTransfer(LegacyTransferLearningMixin, StochasticSearcher):
             self._ranks = self._update_ranks()
         return best_config.to_dict()
 
-    def _sample_random_config(self, config_space: Dict[str, Any]) -> Dict[str, Any]:
+    def _sample_random_config(self, config_space: dict[str, Any]) -> dict[str, Any]:
         return {
             k: v.sample(random_state=self.random_state) if isinstance(v, Domain) else v
             for k, v in config_space.items()
@@ -175,6 +175,6 @@ class LegacyZeroShotTransfer(LegacyTransferLearningMixin, StochasticSearcher):
         return self._scores.rank(axis=1)
 
     def _update(
-        self, trial_id: str, config: Dict[str, Any], result: Dict[str, Any]
+        self, trial_id: str, config: dict[str, Any], result: dict[str, Any]
     ) -> None:
         pass

--- a/syne_tune/optimizer/schedulers/transfer_learning/quantile_based/legacy_quantile_based_searcher.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/quantile_based/legacy_quantile_based_searcher.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Optional, Any, Tuple
+from typing import Optional, Any
 import numpy as np
 import xgboost
 from sklearn.model_selection import train_test_split
@@ -86,7 +86,7 @@ def subsample(
     y: np.array,
     max_samples: Optional[int] = 10000,
     random_state: np.random.RandomState = None,
-) -> Tuple[pd.DataFrame, np.array]:
+) -> tuple[pd.DataFrame, np.array]:
     """
     Subsample both X and y with `max_samples` elements. If `max_samples` is not set then X and y are returned as such
     and if it is set, the index of X is reset.
@@ -134,9 +134,9 @@ class LegacyQuantileBasedSurrogateSearcher(StochasticSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        transfer_learning_evaluations: Dict[str, LegacyTransferLearningTaskEvaluations],
+        transfer_learning_evaluations: dict[str, LegacyTransferLearningTaskEvaluations],
         mode: Optional[str] = None,
         max_fit_samples: int = 100000,
         normalization: str = "gaussian",
@@ -171,10 +171,10 @@ class LegacyQuantileBasedSurrogateSearcher(StochasticSearcher):
                 self.mu_pred = self.mu_pred.reshape(-1, 1)
             self.sigma_pred = np.ones_like(self.mu_pred) * sigma_val
 
-    def _update(self, trial_id: str, config: Dict[str, Any], result: Dict[str, Any]):
+    def _update(self, trial_id: str, config: dict[str, Any], result: dict[str, Any]):
         pass
 
-    def clone_from_state(self, state: Dict[str, Any]):
+    def clone_from_state(self, state: dict[str, Any]):
         raise NotImplementedError
 
     def get_config(self, **kwargs) -> Optional[dict]:

--- a/syne_tune/optimizer/schedulers/transfer_learning/quantile_based/quantile_based_searcher.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/quantile_based/quantile_based_searcher.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Optional, Any, Tuple
+from typing import Optional, Any
 import numpy as np
 import xgboost
 from sklearn.model_selection import train_test_split
@@ -88,7 +88,7 @@ def subsample(
     y: np.array,
     max_samples: Optional[int] = 10000,
     random_state: np.random.RandomState = None,
-) -> Tuple[pd.DataFrame, np.array]:
+) -> tuple[pd.DataFrame, np.array]:
     """
     Subsample both X and y with `max_samples` elements. If `max_samples` is not set then X and y are returned as such
     and if it is set, the index of X is reset.
@@ -134,8 +134,8 @@ class QuantileBasedSurrogateSearcher(SingleObjectiveBaseSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        transfer_learning_evaluations: Dict[str, TransferLearningTaskEvaluations],
+        config_space: dict[str, Any],
+        transfer_learning_evaluations: dict[str, TransferLearningTaskEvaluations],
         max_fit_samples: int = 100000,
         normalization: str = "gaussian",
         random_seed: int = None,
@@ -167,13 +167,13 @@ class QuantileBasedSurrogateSearcher(SingleObjectiveBaseSearcher):
                 self.mu_pred = self.mu_pred.reshape(-1, 1)
             self.sigma_pred = np.ones_like(self.mu_pred) * sigma_val
 
-    def _update(self, trial_id: str, config: Dict[str, Any], result: Dict[str, Any]):
+    def _update(self, trial_id: str, config: dict[str, Any], result: dict[str, Any]):
         pass
 
-    def clone_from_state(self, state: Dict[str, Any]):
+    def clone_from_state(self, state: dict[str, Any]):
         raise NotImplementedError
 
-    def suggest(self, **kwargs) -> Optional[Dict[str, Any]]:
+    def suggest(self, **kwargs) -> Optional[dict[str, Any]]:
         samples = self.random_state.normal(loc=self.mu_pred, scale=self.sigma_pred)
         candidate = self.X_candidates.loc[np.argmin(samples)]
         return dict(candidate)

--- a/syne_tune/optimizer/schedulers/transfer_learning/rush.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/rush.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Any
+from typing import Optional, Any
 
 from syne_tune.optimizer.schedulers.legacy_hyperband import LegacyHyperbandScheduler
 from syne_tune.optimizer.schedulers.transfer_learning import (
@@ -41,12 +41,12 @@ class RUSHScheduler(LegacyTransferLearningMixin, LegacyHyperbandScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        transfer_learning_evaluations: Dict[str, LegacyTransferLearningTaskEvaluations],
+        config_space: dict[str, Any],
+        transfer_learning_evaluations: dict[str, LegacyTransferLearningTaskEvaluations],
         metric: str,
         type: str = "stopping",
-        points_to_evaluate: Optional[List[dict]] = None,
-        custom_rush_points: Optional[List[dict]] = None,
+        points_to_evaluate: Optional[list[dict]] = None,
+        custom_rush_points: Optional[list[dict]] = None,
         num_hyperparameters_per_task: int = 1,
         **kwargs,
     ):

--- a/syne_tune/optimizer/schedulers/transfer_learning/transfer_learning_mixin.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/transfer_learning_mixin.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any
 
 from syne_tune.optimizer.schedulers.transfer_learning.transfer_learning_task_evaluation import (
     TransferLearningTaskEvaluations,
@@ -8,8 +8,8 @@ from syne_tune.optimizer.schedulers.transfer_learning.transfer_learning_task_eva
 class TransferLearningMixin:
     def __init__(
         self,
-        config_space: Dict,
-        transfer_learning_evaluations: Dict[str, TransferLearningTaskEvaluations],
+        config_space: dict,
+        transfer_learning_evaluations: dict[str, TransferLearningTaskEvaluations],
         metric: str,
         random_seed: int = None,
         **kwargs,
@@ -31,8 +31,8 @@ class TransferLearningMixin:
 
     def _check_consistency(
         self,
-        config_space: Dict,
-        transfer_learning_evaluations: Dict[str, TransferLearningTaskEvaluations],
+        config_space: dict,
+        transfer_learning_evaluations: dict[str, TransferLearningTaskEvaluations],
     ):
         for task, evals in transfer_learning_evaluations.items():
             for key in config_space.keys():
@@ -47,10 +47,10 @@ class TransferLearningMixin:
 
     def top_k_hyperparameter_configurations_per_task(
         self,
-        transfer_learning_evaluations: Dict[str, TransferLearningTaskEvaluations],
+        transfer_learning_evaluations: dict[str, TransferLearningTaskEvaluations],
         num_hyperparameters_per_task: int,
         do_minimize: bool = False,
-    ) -> Dict[str, List[Dict[str, Any]]]:
+    ) -> dict[str, list[dict[str, Any]]]:
         """
         Returns the best hyperparameter configurations for each task.
         :param transfer_learning_evaluations: Set of candidates to choose from.

--- a/syne_tune/optimizer/schedulers/transfer_learning/transfer_learning_task_evaluation.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/transfer_learning_task_evaluation.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -17,9 +17,9 @@ class TransferLearningTaskEvaluations:
             (num_evals, num_seeds, num_fidelities, num_objectives)
     """
 
-    configuration_space: Dict
+    configuration_space: dict
     hyperparameters: pd.DataFrame
-    objectives_names: List[str]
+    objectives_names: list[str]
     objectives_evaluations: np.array
 
     def __post_init__(self):
@@ -49,7 +49,7 @@ class TransferLearningTaskEvaluations:
 
     def top_k_hyperparameter_configurations(
         self, k: int, objective: str, do_minimize: bool = False
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """
         Returns the best k hyperparameter configurations.
         :param k: The number of top hyperparameters to return.

--- a/syne_tune/optimizer/schedulers/transfer_learning/zero_shot.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/zero_shot.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Optional, Any
+from typing import Optional, Any
 
 import numpy as np
 import pandas as pd
@@ -47,9 +47,9 @@ class ZeroShotTransfer(TransferLearningMixin, SingleObjectiveScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        transfer_learning_evaluations: Dict[str, TransferLearningTaskEvaluations],
+        transfer_learning_evaluations: dict[str, TransferLearningTaskEvaluations],
         do_minimize: Optional[bool] = True,
         sort_transfer_learning_evaluations: bool = True,
         use_surrogates: bool = False,
@@ -111,10 +111,10 @@ class ZeroShotTransfer(TransferLearningMixin, SingleObjectiveScheduler):
 
     def _create_surrogate_transfer_learning_evaluations(
         self,
-        config_space: Dict[str, Any],
-        transfer_learning_evaluations: Dict[str, TransferLearningTaskEvaluations],
+        config_space: dict[str, Any],
+        transfer_learning_evaluations: dict[str, TransferLearningTaskEvaluations],
         metric: str,
-    ) -> Dict[str, TransferLearningTaskEvaluations]:
+    ) -> dict[str, TransferLearningTaskEvaluations]:
         """
         Creates transfer_learning_evaluations where each configuration is evaluated on each task using surrogate models.
         """
@@ -168,7 +168,7 @@ class ZeroShotTransfer(TransferLearningMixin, SingleObjectiveScheduler):
             self._ranks = self._update_ranks()
         return best_config.to_dict()
 
-    def _sample_random_config(self, config_space: Dict[str, Any]) -> Dict[str, Any]:
+    def _sample_random_config(self, config_space: dict[str, Any]) -> dict[str, Any]:
         return {
             k: v.sample(random_state=self.random_state) if isinstance(v, Domain) else v
             for k, v in config_space.items()
@@ -178,6 +178,6 @@ class ZeroShotTransfer(TransferLearningMixin, SingleObjectiveScheduler):
         return self._scores.rank(axis=1)
 
     def _update(
-        self, trial_id: str, config: Dict[str, Any], result: Dict[str, Any]
+        self, trial_id: str, config: dict[str, Any], result: dict[str, Any]
     ) -> None:
         pass

--- a/syne_tune/optimizer/schedulers/utils/simple_profiler.py
+++ b/syne_tune/optimizer/schedulers/utils/simple_profiler.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any
+from typing import Any
 import time
 import logging
 from dataclasses import dataclass
@@ -9,9 +9,9 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class ProfilingBlock:
-    meta: Dict[str, Any]
+    meta: dict[str, Any]
     time_stamp: float
-    durations: Dict[str, List[float]]
+    durations: dict[str, list[float]]
 
 
 class SimpleProfiler:
@@ -36,7 +36,7 @@ class SimpleProfiler:
         self.meta_keys = None
         self.prefix = ""
 
-    def begin_block(self, meta: Dict[str, Any]):
+    def begin_block(self, meta: dict[str, Any]):
         assert not self.start_time, "Timers for these tags still running:\n{}".format(
             self.start_time.keys()
         )
@@ -98,7 +98,7 @@ class SimpleProfiler:
             )
         self.start_time = dict()
 
-    def records_as_dict(self) -> Dict[str, Any]:
+    def records_as_dict(self) -> dict[str, Any]:
         """
         Return records as a dict of lists, can be converted into Pandas
         data-frame by:

--- a/syne_tune/optimizer/schedulers/utils/successive_halving.py
+++ b/syne_tune/optimizer/schedulers/utils/successive_halving.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional
 import logging
 import numpy as np
 
@@ -10,12 +10,12 @@ def _is_positive_int(x):
 
 
 def successive_halving_rung_levels(
-    rung_levels: Optional[List[int]],
+    rung_levels: Optional[list[int]],
     grace_period: int,
     reduction_factor: Optional[float],
     rung_increment: Optional[int],
     max_t: int,
-) -> List[int]:
+) -> list[int]:
     """Creates ``rung_levels`` from ``grace_period``, ``reduction_factor``
 
     Note: If ``rung_levels`` is given and ``rung_levels[-1] == max_t``, we strip

--- a/syne_tune/report.py
+++ b/syne_tune/report.py
@@ -4,7 +4,7 @@ import re
 import sys
 from dataclasses import dataclass
 from time import time, perf_counter
-from typing import List, Dict, Any
+from typing import Any
 
 from syne_tune.constants import (
     ST_WORKER_TIME,
@@ -75,7 +75,7 @@ class Reporter:
         _report_logger(**kwargs)
 
     @staticmethod
-    def _check_reported_values(kwargs: Dict[str, Any]):
+    def _check_reported_values(kwargs: dict[str, Any]):
         assert all(
             v is not None for v in kwargs.values()
         ), f"Invalid value in report: kwargs = {kwargs}"
@@ -86,7 +86,7 @@ def _report_logger(**kwargs):
     sys.stdout.flush()
 
 
-def _serialize_report_dict(report_dict: Dict[str, Any]) -> str:
+def _serialize_report_dict(report_dict: dict[str, Any]) -> str:
     """
     :param report_dict: a dictionary of metrics to be serialized
     :return: serialized string of the reported metrics, an exception is raised if the size is too large or
@@ -106,7 +106,7 @@ def _serialize_report_dict(report_dict: Dict[str, Any]) -> str:
         raise e
 
 
-def retrieve(log_lines: List[str]) -> List[Dict[str, float]]:
+def retrieve(log_lines: list[str]) -> list[dict[str, float]]:
     """Retrieves metrics reported with :func:`_report_logger` given log lines.
 
     :param log_lines: Lines in log file to be scanned for metric reports

--- a/syne_tune/results_callback.py
+++ b/syne_tune/results_callback.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional, List
+from typing import Any, Optional
 from time import perf_counter
 import copy
 import pandas as pd
@@ -27,7 +27,7 @@ class ExtraResultsComposer:
     functions are not.
     """
 
-    def __call__(self, tuner) -> Optional[Dict[str, Any]]:
+    def __call__(self, tuner) -> Optional[dict[str, Any]]:
         """
         Called in :meth:`StoreResultsCallback.on_trial_result`. The dictionary
         returned is appended (as extra columns) to the results dataframe.
@@ -39,7 +39,7 @@ class ExtraResultsComposer:
         """
         raise NotImplementedError
 
-    def keys(self) -> List[str]:
+    def keys(self) -> list[str]:
         """
         :return: Key names of dictionaries returned in :meth:`__call__`, or
             ``[]`` if nothing is returned
@@ -73,7 +73,7 @@ class StoreResultsCallback(TunerCallback):
         self._start_time_stamp = None
         self._tuner = None
 
-    def _set_time_fields(self, result: Dict[str, Any]):
+    def _set_time_fields(self, result: dict[str, Any]):
         """
         Note that we only add wallclock time to the result if this has not
         already been done (by the backend)
@@ -81,14 +81,14 @@ class StoreResultsCallback(TunerCallback):
         if self._start_time_stamp is not None and ST_TUNER_TIME not in result:
             result[ST_TUNER_TIME] = perf_counter() - self._start_time_stamp
 
-    def _append_extra_results(self, result: Dict[str, Any]):
+    def _append_extra_results(self, result: dict[str, Any]):
         if self._extra_results_composer is not None:
             extra_results = self._extra_results_composer(self._tuner)
             if extra_results is not None:
                 result.update(extra_results)
 
     def on_trial_result(
-        self, trial: Trial, status: str, result: Dict[str, Any], decision: str
+        self, trial: Trial, status: str, result: dict[str, Any], decision: str
     ):
         assert (
             self.save_results_at_frequency is not None

--- a/syne_tune/stopping_criterion.py
+++ b/syne_tune/stopping_criterion.py
@@ -2,7 +2,7 @@ import logging
 import numpy as np
 
 from dataclasses import dataclass
-from typing import Optional, Dict
+from typing import Optional
 
 from syne_tune.tuning_status import TuningStatus
 
@@ -46,9 +46,9 @@ class StoppingCriterion:
     max_cost: float = None
     max_num_trials_finished: int = None
     # minimum value for metrics, any value below this threshold will trigger a stop
-    min_metric_value: Optional[Dict[str, float]] = None
+    min_metric_value: Optional[dict[str, float]] = None
     # maximum value for metrics, any value above this threshold will trigger a stop
-    max_metric_value: Optional[Dict[str, float]] = None
+    max_metric_value: Optional[dict[str, float]] = None
 
     # todo we should have unit-test for all those cases.
     def __call__(self, status: TuningStatus) -> bool:

--- a/syne_tune/stopping_criterions/automatic_termination_criterion.py
+++ b/syne_tune/stopping_criterions/automatic_termination_criterion.py
@@ -1,7 +1,7 @@
 import logging
 import numpy as np
 import torch
-from typing import List, Dict, Any
+from typing import Any
 
 from torch import Tensor
 from botorch.models import SingleTaskGP
@@ -52,7 +52,7 @@ class AutomaticTerminationCriterion(object):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         threshold: float,
         mode: str = "min",
@@ -82,7 +82,7 @@ class AutomaticTerminationCriterion(object):
         else:
             self.multiplier = -1
 
-    def _config_to_feature_matrix(self, configs: List[dict]) -> Tensor:
+    def _config_to_feature_matrix(self, configs: list[dict]) -> Tensor:
         bounds = Tensor(self._hp_ranges.get_ndarray_bounds()).T
         X = Tensor(self._hp_ranges.to_ndarray_matrix(configs))
         return normalize(X, bounds)

--- a/syne_tune/tuner.py
+++ b/syne_tune/tuner.py
@@ -2,7 +2,8 @@ import logging
 import time
 from collections import OrderedDict
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Set, Tuple, Any, Union
+from typing import Optional, Any, Union
+from collections.abc import Callable
 
 import dill as dill
 
@@ -131,7 +132,7 @@ class Tuner:
         tuner_name: Optional[str] = None,
         asynchronous_scheduling: bool = True,
         wait_trial_completion_when_stopping: bool = False,
-        callbacks: Optional[List[TunerCallback]] = None,
+        callbacks: Optional[list[TunerCallback]] = None,
         metadata: Optional[dict] = None,
         suffix_tuner_name: bool = True,
         save_tuner: bool = True,
@@ -183,7 +184,7 @@ class Tuner:
         self.status_printer = None
         self._initialize_early_checkpoint_removal()
 
-    def _init_callbacks(self, callbacks: Optional[List[TunerCallback]]):
+    def _init_callbacks(self, callbacks: Optional[list[TunerCallback]]):
         if callbacks is None:
             callbacks = [self._default_callback()]
         else:
@@ -194,7 +195,7 @@ class Tuner:
                     "None of the callbacks provided are of type StoreResultsCallback. "
                     "This means no tuning results will be written."
                 )
-        self.callbacks: List[TunerCallback] = callbacks
+        self.callbacks: list[TunerCallback] = callbacks
 
     def _initialize_early_checkpoint_removal(self):
         """
@@ -366,7 +367,7 @@ class Tuner:
             callback.on_tuning_sleep(self.sleep_time)
 
     @staticmethod
-    def _set_metadata(metadata: Dict[str, Any], name: str, value):
+    def _set_metadata(metadata: dict[str, Any], name: str, value):
         if name in metadata:
             logger.warning(
                 f"Entry {name} in metadata is used, but will be overwritten:\n"
@@ -375,7 +376,7 @@ class Tuner:
             )
         metadata[name] = value
 
-    def _enrich_metadata(self, metadata: Dict[str, Any]) -> Dict[str, Any]:
+    def _enrich_metadata(self, metadata: dict[str, Any]) -> dict[str, Any]:
         """
         :param metadata: Original metadata
         :return: ``metadata`` enriched by default entries
@@ -398,7 +399,7 @@ class Tuner:
         )
 
     def _process_new_results(
-        self, running_trials_ids: Set[int]
+        self, running_trials_ids: set[int]
     ) -> (TrialAndStatusInformation, TrialIdAndResultList):
         """Communicates new results from the backend to the scheduler
 
@@ -442,7 +443,7 @@ class Tuner:
 
         return done_trials_statuses, new_results
 
-    def _schedule_new_tasks(self, running_trials_ids: Set[int]):
+    def _schedule_new_tasks(self, running_trials_ids: set[int]):
         """Schedules new tasks if resources are available or sleep.
 
         Note: If ``start_jobs_without_delay`` is False, we ask the backend for
@@ -531,7 +532,7 @@ class Tuner:
                 callback.on_resume_trial(trial)
             return trial
 
-    def _handle_failure(self, done_trials_statuses: Dict[int, Tuple[Trial, str]]):
+    def _handle_failure(self, done_trials_statuses: dict[int, tuple[Trial, str]]):
         logger.error(f"Stopped as {self.max_failures} failures were reached")
         for trial_id, (_, status) in done_trials_statuses.items():
             if status == Status.failed:
@@ -681,7 +682,7 @@ class Tuner:
 
     def best_config(
         self, metric: Optional[Union[str, int]] = 0
-    ) -> Tuple[int, Dict[str, Any]]:
+    ) -> tuple[int, dict[str, Any]]:
         """
         :param metric: Indicates which metric to use, can be the index or a name of the metric.
             default to 0 - first metric defined in the Scheduler

--- a/syne_tune/tuner_callback.py
+++ b/syne_tune/tuner_callback.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 
 from syne_tune.backend.trial_status import Trial
 from syne_tune.backend.trial_backend import (
@@ -56,7 +56,7 @@ class TunerCallback:
         """
         pass
 
-    def on_trial_complete(self, trial: Trial, result: Dict[str, Any]):
+    def on_trial_complete(self, trial: Trial, result: dict[str, Any]):
         """Called when a trial completes (``Status.completed``)
 
         The arguments here also have been passed to ``scheduler.on_trial_complete``,
@@ -68,7 +68,7 @@ class TunerCallback:
         pass
 
     def on_trial_result(
-        self, trial: Trial, status: str, result: Dict[str, Any], decision: str
+        self, trial: Trial, status: str, result: dict[str, Any], decision: str
     ):
         """Called when a new result (reported by a trial) is observed
 

--- a/syne_tune/tuning_status.py
+++ b/syne_tune/tuning_status.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Union, Set, Optional, Dict, Any
+from typing import Union, Optional, Any
 import numbers
 import logging
 import time
@@ -30,7 +30,7 @@ class MetricsStatistics:
         self.last_metrics = dict()
         self.is_numeric = dict()
 
-    def add(self, metrics: Dict[str, Any]):
+    def add(self, metrics: dict[str, Any]):
         for metric_name, current_metric in metrics.items():
             if metric_name in self.is_numeric:
                 if self.is_numeric[metric_name] != isinstance(
@@ -67,7 +67,7 @@ class TuningStatus:
     """
 
     # TODO: ``metric_names`` not used for anything. Remove?
-    def __init__(self, metric_names: List[str]):
+    def __init__(self, metric_names: list[str]):
         self.metric_names = metric_names
         self.start_time = time.perf_counter()
 
@@ -138,7 +138,7 @@ class TuningStatus:
         """
         return len(self.last_trial_status_seen)
 
-    def _num_trials(self, status: Union[str, Set[str]]):
+    def _num_trials(self, status: Union[str, set[str]]):
         if isinstance(status, str):
             status = set([status])
         elif not isinstance(status, set):
@@ -251,8 +251,8 @@ class TuningStatus:
 
 
 def print_best_metric_found(
-    tuning_status: TuningStatus, metric_names: List[str], mode: Optional[str] = None
-) -> Optional[Tuple[int, float]]:
+    tuning_status: TuningStatus, metric_names: list[str], mode: Optional[str] = None
+) -> Optional[tuple[int, float]]:
     """Prints trial status summary and the best metric found.
 
     :param tuning_status: Current tuning status

--- a/syne_tune/util.py
+++ b/syne_tune/util.py
@@ -8,9 +8,8 @@ from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from time import perf_counter
-from typing import Optional, Dict, Any, Iterable
-from typing import Tuple, Union, List
-
+from typing import Optional, Any, Union
+from collections.abc import Iterable
 import numpy as np
 
 from syne_tune.constants import (
@@ -143,7 +142,7 @@ def catchtime(name: str) -> float:
         print(f"Time for {name}: {perf_counter() - start:.4f} secs")
 
 
-def is_increasing(lst: List[Union[float, int]]) -> bool:
+def is_increasing(lst: list[Union[float, int]]) -> bool:
     """
     :param lst: List of float or int entries
     :return: Is ``lst`` strictly increasing?
@@ -151,7 +150,7 @@ def is_increasing(lst: List[Union[float, int]]) -> bool:
     return all(x < y for x, y in zip(lst, lst[1:]))
 
 
-def is_positive_integer(lst: List[int]) -> bool:
+def is_positive_integer(lst: list[int]) -> bool:
     """
     :param lst: List of int entries
     :return: Are all entries of ``lst`` of type ``int`` and positive?
@@ -192,7 +191,7 @@ def dump_json_with_numpy(
         return None
 
 
-def dict_get(params: Dict[str, Any], key: str, default: Any) -> Any:
+def dict_get(params: dict[str, Any], key: str, default: Any) -> Any:
     """
     Returns ``params[key]`` if this exists and is not None, and ``default`` otherwise.
     Note that this is not the same as ``params.get(key, default)``. Namely, if ``params[key]``
@@ -208,10 +207,10 @@ def dict_get(params: Dict[str, Any], key: str, default: Any) -> Any:
 
 
 def recursive_merge(
-    a: Dict[str, Any],
-    b: Dict[str, Any],
-    stop_keys: Optional[List[str]] = None,
-) -> Dict[str, Any]:
+    a: dict[str, Any],
+    b: dict[str, Any],
+    stop_keys: Optional[list[str]] = None,
+) -> dict[str, Any]:
     """
     Merge dictionaries ``a`` and ``b``, where ``b`` takes precedence. We
     typically use this to modify a dictionary ``a``, so ``b`` is smaller
@@ -260,8 +259,8 @@ def find_first_of_type(a: Iterable[Any], typ) -> Optional[Any]:
 
 
 def metric_name_mode(
-    metric_names: List[str], metric_mode: Union[str, List[str]], metric: Union[str, int]
-) -> Tuple[str, str]:
+    metric_names: list[str], metric_mode: Union[str, list[str]], metric: Union[str, int]
+) -> tuple[str, str]:
     """
     Retrieve the metric mode given a metric queried by either index or name.
     :param metric_names: metrics names defined in a scheduler

--- a/syne_tune/utils/checkpoint.py
+++ b/syne_tune/utils/checkpoint.py
@@ -1,4 +1,5 @@
-from typing import Callable, Any, Optional, Dict
+from typing import Any, Optional
+from collections.abc import Callable
 import argparse
 import os
 
@@ -17,7 +18,7 @@ def add_checkpointing_to_argparse(parser: argparse.ArgumentParser):
 
 
 def resume_from_checkpointed_model(
-    config: Dict[str, Any], load_model_fn: Callable[[str], int]
+    config: dict[str, Any], load_model_fn: Callable[[str], int]
 ) -> int:
     """
     Checks whether there is a checkpoint to be resumed from. If so, the
@@ -49,7 +50,7 @@ def resume_from_checkpointed_model(
 
 
 def checkpoint_model_at_rung_level(
-    config: Dict[str, Any], save_model_fn: Callable[[str, int], Any], resource: int
+    config: dict[str, Any], save_model_fn: Callable[[str, int], Any], resource: int
 ):
     """
     If checkpointing is supported, checks whether a checkpoint is to be
@@ -86,7 +87,7 @@ MUTABLE_STATE_PREFIX = "st_mutable_"
 
 
 def pytorch_load_save_functions(
-    state_dict_objects: Dict[str, Any],
+    state_dict_objects: dict[str, Any],
     mutable_state: Optional[dict] = None,
     fname: str = "checkpoint.json",
 ):

--- a/syne_tune/utils/config_as_json.py
+++ b/syne_tune/utils/config_as_json.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 import argparse
 import json
 
@@ -14,7 +14,7 @@ def add_config_json_to_argparse(parser: argparse.ArgumentParser):
     parser.add_argument(f"--{ST_CONFIG_JSON_FNAME_ARG}", type=str)
 
 
-def load_config_json(args: Dict[str, Any]) -> Dict[str, Any]:
+def load_config_json(args: dict[str, Any]) -> dict[str, Any]:
     """
     Loads configuration from JSON file and returns the union with ``args``.
 

--- a/syne_tune/utils/convert_domain.py
+++ b/syne_tune/utils/convert_domain.py
@@ -1,7 +1,7 @@
 # This file has been taken from Ray. The reason for reusing the file is to be able to support the same API when
 # defining search space while avoiding to have Ray as a required dependency. We may want to add functionality in the
 # future.
-from typing import Dict, Any, Union, Optional, List
+from typing import Any, Union, Optional
 from numbers import Real
 import numpy as np
 import logging
@@ -24,7 +24,7 @@ from syne_tune.util import is_integer
 logger = logging.getLogger(__name__)
 
 
-def fit_to_regular_grid(x: np.ndarray) -> Dict[str, float]:
+def fit_to_regular_grid(x: np.ndarray) -> dict[str, float]:
     r"""
     Computes the least squares fit of :math:`a * j + b` to ``x[j]``, where
     :math:`j = 0,\dots, n-1`. Returns the LS estimate of ``a``, ``b``, and the
@@ -179,10 +179,10 @@ def convert_domain(domain: Domain, name: Optional[str] = None) -> Domain:
 
 
 def streamline_config_space(
-    config_space: Dict[str, Any],
-    exclude_names: Optional[List[str]] = None,
+    config_space: dict[str, Any],
+    exclude_names: Optional[list[str]] = None,
     verbose: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Given a configuration space ``config_space``, this function returns a new
     configuration space where some domains may have been replaced by approximately

--- a/tst/blackbox_repository/test_data_consistency.py
+++ b/tst/blackbox_repository/test_data_consistency.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional, List
+from typing import Optional
 import pytest
 import numpy as np
 
@@ -108,7 +108,7 @@ def create_blackbox(benchmark: BenchmarkDefinition):
     return blackbox
 
 
-def _assert_strictly_increasing(elapsed_times: List[float], error_prefix: str):
+def _assert_strictly_increasing(elapsed_times: list[float], error_prefix: str):
     error_msg_parts = []
     for pos, (et1, et2) in enumerate(zip(elapsed_times[:-1], elapsed_times[1:])):
         if et1 >= et2:
@@ -120,7 +120,7 @@ def _assert_strictly_increasing(elapsed_times: List[float], error_prefix: str):
     assert not error_msg, error_msg
 
 
-def _assert_no_extreme_deviations(elapsed_times: List[float], error_prefix: str):
+def _assert_no_extreme_deviations(elapsed_times: list[float], error_prefix: str):
     pairs = list(zip(elapsed_times[:-1], elapsed_times[1:]))
     epoch_times = [et2 - et1 for et1, et2 in pairs]
     median_val = np.median(epoch_times)

--- a/tst/callbacks/test_hyperband_remove_checkpoints.py
+++ b/tst/callbacks/test_hyperband_remove_checkpoints.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Dict, Any
+from typing import Any
 import numpy as np
 from scipy.special import betainc
 
@@ -12,7 +12,7 @@ from syne_tune.callbacks.hyperband_remove_checkpoints_callback import (
 
 def _q_vals_betainc(
     l_val: int, p_val: float
-) -> Tuple[float, float, float, float, float]:
+) -> tuple[float, float, float, float, float]:
     u_vals = np.arange(5)
     cdf_vals = betainc(
         np.maximum(l_val - u_vals, 1e-7), u_vals + 1, np.array([1 - p_val])
@@ -23,8 +23,8 @@ def _q_vals_betainc(
 
 
 def _q_vals(
-    n_val: int, p_val: float, s_pos: int, i_pos: int, extra: Dict[str, Any]
-) -> Tuple[float, float, float, float, float]:
+    n_val: int, p_val: float, s_pos: int, i_pos: int, extra: dict[str, Any]
+) -> tuple[float, float, float, float, float]:
     r"""
     Probabilities of binomial :math:`\mathrm{bin}(l, p)` to be equal to
     ``0, 1, 2, 3, 4``.
@@ -45,7 +45,7 @@ def _q_vals(
     return q0, q1, q2, q3, q4
 
 
-def _append_column(m_vals: List[np.ndarray], i: int, col: np.ndarray):
+def _append_column(m_vals: list[np.ndarray], i: int, col: np.ndarray):
     num_m = len(m_vals)
     col = col.reshape((-1, 1))
     if i >= num_m:
@@ -56,7 +56,7 @@ def _append_column(m_vals: List[np.ndarray], i: int, col: np.ndarray):
 
 
 def compute_probability_resumed(
-    l_ind: List[int], p_val: float, s_pos: int, extra: Dict[str, Any]
+    l_ind: list[int], p_val: float, s_pos: int, extra: dict[str, Any]
 ) -> float:
     """
     Here, ``l_ind`` must have length 5

--- a/tst/schedulers/bayesopt/gpautograd/test_comparison_gpy.py
+++ b/tst/schedulers/bayesopt/gpautograd/test_comparison_gpy.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Dict, Any
+from typing import Any
 import numpy as np
 import pickle
 import tempfile
@@ -86,10 +86,10 @@ def download(url, path=None, overwrite=False):
 # Note: Instead of a ScalarMeanFunction, we use a ZeroMeanFunction here. This
 # is because it is too annoying to make GPy use such a mean function
 def fit_predict_ours(
-    data: Dict[str, Any],
+    data: dict[str, Any],
     random_seed: int,
     optimization_config: OptimizationConfig,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     # Create surrogate model
     num_dims = len(data["ss_limits"])
     _gpmodel = GaussianProcessRegression(
@@ -113,8 +113,8 @@ def fit_predict_ours(
 # GPy as a dependency of the tests. With GPy 1.9.9, it can be executed to generate
 # the numerical values that are tested in the main testing function ``test_comparison_gpy``
 def fit_predict_gpy(
-    data: Dict[str, Any], random_seed: int, optimization_config: OptimizationConfig
-) -> Dict[str, Any]:
+    data: dict[str, Any], random_seed: int, optimization_config: OptimizationConfig
+) -> dict[str, Any]:
     import GPy  # Needs GPy to be installed
 
     assert GPy.__version__ == "1.9.9"
@@ -174,7 +174,7 @@ def fit_predict_gpy(
     return {"means": means, "stddevs": stddevs}
 
 
-def _plot_comparison(y_list: List[np.ndarray]):
+def _plot_comparison(y_list: list[np.ndarray]):
     import matplotlib.pyplot as plt
 
     yshape = y_list[0].shape
@@ -191,9 +191,9 @@ def _plot_comparison(y_list: List[np.ndarray]):
 # Note: this function is not ran by the tests but can be executed separately
 # to get a visual interpretation, see ``test_comparison_gpy``
 def plot_predictions(
-    data: Dict[str, Any],
-    pred_ours: Dict[str, Any],
-    pred_gpy: Dict[str, Any],
+    data: dict[str, Any],
+    pred_ours: dict[str, Any],
+    pred_gpy: dict[str, Any],
     title: str,
 ):
     import matplotlib.pyplot as plt

--- a/tst/schedulers/bayesopt/test_bayesopt_cei.py
+++ b/tst/schedulers/bayesopt/test_bayesopt_cei.py
@@ -1,4 +1,3 @@
-from typing import List
 import numpy as np
 import pytest
 
@@ -61,7 +60,7 @@ def _construct_models(X, Y, metric, hp_ranges, do_mcmc, with_pending):
 
 def default_models(
     metric, do_mcmc=True, with_pending=False
-) -> List[GaussProcPredictor]:
+) -> list[GaussProcPredictor]:
     config_space = {"x": uniform(0.0, 1.0), "y": uniform(0.0, 1.0)}
     hp_ranges = make_hyperparameter_ranges(config_space)
     X = [(0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (1.0, 1.0)]
@@ -99,7 +98,7 @@ def _build_models_with_and_without_feasible_candidates(do_mcmc, with_pending):
 
 def default_models_all_infeasible(
     metric, do_mcmc=True, with_pending=False
-) -> List[GaussProcPredictor]:
+) -> list[GaussProcPredictor]:
     config_space = {"x": uniform(0.0, 1.0), "y": uniform(0.0, 1.0)}
     hp_ranges = make_hyperparameter_ranges(config_space)
     X = [

--- a/tst/schedulers/bayesopt/test_bayesopt_ei.py
+++ b/tst/schedulers/bayesopt/test_bayesopt_ei.py
@@ -1,4 +1,3 @@
-from typing import List
 import numpy as np
 import pytest
 
@@ -59,7 +58,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.test_objects import
 #
 # In fact, if EI is optimized starting at a point outside [0, 0.1]^2, the optimizer
 # returns with the starting point, and test_optimization_improves fails.
-def default_models(do_mcmc=True) -> List[GaussProcPredictor]:
+def default_models(do_mcmc=True) -> list[GaussProcPredictor]:
     config_space = {"x": uniform(0.0, 1.0), "y": uniform(0.0, 1.0)}
     hp_ranges = make_hyperparameter_ranges(config_space)
     X = [(0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (1.0, 1.0)]

--- a/tst/schedulers/bayesopt/test_bayesopt_eipu.py
+++ b/tst/schedulers/bayesopt/test_bayesopt_eipu.py
@@ -1,4 +1,3 @@
-from typing import List
 import numpy as np
 import pytest
 
@@ -42,7 +41,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.test_objects import
 COST_METRIC_NAME = "cost_metric"
 
 
-def default_models(metric, do_mcmc=True) -> List[GaussProcPredictor]:
+def default_models(metric, do_mcmc=True) -> list[GaussProcPredictor]:
     config_space = {"x": uniform(0.0, 1.0), "y": uniform(0.0, 1.0)}
     hp_ranges = make_hyperparameter_ranges(config_space)
     X = [(0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (1.0, 1.0)]

--- a/tst/schedulers/bayesopt/test_common.py
+++ b/tst/schedulers/bayesopt/test_common.py
@@ -1,4 +1,3 @@
-from typing import List, Set, Tuple
 import pytest
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common import (
@@ -51,10 +50,10 @@ def hp_ranges():
 )
 def test_compute_blacklisted_candidates(
     hp_ranges: HyperparameterRanges,
-    observed_data: List[Tuple],
-    failed_tuples: List[Tuple],
-    pending_tuples: List[Tuple],
-    expected: Set[str],
+    observed_data: list[tuple],
+    failed_tuples: list[tuple],
+    pending_tuples: list[tuple],
+    expected: set[str],
 ):
     if observed_data:
         cand_tuples, metrics = zip(*observed_data)
@@ -75,7 +74,7 @@ def test_compute_blacklisted_candidates(
 
 
 def _assert_no_duplicates(
-    candidates: List[Configuration], hp_ranges: HyperparameterRanges
+    candidates: list[Configuration], hp_ranges: HyperparameterRanges
 ):
     cands_tpl = [hp_ranges.config_to_match_string(x) for x in candidates]
     assert len(candidates) == len(set(cands_tpl))

--- a/tst/schedulers/bayesopt/test_expdecay_model.py
+++ b/tst/schedulers/bayesopt/test_expdecay_model.py
@@ -1,4 +1,3 @@
-from typing import Dict
 import json
 import numpy as np
 import pytest
@@ -19,7 +18,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.tuning_job_stat
 )
 
 
-def _common_kwargs(config_space: Dict) -> Dict:
+def _common_kwargs(config_space: dict) -> dict:
     return {
         "config_space": config_space,
         "max_epochs": config_space["epochs"],
@@ -32,7 +31,7 @@ def _common_kwargs(config_space: Dict) -> Dict:
     }
 
 
-def build_gp_estimator(config_space: Dict, model_params: Dict) -> Dict:
+def build_gp_estimator(config_space: dict, model_params: dict) -> dict:
     kwargs = dict(
         _common_kwargs(config_space),
         model="gp_multitask",
@@ -53,7 +52,7 @@ def _convert_keys(dict_old, dict_new, pref_old, pref_new):
             dict_new[k_new] = v
 
 
-def _convert_model_params(model_params: Dict) -> Dict:
+def _convert_model_params(model_params: dict) -> dict:
     """
     Convert from ``GaussianProcessRegression`` to
     ``GaussianProcessLearningCurveModel`` parameters.
@@ -69,7 +68,7 @@ def _convert_model_params(model_params: Dict) -> Dict:
     return new_model_params
 
 
-def build_gped_estimator(config_space: Dict, model_params: Dict, **kwargs):
+def build_gped_estimator(config_space: dict, model_params: dict, **kwargs):
     kwargs = dict(
         _common_kwargs(config_space),
         model="gp_expdecay",

--- a/tst/schedulers/bayesopt/test_gaussproc.py
+++ b/tst/schedulers/bayesopt/test_gaussproc.py
@@ -1,4 +1,3 @@
-from typing import List
 import numpy as np
 import pytest
 
@@ -258,7 +257,7 @@ def test_gp_fantasizing():
     assert np.allclose(grads, grads2)
 
 
-def default_models() -> List[GaussProcPredictor]:
+def default_models() -> list[GaussProcPredictor]:
     hp_ranges = _simple_hp_ranges()
     X = [
         (0.0, 0.0),

--- a/tst/schedulers/bayesopt/test_sklearn_surrogate.py
+++ b/tst/schedulers/bayesopt/test_sklearn_surrogate.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import numpy as np
 import pytest
 
@@ -30,7 +28,7 @@ from syne_tune.optimizer.schedulers.searchers.utils.hp_ranges_factory import (
 
 
 class TestPredictor(SKLearnPredictor):
-    def predict(self, X: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def predict(self, X: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         nexamples = X.shape[0]
         return np.ones_like(nexamples), np.zeros(nexamples)
 

--- a/tst/schedulers/bayesopt/test_subsample_state.py
+++ b/tst/schedulers/bayesopt/test_subsample_state.py
@@ -1,4 +1,4 @@
-from typing import Tuple, List, Optional, Dict, Any
+from typing import Optional, Any
 import pytest
 from operator import itemgetter
 from numpy.random import RandomState
@@ -28,7 +28,7 @@ from syne_tune.optimizer.schedulers.utils.successive_halving import (
 
 
 def _state_from_data(
-    data: List[Tuple[int, int]], hp_ranges: HyperparameterRanges
+    data: list[tuple[int, int]], hp_ranges: HyperparameterRanges
 ) -> TuningJobState:
     trial_ids = set(i for i, _ in data)
     config_for_trial = {str(trial_id): dict() for trial_id in trial_ids}
@@ -41,7 +41,7 @@ def _state_from_data(
     )
 
 
-def _data_from_state(state: TuningJobState) -> List[Tuple[int, int]]:
+def _data_from_state(state: TuningJobState) -> list[tuple[int, int]]:
     return [(i, r) for i, r, _ in _extract_observations(state.trials_evaluations)]
 
 
@@ -238,8 +238,8 @@ def test_cap_size_tuning_job_state(data, result_part, max_size):
 
 
 def _partition_wrt_rung_levels(
-    data: List[Tuple[int, int]], rung_levels: List[int]
-) -> List[List[Tuple[int, int]]]:
+    data: list[tuple[int, int]], rung_levels: list[int]
+) -> list[list[tuple[int, int]]]:
     r"""
     Partitions ``data`` into parts according to :math:`r_j < r \le r_{j+1}`,
     where :math:`[r_j]` is ``rung_levels``.
@@ -256,8 +256,8 @@ def _partition_wrt_rung_levels(
 
 
 def _sparsify_at_most_one_per_trial(
-    data: List[Tuple[int, int]], target_size: Optional[int]
-) -> List[Tuple[int, int]]:
+    data: list[tuple[int, int]], target_size: Optional[int]
+) -> list[tuple[int, int]]:
     """
     Filters ``data`` so that for every trial ID :math:`i` in ``data``, only
     the entry with the largest resource :math:`r` is retained. If ``target_size``
@@ -285,8 +285,8 @@ def _sparsify_at_most_one_per_trial(
 
 
 def _sparsify_data(
-    data: List[Tuple[int, int]], max_size: int, rung_levels: List[int]
-) -> List[Tuple[int, int]]:
+    data: list[tuple[int, int]], max_size: int, rung_levels: list[int]
+) -> list[tuple[int, int]]:
     """
     Does the same as
     :func:`~syne_tune.optimizer.schedulers.searchers.bayesopt.models.subsample_state.sparsify_tuning_job_state`,
@@ -315,8 +315,8 @@ def _sparsify_data(
 
 
 def _error_message_comparison(
-    data1: List[Tuple[int, int]],
-    data2: List[Tuple[int, int]],
+    data1: list[tuple[int, int]],
+    data2: list[tuple[int, int]],
 ) -> str:
     parts = [
         f"{x}   {y}"
@@ -331,7 +331,7 @@ def _random_data(
     random_state: RandomState,
     r_min: Optional[int] = None,
     r_step: Optional[int] = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     # Create data at random
     num_trials = random_state.randint(low=1, high=30)
     if r_min is None:
@@ -410,8 +410,8 @@ def test_sparsify_tuning_job_state():
 
 
 def _sparsify_data_simple(
-    data: List[Tuple[int, int]], max_size: int, rung_levels: List[int]
-) -> List[Tuple[int, int]]:
+    data: list[tuple[int, int]], max_size: int, rung_levels: list[int]
+) -> list[tuple[int, int]]:
     """
     Different to :func:`_sparsify_data` above, data for trial :math:`i` is
     given for resource levels :math:`1, 2, \dots, r_i`.
@@ -486,7 +486,7 @@ def test_sparsify_tuning_job_state_simple():
 
 
 def _state_from_data_singlefid(
-    data: List[Tuple[int, float]], hp_ranges: HyperparameterRanges
+    data: list[tuple[int, float]], hp_ranges: HyperparameterRanges
 ) -> TuningJobState:
     trial_ids = set(i for i, _ in data)
     config_for_trial = {str(trial_id): dict() for trial_id in trial_ids}
@@ -499,7 +499,7 @@ def _state_from_data_singlefid(
     )
 
 
-def _data_from_state_singlefid(state: TuningJobState) -> List[Tuple[int, float]]:
+def _data_from_state_singlefid(state: TuningJobState) -> list[tuple[int, float]]:
     return _extract_observations_singlefid(state.trials_evaluations)
 
 

--- a/tst/schedulers/multiobjective/test_simple_scalarizer.py
+++ b/tst/schedulers/multiobjective/test_simple_scalarizer.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Callable
+from collections.abc import Callable
 
 import pytest
 

--- a/tst/schedulers/test_hyperband.py
+++ b/tst/schedulers/test_hyperband.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional, Dict, Tuple, Any
+from typing import Optional, Any
 import pytest
 import numpy as np
 
@@ -30,7 +30,7 @@ def _make_result(epoch, metric):
     return dict(epoch=epoch, metric=metric)
 
 
-def _new_trial(trial_id: int, config: Dict[str, Any]):
+def _new_trial(trial_id: int, config: dict[str, Any]):
     return Trial(trial_id=trial_id, config=config, creation_time=datetime.now())
 
 
@@ -40,7 +40,7 @@ class MyRandomSearcher(LegacyRandomSearcher):
         self._pending_records = []
 
     def register_pending(
-        self, trial_id: str, config: Optional[Dict] = None, milestone=None
+        self, trial_id: str, config: Optional[dict] = None, milestone=None
     ):
         self._pending_records.append((trial_id, config, milestone))
 
@@ -50,7 +50,7 @@ class MyRandomSearcher(LegacyRandomSearcher):
         return result
 
 
-def _should_be(record: Tuple, trial_id: int, milestone: int, config_none: bool):
+def _should_be(record: tuple, trial_id: int, milestone: int, config_none: bool):
     assert record[0] == str(trial_id) and record[2] == milestone, (
         record,
         trial_id,

--- a/tst/schedulers/test_hyperband_cost_promotion.py
+++ b/tst/schedulers/test_hyperband_cost_promotion.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 from datetime import datetime
 
 from syne_tune.optimizer.schedulers.legacy_hyperband import LegacyHyperbandScheduler
@@ -11,7 +11,7 @@ def _make_result(epoch, metric, cost):
     return dict(epoch=epoch, metric=metric, cost=cost)
 
 
-def _new_trial(trial_id: int, config: Dict[str, Any]):
+def _new_trial(trial_id: int, config: dict[str, Any]):
     return Trial(trial_id=trial_id, config=config, creation_time=datetime.now())
 
 

--- a/tst/schedulers/test_hyperband_sychronous.py
+++ b/tst/schedulers/test_hyperband_sychronous.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Optional
+from typing import Optional
 import numpy as np
 from collections import Counter
 import pytest
@@ -25,7 +25,7 @@ def _ask_for_slots(
     level: int,
     slot_index: int,
     trial_ids: list,
-) -> (List[SlotInRung], int):
+) -> (list[SlotInRung], int):
     slots = []
     for trial_id in trial_ids:
         slot_in_rung = bracket.next_free_slot()
@@ -45,9 +45,9 @@ def _ask_for_slots(
 
 def _send_results(
     bracket: SynchronousHyperbandBracket,
-    slots: List[SlotInRung],
-    all_results: List[Tuple[int, float]],
-    trials_not_promoted: Optional[List[int]],
+    slots: list[SlotInRung],
+    all_results: list[tuple[int, float]],
+    trials_not_promoted: Optional[list[int]],
 ):
     trials_n_p = None
     for slot_in_rung in slots:
@@ -160,7 +160,7 @@ def test_hyperband_bracket():
 
 def _send_result(
     bracket_manager: SynchronousHyperbandBracketManager,
-    slots: List[Tuple[int, SlotInRung]],
+    slots: list[tuple[int, SlotInRung]],
     next_trial_id: int,
     random_state: np.random.RandomState,
 ) -> int:

--- a/tst/test_experiment_path.py
+++ b/tst/test_experiment_path.py
@@ -1,6 +1,5 @@
 import os
 from pathlib import Path
-from typing import Dict
 
 import pytest
 
@@ -34,7 +33,7 @@ from syne_tune.util import experiment_path
     ],
 )
 def test_experiment_path(
-    tuner_name: str, local_path: str, env: Dict, expected_path: str
+    tuner_name: str, local_path: str, env: dict, expected_path: str
 ):
     try:
         env_prev = os.environ.copy()

--- a/tst/test_legacy_pointstoevaluate.py
+++ b/tst/test_legacy_pointstoevaluate.py
@@ -1,4 +1,3 @@
-from typing import Dict
 import numpy as np
 import pytest
 
@@ -31,7 +30,7 @@ def _log_avg(a, b):
     return np.exp(0.5 * (np.log(b) + np.log(a)))
 
 
-def _impute_config(config: Dict) -> Dict:
+def _impute_config(config: dict) -> dict:
     new_config = config.copy()
     k, lower, upper = "int", 1, 5
     if k not in config:

--- a/tst/test_random_seed.py
+++ b/tst/test_random_seed.py
@@ -1,4 +1,3 @@
-from typing import Dict
 import pytest
 import itertools
 import logging
@@ -26,7 +25,7 @@ class StoreConfigCallback(TunerCallback):
     def _to_tuple(self, config):
         return tuple(config[k] for k in self._keys)
 
-    def on_trial_result(self, trial: Trial, status: str, result: Dict, decision: str):
+    def on_trial_result(self, trial: Trial, status: str, result: dict, decision: str):
         config = self._reduce(trial.config)
         key = self._to_tuple(config)
         if key not in self._configs_set:

--- a/tst/trial_backend/test_fetch_results.py
+++ b/tst/trial_backend/test_fetch_results.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Optional, Any
+from typing import Optional, Any
 
 from syne_tune.backend.trial_backend import TrialBackend
 from syne_tune.backend.trial_status import TrialResult, Status
@@ -17,7 +17,7 @@ class DeterministicBackend(TrialBackend):
         self.timestamp = 0
 
     def generate_event(
-        self, trial_id: int, metrics: List[Dict], status: Optional[str] = None
+        self, trial_id: int, metrics: list[dict], status: Optional[str] = None
     ):
         for m in metrics:
             m[ST_WORKER_TIMESTAMP] = self.timestamp
@@ -37,25 +37,25 @@ class DeterministicBackend(TrialBackend):
                 training_end_time=None,
             )
 
-    def _all_trial_results(self, trial_ids: List[int]) -> List[TrialResult]:
+    def _all_trial_results(self, trial_ids: list[int]) -> list[TrialResult]:
         return [self.trialid_to_results[trial_id] for trial_id in trial_ids]
 
     def _resume_trial(self, trial_id: int):
         pass
 
-    def _pause_trial(self, trial_id: int, result: Dict[str, Any]):
+    def _pause_trial(self, trial_id: int, result: dict[str, Any]):
         pass
 
-    def _stop_trial(self, trial_id: int, result: Dict[str, Any]):
+    def _stop_trial(self, trial_id: int, result: dict[str, Any]):
         pass
 
-    def _schedule(self, trial_id: int, config: Dict):
+    def _schedule(self, trial_id: int, config: dict):
         pass
 
-    def stdout(self, trial_id: int) -> List[str]:
+    def stdout(self, trial_id: int) -> list[str]:
         return []
 
-    def stderr(self, trial_id: int) -> List[str]:
+    def stderr(self, trial_id: int) -> list[str]:
         return []
 
 

--- a/tst/trial_backend/test_local_trial_backend.py
+++ b/tst/trial_backend/test_local_trial_backend.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Optional, List, Dict, Any
+from typing import Optional,Any
 
 import pytest
 
@@ -151,14 +151,14 @@ def test_start_config_previous_checkpoint(caplog):
     assert results == ["nothing", "nothing", "state-0", "state-1"]
 
 
-def _map_gpu(gpu: int, gpus_to_use: Optional[List[int]]) -> int:
+def _map_gpu(gpu: int, gpus_to_use: Optional[list[int]]) -> int:
     return gpu if gpus_to_use is None else gpus_to_use[gpu]
 
 
 def _assert_cuda_visible_devices(
-    env: Dict[str, Any],
-    gpus_to_use: Optional[List[int]],
-    visible_devices: List[int],
+    env: dict[str, Any],
+    gpus_to_use: Optional[list[int]],
+    visible_devices: list[int],
 ):
     cuda_visible_devices = ",".join(
         str(_map_gpu(gpu, gpus_to_use)) for gpu in visible_devices

--- a/tst/trial_backend/test_local_trial_backend.py
+++ b/tst/trial_backend/test_local_trial_backend.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Optional,Any
+from typing import Optional, Any
 
 import pytest
 

--- a/tst/trial_backend/test_simulator_trial_backend.py
+++ b/tst/trial_backend/test_simulator_trial_backend.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 import math
 import pytest
 
@@ -23,7 +23,7 @@ from syne_tune.optimizer.schedulers.legacy_fifo import LegacyFIFOScheduler
 from syne_tune.optimizer.scheduler import SchedulerDecision
 
 
-def _compare_results(res_local: Dict[str, Any], res_simul: Dict[str, Any], num: int):
+def _compare_results(res_local: dict[str, Any], res_simul: dict[str, Any], num: int):
     for key in (ST_TRIAL_ID, ST_DECISION, "epoch", "mean_loss"):
         rloc = res_local[key]
         rsim = res_simul[key]

--- a/tst/util_test.py
+++ b/tst/util_test.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Optional
 import tempfile
 import time
 
@@ -34,7 +34,7 @@ from examples.training_scripts.height_example.blackbox_height import (
 class TestPredictor(SKLearnPredictor):
     def predict(
         self, X: np.ndarray, return_std: bool = True
-    ) -> Tuple[np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray]:
         nexamples = X.shape[0]
         return np.ones(nexamples), np.ones(nexamples)
 


### PR DESCRIPTION
Removes type imports which will deprecate in the future, like `List`, `Dict`, `Set`, `Tuple` and replaces them with native types. Changed imports of `Callable`, `Iterator` and `Iterable` to import from `collections.abc`. Used this [article](https://medium.com/@anuraagkhare_39064/typing-module-deprecated-in-python-what-you-need-to-know-d4348b694141) as linked in the issue.

Closes #880.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
