### PR TITLE
Fix: Fix hpob import

### DIFF
--- a/benchmarking/results_analysis/show_results.py
+++ b/benchmarking/results_analysis/show_results.py
@@ -46,6 +46,22 @@ benchmark_families = [
     "tabrepo-LightGBM",
     "tabrepo-CatBoost",
     # "yahpo"
+    "hpob_4796",
+    "hpob_5527",
+    "hpob_5636",
+    "hpob_5859",
+    "hpob_5860",
+    "hpob_5891",
+    "hpob_5906",
+    "hpob_5965",
+    "hpob_5970",
+    "hpob_5971",
+    "hpob_6766",
+    "hpob_6767",
+    "hpob_6794",
+    "hpob_7607",
+    "hpob_7609",
+    "hpob_5889"
 ]
 benchmark_names = {
     "fcnet": "\\FCNet{}",
@@ -248,7 +264,26 @@ def stack_benchmark_results(
             # (num_benchmarks, num_methods, num_min_seeds, num_time_steps)
             benchmark_results = np.stack(benchmark_results)
 
-            if benchmark_family in ["lcbench", "yahpo"]:
+            if benchmark_family in [
+                "lcbench",
+                "yahpo",
+                "hpob_4796",
+                "hpob_5527",
+                "hpob_5636",
+                "hpob_5859",
+                "hpob_5860",
+                "hpob_5891",
+                "hpob_5906",
+                "hpob_5965",
+                "hpob_5970",
+                "hpob_5971",
+                "hpob_6766",
+                "hpob_6767",
+                "hpob_6794",
+                "hpob_7607",
+                "hpob_7609",
+                "hpob_5889"
+            ]:
                 # max instead of minimization, todo pass the mode somehow
                 benchmark_results *= -1
 

--- a/benchmarking/results_analysis/show_results.py
+++ b/benchmarking/results_analysis/show_results.py
@@ -61,7 +61,7 @@ benchmark_families = [
     "hpob_6794",
     "hpob_7607",
     "hpob_7609",
-    "hpob_5889"
+    "hpob_5889",
 ]
 benchmark_names = {
     "fcnet": "\\FCNet{}",
@@ -282,7 +282,7 @@ def stack_benchmark_results(
                 "hpob_6794",
                 "hpob_7607",
                 "hpob_7609",
-                "hpob_5889"
+                "hpob_5889",
             ]:
                 # max instead of minimization, todo pass the mode somehow
                 benchmark_results *= -1

--- a/examples/launch_hpob.py
+++ b/examples/launch_hpob.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
     n_workers = 4
 
     metric = "metric_accuracy"
-    blackbox = load_blackbox("hpob_4796", local_files_only=True)["3549"]
+    blackbox = load_blackbox("hpob_4796")["3549"]
     trial_backend = BlackboxRepositoryBackend(
         blackbox_name="hpob_4796",
         dataset="3549",

--- a/examples/launch_hpob.py
+++ b/examples/launch_hpob.py
@@ -21,7 +21,7 @@ def simulate_benchmark(blackbox, trial_backend, metric):
         ),
         metric=metric,
         random_seed=31415927,
-        do_minimize=False
+        do_minimize=False,
     )
 
     stop_criterion = StoppingCriterion(max_wallclock_time=600)

--- a/examples/launch_hpob.py
+++ b/examples/launch_hpob.py
@@ -9,21 +9,22 @@ from syne_tune.blackbox_repository import (
 )
 
 from syne_tune.backend.simulator_backend.simulator_callback import SimulatorCallback
-from syne_tune.optimizer.baselines import RandomSearch
+from syne_tune.optimizer.baselines import RandomSearch, CQR
 from syne_tune import StoppingCriterion, Tuner
 
 
 def simulate_benchmark(blackbox, trial_backend, metric):
     max_resource_attr = "epochs"
-    scheduler = RandomSearch(
+    scheduler = CQR(
         config_space=blackbox.configuration_space_with_max_resource_attr(
             max_resource_attr
         ),
-        metrics=[metric],
+        metric=metric,
         random_seed=31415927,
+        do_minimize=False
     )
 
-    stop_criterion = StoppingCriterion(max_wallclock_time=7200)
+    stop_criterion = StoppingCriterion(max_wallclock_time=600)
 
     tuner = Tuner(
         trial_backend=trial_backend,
@@ -42,7 +43,7 @@ if __name__ == "__main__":
     n_workers = 4
 
     metric = "metric_accuracy"
-    blackbox = load_blackbox("hpob_4796")["3549"]
+    blackbox = load_blackbox("hpob_4796", local_files_only=True)["3549"]
     trial_backend = BlackboxRepositoryBackend(
         blackbox_name="hpob_4796",
         dataset="3549",

--- a/examples/launch_hpob.py
+++ b/examples/launch_hpob.py
@@ -9,7 +9,7 @@ from syne_tune.blackbox_repository import (
 )
 
 from syne_tune.backend.simulator_backend.simulator_callback import SimulatorCallback
-from syne_tune.optimizer.baselines import RandomSearch, CQR
+from syne_tune.optimizer.baselines import CQR
 from syne_tune import StoppingCriterion, Tuner
 
 

--- a/syne_tune/blackbox_repository/conversion_scripts/scripts/hpob_import.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/scripts/hpob_import.py
@@ -15,8 +15,8 @@ from syne_tune.blackbox_repository.conversion_scripts.blackbox_recipe import (
 )
 from syne_tune.config_space import (
     uniform,
-    loguniform,
     randint,
+    choice,
     config_space_to_json_dict,
     config_space_from_json_dict,
 )
@@ -33,218 +33,245 @@ BLACKBOX_NAME = "hpob_"
 METRIC_ELAPSED_TIME = "metric_elapsed_time"
 
 # configuration_space values taken from "https://raw.githubusercontent.com/machinelearningnuremberg/HPO-B/refs/heads/main/hpob-data/meta-dataset-descriptors.json"
+
 SEARCH_SPACE_4796 = {
     "name": "4796",
+    "positions_hps": {"minsplit": 0, "minbucket": 1, "cp": 2},
+    "positions_categorical": {},
     "config_space": {
-        "minsplit": loguniform(2.0, 128.0),
-        "minbucket": loguniform(1.0, 64.0),
-        "cp": loguniform(0.0002, 0.1),
+        "minsplit": uniform(0.0, 1.0),
+        "minbucket": uniform(0.0, 1.0),
+        "cp": uniform(0.0, 1.0),
     },
 }
 
 SEARCH_SPACE_5527 = {
     "name": "5527",
+    "positions_hps": {"cost": 0, "gamma": 1, "degree": 3},
+    "positions_categorical": {"kernel": [4, 5, 6]},
     "config_space": {
-        "cost": loguniform(0.001, 1024.0),
-        "gamma": loguniform(0.0001, 1024.0),
-        "gamma.na": uniform(0.0, 1.0),
-        "degree": uniform(0.0, 5.0),
-        "degree.na": uniform(0.0, 1.0),
-        "kernel.ohe.na": 308190.0,
-        "kernel.ohe.linear": 316563.0,
-        "kernel.ohe.polynomial": 311266.0,
+        "cost": uniform(0.0, 1.0),
+        "gamma": uniform(0.0, 1.0),
+        "degree": uniform(0.0, 1.0),
+        #"kernel": choice(["_INVALID", "_linear", "_polynomial"]),
+        "kernel": choice([0.0,1.0,2.0])
     },
 }
 SEARCH_SPACE_5636 = {
     "name": "5636",
+    "positions_hps": {"minsplit": 0, "cp": 2, "maxdepth": 3, "minbucket": 4},
+    "positions_categorical": {},
     "config_space": {
-        "minsplit": uniform(0.0, 60.0),
-        "minsplit.na": uniform(0.0, 1.0),
-        "minbucket": uniform(1.0, 60.0),
-        "cp": uniform(-9.2, 9.906167518025702e-5),
-        "maxdepth": uniform(0.0, 29.0),
-        "maxdepth.na": uniform(0.0, 1.0),
+        "minsplit": uniform(0.0, 1.0),
+        "minbucket": uniform(0.0, 1.0),
+        "cp": uniform(0.0, 1.0),
+        "maxdepth": uniform(0.0, 1.0),
     },
 }
 SEARCH_SPACE_5859 = {
     "name": "5859",
+    "positions_hps": {"minsplit": 0, "cp": 2, "maxdepth": 3, "minbucket": 4},
+    "positions_categorical": {},
     "config_space": {
-        "minsplit": uniform(0.0, 60.0),
-        "minsplit.na": uniform(0.0, 1.0),
-        "minbucket": uniform(1.0, 60.0),
-        "cp": loguniform(0.0001, 1.0),
-        "maxdepth": uniform(0.0, 29.0),
-        "maxdepth.na": uniform(0.0, 1.0),
+        "minsplit": uniform(0.0, 1.0),
+        "minbucket": uniform(1.0, 1.0),
+        "cp": uniform(0.0, 1.0),
+        "maxdepth": uniform(0.0, 1.0),
     },
 }
 SEARCH_SPACE_5860 = {
     "name": "5860",
+    "positions_hps": {"alpha": 0, "lambda": 1},
+    "positions_categorical": {},
     "config_space": {
-        "alpha": loguniform(0.000578, 1.0),
-        "lambda": loguniform(0.001, 1019.35),
+        "alpha": uniform(0.0, 1.0),
+        "lambda": uniform(0.0, 1.0),
     },
 }
 SEARCH_SPACE_5891 = {
     "name": "5891",
+    "positions_hps": {"cost": 0, "gamma": 1, "degree": 3},
+    "positions_categorical": {"kernel": [5, 6, 7]},
     "config_space": {
-        "cost": uniform(0.001, 1024.0),
-        "gamma": uniform(0.0, 1024.0),
-        "gamma.na": uniform(0.0, 1.0),
-        "degree": uniform(0.0, 5.0),
-        "degree.na": uniform(0.0, 1.0),
-        "kernel.ohe.na": 24627,
-        "kernel.ohe.linear": 24952,
-        "kernel.ohe.polynomial": 24813,
+        "cost": uniform(0.0, 1.0),
+        "gamma": uniform(0.0, 1.0),
+        "degree": uniform(0.0, 1.0),
+        #"kernel": choice(["_INVALID", "_linear", "_polynomial"]),
+        "kernel": choice([0.0,1.0,2.0])
     },
 }
 SEARCH_SPACE_5906 = {
     "name": "5906",
+    "positions_hps": {
+        "eta": 0, "max_depth": 1, "min_child_weight": 3, "subsample": 5,
+        "colsample_bytree": 6, "colsample_bylevel": 8,
+        "lambda": 10, "alpha": 11, "nrounds": 12,
+    },
+    "positions_categorical": {"booster": [14, 15]},
     "config_space": {
-        "eta": loguniform(0.001, 1.0),
-        "max_depth": uniform(0.0, 15.0),
-        "max_depth.na": uniform(0.0, 1.0),
-        "min_child_weight": loguniform(0.0001, 128.0),
-        "min_child_weight.na": uniform(0.0, 1.0),
-        "subsample": uniform(0.1, 1.0),
-        "colsample_bytree": loguniform(0.0001, 1.0),
-        "colsample_bytree.na": uniform(0.0, 1.0),
+        "eta": uniform(0.0, 1.0),
+        "max_depth": uniform(0.0, 1.0),
+        "min_child_weight": uniform(0.0, 1.0),
+        "subsample": uniform(0.0, 1.0),
+        "colsample_bytree": uniform(0.0, 1.0),
         "colsample_bylevel": uniform(0.0, 1.0),
-        "colsample_bylevel.na": uniform(0.0, 1.0),
-        "lambda": loguniform(0.001, 1020.8),
-        "alpha": loguniform(0.001, 1024.0),
-        "nrounds": loguniform(0.0001, 5000.0),
-        "nrounds.na": uniform(0.0, 1.0),
-        "booster.ohe.na": 1449,
-        "booster.ohe.gblinear": 1937,
+        "lambda": uniform(0.0, 1.0),
+        "alpha": uniform(0.0, 1.0),
+        "nrounds": uniform(0.0, 1.0),
+        #"booster": choice(["_INVALID", "_gblinear"]),
+        "booster": choice([0.0,1.0])
     },
 }
 SEARCH_SPACE_5965 = {
     "name": "5965",
+    "positions_hps": {"num.trees": 0, "sample.fraction": 2, "min.node.size": 3, "mtry": 4},
+    "positions_categorical": {
+        "replace": [6, 7],
+        "respect": [8, 9]
+    },
     "config_space": {
-        "num.trees": loguniform(0.0001, 2000.0),
-        "num.trees.na": uniform(0.0, 1.0),
-        "mtry": loguniform(1.0, 1776.0),
-        "sample.fraction": uniform(0.1, 1.0),
-        "min.node.size": loguniform(0.0001, 45310.0),
-        "min.node.size.na": uniform(0.0, 1.0),
-        "replace.ohe.FALSE": 295436,
-        "replace.ohe.na": 296498,
-        "respect.unordered.factors.ohe.INVALID": 294378,
-        "respect.unordered.factors.ohe.TRUE": 297556,
+        "num.trees": uniform(0.0, 1.0),
+        "mtry": uniform(0.0, 1.0),
+        "sample.fraction": uniform(0.0, 1.0),
+        "min.node.size": uniform(0.0, 1.0),
+        #"replace": choice(["_FALSE", "_INVALID"]),
+        "replace": choice([0.0, 1.0]),
+        #"respect": choice(["_INVALID", "_TRUE"]),
+        "respect": choice([0.0, 1.0]),
     },
 }
 SEARCH_SPACE_5970 = {
     "name": "5970",
+    "positions_hps": {"alpha": 0, "lambda": 1},
+    "positions_categorical": {},
     "config_space": {
-        "alpha": loguniform(1.0, 2.72),
-        "lambda": loguniform(0.001, 1024.0),
+        "alpha": uniform(0.0, 1.0),
+        "lambda": uniform(0.0, 1.0),
     },
 }
 SEARCH_SPACE_5971 = {
     "name": "5971",
+    "positions_hps": {
+        "eta": 0, "max_depth": 1, "min_child_weight": 3, "subsample": 5,
+        "colsample_bytree": 6, "colsample_bylevel": 8,
+        "lambda": 10, "alpha": 11, "nrounds": 12,
+    },
+    "positions_categorical": {"booster": [14, 15]},
     "config_space": {
-        "eta": loguniform(0.001, 1.0),
-        "max_depth": uniform(0.0, 15.0),
-        "max_depth.na": uniform(0.0, 1.0),
-        "min_child_weight": loguniform(0.0001, 128.0),
-        "min_child_weight.na": uniform(0.0, 1.0),
-        "subsample": uniform(0.1, 1.0),
+        "eta": uniform(0.0, 1.0),
+        "max_depth": uniform(0.0, 1.0),
+        "min_child_weight": uniform(0.0, 1.0),
+        "subsample": uniform(0.0, 1.0),
         "colsample_bytree": uniform(0.0, 1.0),
-        "colsample_bytree.na": uniform(0.0, 1.0),
         "colsample_bylevel": uniform(0.0, 1.0),
-        "colsample_bylevel.na": uniform(0.0, 1.0),
-        "lambda": loguniform(0.001, 1024.0),
-        "alpha": loguniform(0.001, 1024.0),
-        "nrounds": uniform(0, 5000),
-        "nrounds.na": uniform(0.0, 1.0),
-        "booster.ohe.na": 34130,
-        "booster.ohe.gblinear": 45096,
+        "lambda": uniform(0.0, 1.0),
+        "alpha": uniform(0.0, 1.0),
+        "nrounds": uniform(0.0, 1.0),
+        #"booster": choice(["_INVALID", "_gblinear"]),
+        "booster": choice([0.0, 1.0]),
     },
 }
 SEARCH_SPACE_6766 = {
     "name": "6766",
+    "positions_hps": {"alpha": 0, "lambda": 1},
+    "positions_categorical": {},
     "config_space": {
-        "alpha": loguniform(1.0, 2.72),
-        "lambda": loguniform(0.001, 1024.0),
+        "alpha": uniform(0.0, 1.0),
+        "lambda": uniform(0.0, 1.0),
     },
 }
 SEARCH_SPACE_6767 = {
     "name": "6767",
+    "positions_hps": {
+        "eta": 0, "subsample": 1, "lambda": 2, "alpha": 3,
+        "nthread": 4, "nrounds": 6, "max_depth": 8,
+        "min_child_weight": 10, "colsample_bytree": 12,
+        "colsample_bylevel": 14
+    },
+    "positions_categorical": {"booster": [16, 17]},
     "config_space": {
-        "eta": uniform(0.001, 1.0),
-        "subsample": uniform(0.1, 1.0),
-        "lambda": uniform(0.001, 1024.0),
-        "alpha": uniform(0.001, 1024.0),
+        "eta": uniform(0.0, 1.0),
+        "subsample": uniform(0.0, 1.0),
+        "lambda": uniform(0.0, 1.0),
+        "alpha": uniform(0.0, 1.0),
         "nthread": uniform(0.0, 1.0),
-        "nthread.na": uniform(0.0, 1.0),
-        "nrounds": uniform(0.0, 5000.0),
-        "nrounds.na": uniform(0.0, 1.0),
-        "max_depth": uniform(0.0, 15.0),
-        "max_depth.na": uniform(0.0, 1.0),
-        "min_child_weight": uniform(0.0, 128.0),
-        "min_child_weight.na": uniform(0.0, 1.0),
+        "nrounds": uniform(0.0, 1.0),
+        "max_depth": uniform(0.0, 1.0),
+        "min_child_weight": uniform(0.0, 1.0),
         "colsample_bytree": uniform(0.0, 1.0),
-        "colsample_bytree.na": uniform(0.0, 1.0),
         "colsample_bylevel": uniform(0.0, 1.0),
-        "colsample_bylevel.na": uniform(0.0, 1.0),
-        "booster.ohe.na": 430736,
-        "booster.ohe.gblinear": 620644,
+        #"booster": choice(["_INVALID", "_gblinear"]),
+        "booster": choice([0.0, 1.0]),
     },
 }
 SEARCH_SPACE_6794 = {
     "name": "6794",
+    "positions_hps": {"num.trees": 0, "sample.fraction": 2, "min.node.size": 3, "mtry": 4},
+    "positions_categorical": {
+        "replace": [6, 7],
+        "respect": [8, 9]
+    },
     "config_space": {
-        "num.trees": uniform(0.0, 2000.0),
-        "num.trees.na": uniform(0.0, 1.0),
-        "mtry": uniform(1.0, 1558.0),
-        "sample.fraction": uniform(0.1, 1.0),
-        "min.node.size": uniform(-9.21, 10.72),
-        "min.node.size.na": uniform(0.0, 3195.0),
-        "replace.ohe.FALSE": 623218,
-        "replace.ohe.na": 625345,
-        "respect.unordered.factors.ohe.INVALID": 625034,
-        "respect.unordered.factors.ohe.TRUE": 623529,
+        "num.trees": uniform(0.0, 1.0),
+        "mtry": uniform(0.0, 1.0),
+        "sample.fraction": uniform(0.0, 1.0),
+        "min.node.size": uniform(0.0, 1.0),
+        #"replace": choice(["_FALSE", "_INVALID"]),
+        "replace": choice([0.0, 1.0]),
+        #"respect": choice(["_INVALID", "_TRUE"]),
+        "respect": choice([0.0, 1.0]),
     },
 }
 SEARCH_SPACE_7607 = {
     "name": "7607",
+    "positions_hps": {"num.trees": 0, "min.node.size": 2, "sample.fraction": 3, "mtry": 4},
+    "positions_categorical": {
+        "replace": [5, 6],
+        "respect": [7, 8]
+    },
     "config_space": {
-        "num.trees": uniform(0.0, 2000.0),
-        "num.trees.na": uniform(0.0, 1.0),
-        "mtry": uniform(1.0, 1775.0),
-        "min.node.size": loguniform(1.0, 44808.0),
-        "sample.fraction": uniform(0.1, 1.0),
-        "replace.ohe.FALSE": 14478,
-        "replace.ohe.na": 14434,
-        "respect.unordered.factors.ohe.INVALID": 14392,
-        "respect.unordered.factors.ohe.TRUE": 14520,
+        "num.trees": uniform(0.0, 1.0),
+        "mtry": uniform(0.0, 1.0),
+        "min.node.size": uniform(0.0, 1.0),
+        "sample.fraction": uniform(0.0, 1.0),
+        #"respect": choice(["_INVALID", "_TRUE"]),
+        "respect": choice([0.0, 1.0]),
+        #"replace": choice(["_FALSE", "_INVALID"]),
+        "replace": choice([0.0, 1.0]),
     },
 }
 SEARCH_SPACE_7609 = {
     "name": "7609",
+    "positions_hps": {"num.trees": 0, "sample.fraction": 2, "min.node.size": 3, "mtry": 4},
+    "positions_categorical": {
+        "respect": [5, 6],
+        "replace": [7, 8]
+    },
     "config_space": {
-        "num.trees": uniform(0.0, 2000.0),
-        "num.trees.na": uniform(0.0, 1.0),
-        "mtry": uniform(1.0, 1776.0),
-        "min.node.size": loguniform(1.0, 45280.0),
-        "sample.fraction": uniform(0.1, 1.0),
-        "replace.ohe.FALSE": 32943,
-        "replace.ohe.na": 33003,
-        "respect.unordered.factors.ohe.INVALID": 33007,
-        "respect.unordered.factors.ohe.TRUE": 32939,
+        "num.trees": uniform(0.0, 1.0),
+        "mtry": uniform(0.0, 1.0),
+        "min.node.size": uniform(0.0, 1.0),
+        "sample.fraction": uniform(0.0, 1.0),
+        #"respect": choice(["_INVALID", "_TRUE"]),
+        "respect": choice([0.0, 1.0]),
+        #"replace": choice(["_FALSE", "_INVALID"]),
+        "replace": choice([0.0, 1.0]),
     },
 }
 SEARCH_SPACE_5889 = {
     "name": "5889",
+    "positions_hps": {"num.trees": 0, "mtry": 1, "sample.fraction": 2, "replace": 3},
+    "positions_categorical": {},
     "config_space": {
-        "num.trees": loguniform(0.0001, 2000.0),
-        "num.trees.na": uniform(0.0, 1.0),
-        "mtry": loguniform(1.0, 1324.0),
+        "num.trees": uniform(0.0, 1.0),
+        "mtry": uniform(0.0, 1.0),
         "sample.fraction": uniform(0.1, 1.0),
-        "replace.ohe.FALSE": 1215,
-        "replace.ohe.na": 1226,
+        #"replace": choice(["_FALSE", "_INVALID"]),
+        "replace": choice([0.0, 1.0]),
     },
 }
+
+
 RESOURCE_ATTR = "hp_epoch"
 MAX_RESOURCE_LEVEL = 100
 
@@ -373,7 +400,22 @@ def convert_dataset(search_space, dataset):
     hps = np.zeros((n_evals, n_hps))
 
     for i, config in enumerate(dataset["X"]):
-        hps[i] = config
+        # collect all continuous hyperparameters
+        final_config = [
+            config[pos]
+            for pos in search_space["positions_hps"].values()
+        ]
+
+        # collect categorical hyperparameters and compute encoding
+        for positions in search_space.get("positions_categorical", {}).values():
+            print(config)
+            idx = next(
+                (j for j, p in enumerate(positions) if config[p] == 1.0),
+                len(positions) - 1
+            )
+            final_config.append(float(idx))
+
+        hps[i] = final_config
 
     hyperparameters = pd.DataFrame(data=hps, columns=hp_cols)
 
@@ -402,6 +444,7 @@ def convert_dataset(search_space, dataset):
         objectives_names=objective_names,
         fidelity_space=fidelity_space,
     )
+
 
 
 def load_data():
@@ -580,4 +623,4 @@ if __name__ == "__main__":
 
     for recipe in recipes:
         instance = recipe()
-        instance.generate(upload_on_hub=True)
+        instance.generate(upload_on_hub=False)

--- a/syne_tune/blackbox_repository/conversion_scripts/scripts/hpob_import.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/scripts/hpob_import.py
@@ -431,7 +431,6 @@ def convert_dataset(search_space, dataset):
 
         # collect categorical hyperparameters and compute encoding
         for positions in search_space.get("positions_categorical", {}).values():
-            print(config)
             idx = next(
                 (j for j, p in enumerate(positions) if config[p] == 1.0),
                 len(positions) - 1,

--- a/syne_tune/blackbox_repository/conversion_scripts/scripts/hpob_import.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/scripts/hpob_import.py
@@ -53,8 +53,8 @@ SEARCH_SPACE_5527 = {
         "cost": uniform(0.0, 1.0),
         "gamma": uniform(0.0, 1.0),
         "degree": uniform(0.0, 1.0),
-        #"kernel": choice(["_INVALID", "_linear", "_polynomial"]),
-        "kernel": choice([0.0,1.0,2.0])
+        # "kernel": choice(["_INVALID", "_linear", "_polynomial"]),
+        "kernel": choice([0.0, 1.0, 2.0]),
     },
 }
 SEARCH_SPACE_5636 = {
@@ -96,16 +96,22 @@ SEARCH_SPACE_5891 = {
         "cost": uniform(0.0, 1.0),
         "gamma": uniform(0.0, 1.0),
         "degree": uniform(0.0, 1.0),
-        #"kernel": choice(["_INVALID", "_linear", "_polynomial"]),
-        "kernel": choice([0.0,1.0,2.0])
+        # "kernel": choice(["_INVALID", "_linear", "_polynomial"]),
+        "kernel": choice([0.0, 1.0, 2.0]),
     },
 }
 SEARCH_SPACE_5906 = {
     "name": "5906",
     "positions_hps": {
-        "eta": 0, "max_depth": 1, "min_child_weight": 3, "subsample": 5,
-        "colsample_bytree": 6, "colsample_bylevel": 8,
-        "lambda": 10, "alpha": 11, "nrounds": 12,
+        "eta": 0,
+        "max_depth": 1,
+        "min_child_weight": 3,
+        "subsample": 5,
+        "colsample_bytree": 6,
+        "colsample_bylevel": 8,
+        "lambda": 10,
+        "alpha": 11,
+        "nrounds": 12,
     },
     "positions_categorical": {"booster": [14, 15]},
     "config_space": {
@@ -118,25 +124,27 @@ SEARCH_SPACE_5906 = {
         "lambda": uniform(0.0, 1.0),
         "alpha": uniform(0.0, 1.0),
         "nrounds": uniform(0.0, 1.0),
-        #"booster": choice(["_INVALID", "_gblinear"]),
-        "booster": choice([0.0,1.0])
+        # "booster": choice(["_INVALID", "_gblinear"]),
+        "booster": choice([0.0, 1.0]),
     },
 }
 SEARCH_SPACE_5965 = {
     "name": "5965",
-    "positions_hps": {"num.trees": 0, "sample.fraction": 2, "min.node.size": 3, "mtry": 4},
-    "positions_categorical": {
-        "replace": [6, 7],
-        "respect": [8, 9]
+    "positions_hps": {
+        "num.trees": 0,
+        "sample.fraction": 2,
+        "min.node.size": 3,
+        "mtry": 4,
     },
+    "positions_categorical": {"replace": [6, 7], "respect": [8, 9]},
     "config_space": {
         "num.trees": uniform(0.0, 1.0),
         "mtry": uniform(0.0, 1.0),
         "sample.fraction": uniform(0.0, 1.0),
         "min.node.size": uniform(0.0, 1.0),
-        #"replace": choice(["_FALSE", "_INVALID"]),
+        # "replace": choice(["_FALSE", "_INVALID"]),
         "replace": choice([0.0, 1.0]),
-        #"respect": choice(["_INVALID", "_TRUE"]),
+        # "respect": choice(["_INVALID", "_TRUE"]),
         "respect": choice([0.0, 1.0]),
     },
 }
@@ -152,9 +160,15 @@ SEARCH_SPACE_5970 = {
 SEARCH_SPACE_5971 = {
     "name": "5971",
     "positions_hps": {
-        "eta": 0, "max_depth": 1, "min_child_weight": 3, "subsample": 5,
-        "colsample_bytree": 6, "colsample_bylevel": 8,
-        "lambda": 10, "alpha": 11, "nrounds": 12,
+        "eta": 0,
+        "max_depth": 1,
+        "min_child_weight": 3,
+        "subsample": 5,
+        "colsample_bytree": 6,
+        "colsample_bylevel": 8,
+        "lambda": 10,
+        "alpha": 11,
+        "nrounds": 12,
     },
     "positions_categorical": {"booster": [14, 15]},
     "config_space": {
@@ -167,7 +181,7 @@ SEARCH_SPACE_5971 = {
         "lambda": uniform(0.0, 1.0),
         "alpha": uniform(0.0, 1.0),
         "nrounds": uniform(0.0, 1.0),
-        #"booster": choice(["_INVALID", "_gblinear"]),
+        # "booster": choice(["_INVALID", "_gblinear"]),
         "booster": choice([0.0, 1.0]),
     },
 }
@@ -183,10 +197,16 @@ SEARCH_SPACE_6766 = {
 SEARCH_SPACE_6767 = {
     "name": "6767",
     "positions_hps": {
-        "eta": 0, "subsample": 1, "lambda": 2, "alpha": 3,
-        "nthread": 4, "nrounds": 6, "max_depth": 8,
-        "min_child_weight": 10, "colsample_bytree": 12,
-        "colsample_bylevel": 14
+        "eta": 0,
+        "subsample": 1,
+        "lambda": 2,
+        "alpha": 3,
+        "nthread": 4,
+        "nrounds": 6,
+        "max_depth": 8,
+        "min_child_weight": 10,
+        "colsample_bytree": 12,
+        "colsample_bylevel": 14,
     },
     "positions_categorical": {"booster": [16, 17]},
     "config_space": {
@@ -200,61 +220,67 @@ SEARCH_SPACE_6767 = {
         "min_child_weight": uniform(0.0, 1.0),
         "colsample_bytree": uniform(0.0, 1.0),
         "colsample_bylevel": uniform(0.0, 1.0),
-        #"booster": choice(["_INVALID", "_gblinear"]),
+        # "booster": choice(["_INVALID", "_gblinear"]),
         "booster": choice([0.0, 1.0]),
     },
 }
 SEARCH_SPACE_6794 = {
     "name": "6794",
-    "positions_hps": {"num.trees": 0, "sample.fraction": 2, "min.node.size": 3, "mtry": 4},
-    "positions_categorical": {
-        "replace": [6, 7],
-        "respect": [8, 9]
+    "positions_hps": {
+        "num.trees": 0,
+        "sample.fraction": 2,
+        "min.node.size": 3,
+        "mtry": 4,
     },
+    "positions_categorical": {"replace": [6, 7], "respect": [8, 9]},
     "config_space": {
         "num.trees": uniform(0.0, 1.0),
         "mtry": uniform(0.0, 1.0),
         "sample.fraction": uniform(0.0, 1.0),
         "min.node.size": uniform(0.0, 1.0),
-        #"replace": choice(["_FALSE", "_INVALID"]),
+        # "replace": choice(["_FALSE", "_INVALID"]),
         "replace": choice([0.0, 1.0]),
-        #"respect": choice(["_INVALID", "_TRUE"]),
+        # "respect": choice(["_INVALID", "_TRUE"]),
         "respect": choice([0.0, 1.0]),
     },
 }
 SEARCH_SPACE_7607 = {
     "name": "7607",
-    "positions_hps": {"num.trees": 0, "min.node.size": 2, "sample.fraction": 3, "mtry": 4},
-    "positions_categorical": {
-        "replace": [5, 6],
-        "respect": [7, 8]
+    "positions_hps": {
+        "num.trees": 0,
+        "min.node.size": 2,
+        "sample.fraction": 3,
+        "mtry": 4,
     },
+    "positions_categorical": {"replace": [5, 6], "respect": [7, 8]},
     "config_space": {
         "num.trees": uniform(0.0, 1.0),
         "mtry": uniform(0.0, 1.0),
         "min.node.size": uniform(0.0, 1.0),
         "sample.fraction": uniform(0.0, 1.0),
-        #"respect": choice(["_INVALID", "_TRUE"]),
+        # "respect": choice(["_INVALID", "_TRUE"]),
         "respect": choice([0.0, 1.0]),
-        #"replace": choice(["_FALSE", "_INVALID"]),
+        # "replace": choice(["_FALSE", "_INVALID"]),
         "replace": choice([0.0, 1.0]),
     },
 }
 SEARCH_SPACE_7609 = {
     "name": "7609",
-    "positions_hps": {"num.trees": 0, "sample.fraction": 2, "min.node.size": 3, "mtry": 4},
-    "positions_categorical": {
-        "respect": [5, 6],
-        "replace": [7, 8]
+    "positions_hps": {
+        "num.trees": 0,
+        "sample.fraction": 2,
+        "min.node.size": 3,
+        "mtry": 4,
     },
+    "positions_categorical": {"respect": [5, 6], "replace": [7, 8]},
     "config_space": {
         "num.trees": uniform(0.0, 1.0),
         "mtry": uniform(0.0, 1.0),
         "min.node.size": uniform(0.0, 1.0),
         "sample.fraction": uniform(0.0, 1.0),
-        #"respect": choice(["_INVALID", "_TRUE"]),
+        # "respect": choice(["_INVALID", "_TRUE"]),
         "respect": choice([0.0, 1.0]),
-        #"replace": choice(["_FALSE", "_INVALID"]),
+        # "replace": choice(["_FALSE", "_INVALID"]),
         "replace": choice([0.0, 1.0]),
     },
 }
@@ -266,7 +292,7 @@ SEARCH_SPACE_5889 = {
         "num.trees": uniform(0.0, 1.0),
         "mtry": uniform(0.0, 1.0),
         "sample.fraction": uniform(0.1, 1.0),
-        #"replace": choice(["_FALSE", "_INVALID"]),
+        # "replace": choice(["_FALSE", "_INVALID"]),
         "replace": choice([0.0, 1.0]),
     },
 }
@@ -401,17 +427,14 @@ def convert_dataset(search_space, dataset):
 
     for i, config in enumerate(dataset["X"]):
         # collect all continuous hyperparameters
-        final_config = [
-            config[pos]
-            for pos in search_space["positions_hps"].values()
-        ]
+        final_config = [config[pos] for pos in search_space["positions_hps"].values()]
 
         # collect categorical hyperparameters and compute encoding
         for positions in search_space.get("positions_categorical", {}).values():
             print(config)
             idx = next(
                 (j for j, p in enumerate(positions) if config[p] == 1.0),
-                len(positions) - 1
+                len(positions) - 1,
             )
             final_config.append(float(idx))
 
@@ -444,7 +467,6 @@ def convert_dataset(search_space, dataset):
         objectives_names=objective_names,
         fidelity_space=fidelity_space,
     )
-
 
 
 def load_data():

--- a/syne_tune/blackbox_repository/conversion_scripts/scripts/hpob_import.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/scripts/hpob_import.py
@@ -15,8 +15,8 @@ from syne_tune.blackbox_repository.conversion_scripts.blackbox_recipe import (
 )
 from syne_tune.config_space import (
     uniform,
+    loguniform,
     randint,
-    choice,
     config_space_to_json_dict,
     config_space_from_json_dict,
 )
@@ -33,271 +33,218 @@ BLACKBOX_NAME = "hpob_"
 METRIC_ELAPSED_TIME = "metric_elapsed_time"
 
 # configuration_space values taken from "https://raw.githubusercontent.com/machinelearningnuremberg/HPO-B/refs/heads/main/hpob-data/meta-dataset-descriptors.json"
-
 SEARCH_SPACE_4796 = {
     "name": "4796",
-    "positions_hps": {"minsplit": 0, "minbucket": 1, "cp": 2},
-    "positions_categorical": {},
     "config_space": {
-        "minsplit": uniform(0.0, 1.0),
-        "minbucket": uniform(0.0, 1.0),
-        "cp": uniform(0.0, 1.0),
+        "minsplit": loguniform(2.0, 128.0),
+        "minbucket": loguniform(1.0, 64.0),
+        "cp": loguniform(0.0002, 0.1),
     },
 }
 
 SEARCH_SPACE_5527 = {
     "name": "5527",
-    "positions_hps": {"cost": 0, "gamma": 1, "degree": 3},
-    "positions_categorical": {"kernel": [4, 5, 6]},
     "config_space": {
-        "cost": uniform(0.0, 1.0),
-        "gamma": uniform(0.0, 1.0),
-        "degree": uniform(0.0, 1.0),
-        # "kernel": choice(["_INVALID", "_linear", "_polynomial"]),
-        "kernel": choice([0.0, 1.0, 2.0]),
+        "cost": loguniform(0.001, 1024.0),
+        "gamma": loguniform(0.0001, 1024.0),
+        "gamma.na": uniform(0.0, 1.0),
+        "degree": uniform(0.0, 5.0),
+        "degree.na": uniform(0.0, 1.0),
+        "kernel.ohe.na": 308190.0,
+        "kernel.ohe.linear": 316563.0,
+        "kernel.ohe.polynomial": 311266.0,
     },
 }
 SEARCH_SPACE_5636 = {
     "name": "5636",
-    "positions_hps": {"minsplit": 0, "cp": 2, "maxdepth": 3, "minbucket": 4},
-    "positions_categorical": {},
     "config_space": {
-        "minsplit": uniform(0.0, 1.0),
-        "minbucket": uniform(0.0, 1.0),
-        "cp": uniform(0.0, 1.0),
-        "maxdepth": uniform(0.0, 1.0),
+        "minsplit": uniform(0.0, 60.0),
+        "minsplit.na": uniform(0.0, 1.0),
+        "minbucket": uniform(1.0, 60.0),
+        "cp": uniform(-9.2, 9.906167518025702e-5),
+        "maxdepth": uniform(0.0, 29.0),
+        "maxdepth.na": uniform(0.0, 1.0),
     },
 }
 SEARCH_SPACE_5859 = {
     "name": "5859",
-    "positions_hps": {"minsplit": 0, "cp": 2, "maxdepth": 3, "minbucket": 4},
-    "positions_categorical": {},
     "config_space": {
-        "minsplit": uniform(0.0, 1.0),
-        "minbucket": uniform(1.0, 1.0),
-        "cp": uniform(0.0, 1.0),
-        "maxdepth": uniform(0.0, 1.0),
+        "minsplit": uniform(0.0, 60.0),
+        "minsplit.na": uniform(0.0, 1.0),
+        "minbucket": uniform(1.0, 60.0),
+        "cp": loguniform(0.0001, 1.0),
+        "maxdepth": uniform(0.0, 29.0),
+        "maxdepth.na": uniform(0.0, 1.0),
     },
 }
 SEARCH_SPACE_5860 = {
     "name": "5860",
-    "positions_hps": {"alpha": 0, "lambda": 1},
-    "positions_categorical": {},
     "config_space": {
-        "alpha": uniform(0.0, 1.0),
-        "lambda": uniform(0.0, 1.0),
+        "alpha": loguniform(0.000578, 1.0),
+        "lambda": loguniform(0.001, 1019.35),
     },
 }
 SEARCH_SPACE_5891 = {
     "name": "5891",
-    "positions_hps": {"cost": 0, "gamma": 1, "degree": 3},
-    "positions_categorical": {"kernel": [5, 6, 7]},
     "config_space": {
-        "cost": uniform(0.0, 1.0),
-        "gamma": uniform(0.0, 1.0),
-        "degree": uniform(0.0, 1.0),
-        # "kernel": choice(["_INVALID", "_linear", "_polynomial"]),
-        "kernel": choice([0.0, 1.0, 2.0]),
+        "cost": uniform(0.001, 1024.0),
+        "gamma": uniform(0.0, 1024.0),
+        "gamma.na": uniform(0.0, 1.0),
+        "degree": uniform(0.0, 5.0),
+        "degree.na": uniform(0.0, 1.0),
+        "kernel.ohe.na": 24627,
+        "kernel.ohe.linear": 24952,
+        "kernel.ohe.polynomial": 24813,
     },
 }
 SEARCH_SPACE_5906 = {
     "name": "5906",
-    "positions_hps": {
-        "eta": 0,
-        "max_depth": 1,
-        "min_child_weight": 3,
-        "subsample": 5,
-        "colsample_bytree": 6,
-        "colsample_bylevel": 8,
-        "lambda": 10,
-        "alpha": 11,
-        "nrounds": 12,
-    },
-    "positions_categorical": {"booster": [14, 15]},
     "config_space": {
-        "eta": uniform(0.0, 1.0),
-        "max_depth": uniform(0.0, 1.0),
-        "min_child_weight": uniform(0.0, 1.0),
-        "subsample": uniform(0.0, 1.0),
-        "colsample_bytree": uniform(0.0, 1.0),
+        "eta": loguniform(0.001, 1.0),
+        "max_depth": uniform(0.0, 15.0),
+        "max_depth.na": uniform(0.0, 1.0),
+        "min_child_weight": loguniform(0.0001, 128.0),
+        "min_child_weight.na": uniform(0.0, 1.0),
+        "subsample": uniform(0.1, 1.0),
+        "colsample_bytree": loguniform(0.0001, 1.0),
+        "colsample_bytree.na": uniform(0.0, 1.0),
         "colsample_bylevel": uniform(0.0, 1.0),
-        "lambda": uniform(0.0, 1.0),
-        "alpha": uniform(0.0, 1.0),
-        "nrounds": uniform(0.0, 1.0),
-        # "booster": choice(["_INVALID", "_gblinear"]),
-        "booster": choice([0.0, 1.0]),
+        "colsample_bylevel.na": uniform(0.0, 1.0),
+        "lambda": loguniform(0.001, 1020.8),
+        "alpha": loguniform(0.001, 1024.0),
+        "nrounds": loguniform(0.0001, 5000.0),
+        "nrounds.na": uniform(0.0, 1.0),
+        "booster.ohe.na": 1449,
+        "booster.ohe.gblinear": 1937,
     },
 }
 SEARCH_SPACE_5965 = {
     "name": "5965",
-    "positions_hps": {
-        "num.trees": 0,
-        "sample.fraction": 2,
-        "min.node.size": 3,
-        "mtry": 4,
-    },
-    "positions_categorical": {"replace": [6, 7], "respect": [8, 9]},
     "config_space": {
-        "num.trees": uniform(0.0, 1.0),
-        "mtry": uniform(0.0, 1.0),
-        "sample.fraction": uniform(0.0, 1.0),
-        "min.node.size": uniform(0.0, 1.0),
-        # "replace": choice(["_FALSE", "_INVALID"]),
-        "replace": choice([0.0, 1.0]),
-        # "respect": choice(["_INVALID", "_TRUE"]),
-        "respect": choice([0.0, 1.0]),
+        "num.trees": loguniform(0.0001, 2000.0),
+        "num.trees.na": uniform(0.0, 1.0),
+        "mtry": loguniform(1.0, 1776.0),
+        "sample.fraction": uniform(0.1, 1.0),
+        "min.node.size": loguniform(0.0001, 45310.0),
+        "min.node.size.na": uniform(0.0, 1.0),
+        "replace.ohe.FALSE": 295436,
+        "replace.ohe.na": 296498,
+        "respect.unordered.factors.ohe.INVALID": 294378,
+        "respect.unordered.factors.ohe.TRUE": 297556,
     },
 }
 SEARCH_SPACE_5970 = {
     "name": "5970",
-    "positions_hps": {"alpha": 0, "lambda": 1},
-    "positions_categorical": {},
     "config_space": {
-        "alpha": uniform(0.0, 1.0),
-        "lambda": uniform(0.0, 1.0),
+        "alpha": loguniform(1.0, 2.72),
+        "lambda": loguniform(0.001, 1024.0),
     },
 }
 SEARCH_SPACE_5971 = {
     "name": "5971",
-    "positions_hps": {
-        "eta": 0,
-        "max_depth": 1,
-        "min_child_weight": 3,
-        "subsample": 5,
-        "colsample_bytree": 6,
-        "colsample_bylevel": 8,
-        "lambda": 10,
-        "alpha": 11,
-        "nrounds": 12,
-    },
-    "positions_categorical": {"booster": [14, 15]},
     "config_space": {
-        "eta": uniform(0.0, 1.0),
-        "max_depth": uniform(0.0, 1.0),
-        "min_child_weight": uniform(0.0, 1.0),
-        "subsample": uniform(0.0, 1.0),
+        "eta": loguniform(0.001, 1.0),
+        "max_depth": uniform(0.0, 15.0),
+        "max_depth.na": uniform(0.0, 1.0),
+        "min_child_weight": loguniform(0.0001, 128.0),
+        "min_child_weight.na": uniform(0.0, 1.0),
+        "subsample": uniform(0.1, 1.0),
         "colsample_bytree": uniform(0.0, 1.0),
+        "colsample_bytree.na": uniform(0.0, 1.0),
         "colsample_bylevel": uniform(0.0, 1.0),
-        "lambda": uniform(0.0, 1.0),
-        "alpha": uniform(0.0, 1.0),
-        "nrounds": uniform(0.0, 1.0),
-        # "booster": choice(["_INVALID", "_gblinear"]),
-        "booster": choice([0.0, 1.0]),
+        "colsample_bylevel.na": uniform(0.0, 1.0),
+        "lambda": loguniform(0.001, 1024.0),
+        "alpha": loguniform(0.001, 1024.0),
+        "nrounds": uniform(0, 5000),
+        "nrounds.na": uniform(0.0, 1.0),
+        "booster.ohe.na": 34130,
+        "booster.ohe.gblinear": 45096,
     },
 }
 SEARCH_SPACE_6766 = {
     "name": "6766",
-    "positions_hps": {"alpha": 0, "lambda": 1},
-    "positions_categorical": {},
     "config_space": {
-        "alpha": uniform(0.0, 1.0),
-        "lambda": uniform(0.0, 1.0),
+        "alpha": loguniform(1.0, 2.72),
+        "lambda": loguniform(0.001, 1024.0),
     },
 }
 SEARCH_SPACE_6767 = {
     "name": "6767",
-    "positions_hps": {
-        "eta": 0,
-        "subsample": 1,
-        "lambda": 2,
-        "alpha": 3,
-        "nthread": 4,
-        "nrounds": 6,
-        "max_depth": 8,
-        "min_child_weight": 10,
-        "colsample_bytree": 12,
-        "colsample_bylevel": 14,
-    },
-    "positions_categorical": {"booster": [16, 17]},
     "config_space": {
-        "eta": uniform(0.0, 1.0),
-        "subsample": uniform(0.0, 1.0),
-        "lambda": uniform(0.0, 1.0),
-        "alpha": uniform(0.0, 1.0),
+        "eta": uniform(0.001, 1.0),
+        "subsample": uniform(0.1, 1.0),
+        "lambda": uniform(0.001, 1024.0),
+        "alpha": uniform(0.001, 1024.0),
         "nthread": uniform(0.0, 1.0),
-        "nrounds": uniform(0.0, 1.0),
-        "max_depth": uniform(0.0, 1.0),
-        "min_child_weight": uniform(0.0, 1.0),
+        "nthread.na": uniform(0.0, 1.0),
+        "nrounds": uniform(0.0, 5000.0),
+        "nrounds.na": uniform(0.0, 1.0),
+        "max_depth": uniform(0.0, 15.0),
+        "max_depth.na": uniform(0.0, 1.0),
+        "min_child_weight": uniform(0.0, 128.0),
+        "min_child_weight.na": uniform(0.0, 1.0),
         "colsample_bytree": uniform(0.0, 1.0),
+        "colsample_bytree.na": uniform(0.0, 1.0),
         "colsample_bylevel": uniform(0.0, 1.0),
-        # "booster": choice(["_INVALID", "_gblinear"]),
-        "booster": choice([0.0, 1.0]),
+        "colsample_bylevel.na": uniform(0.0, 1.0),
+        "booster.ohe.na": 430736,
+        "booster.ohe.gblinear": 620644,
     },
 }
 SEARCH_SPACE_6794 = {
     "name": "6794",
-    "positions_hps": {
-        "num.trees": 0,
-        "sample.fraction": 2,
-        "min.node.size": 3,
-        "mtry": 4,
-    },
-    "positions_categorical": {"replace": [6, 7], "respect": [8, 9]},
     "config_space": {
-        "num.trees": uniform(0.0, 1.0),
-        "mtry": uniform(0.0, 1.0),
-        "sample.fraction": uniform(0.0, 1.0),
-        "min.node.size": uniform(0.0, 1.0),
-        # "replace": choice(["_FALSE", "_INVALID"]),
-        "replace": choice([0.0, 1.0]),
-        # "respect": choice(["_INVALID", "_TRUE"]),
-        "respect": choice([0.0, 1.0]),
+        "num.trees": uniform(0.0, 2000.0),
+        "num.trees.na": uniform(0.0, 1.0),
+        "mtry": uniform(1.0, 1558.0),
+        "sample.fraction": uniform(0.1, 1.0),
+        "min.node.size": uniform(-9.21, 10.72),
+        "min.node.size.na": uniform(0.0, 3195.0),
+        "replace.ohe.FALSE": 623218,
+        "replace.ohe.na": 625345,
+        "respect.unordered.factors.ohe.INVALID": 625034,
+        "respect.unordered.factors.ohe.TRUE": 623529,
     },
 }
 SEARCH_SPACE_7607 = {
     "name": "7607",
-    "positions_hps": {
-        "num.trees": 0,
-        "min.node.size": 2,
-        "sample.fraction": 3,
-        "mtry": 4,
-    },
-    "positions_categorical": {"replace": [5, 6], "respect": [7, 8]},
     "config_space": {
-        "num.trees": uniform(0.0, 1.0),
-        "mtry": uniform(0.0, 1.0),
-        "min.node.size": uniform(0.0, 1.0),
-        "sample.fraction": uniform(0.0, 1.0),
-        # "respect": choice(["_INVALID", "_TRUE"]),
-        "respect": choice([0.0, 1.0]),
-        # "replace": choice(["_FALSE", "_INVALID"]),
-        "replace": choice([0.0, 1.0]),
+        "num.trees": uniform(0.0, 2000.0),
+        "num.trees.na": uniform(0.0, 1.0),
+        "mtry": uniform(1.0, 1775.0),
+        "min.node.size": loguniform(1.0, 44808.0),
+        "sample.fraction": uniform(0.1, 1.0),
+        "replace.ohe.FALSE": 14478,
+        "replace.ohe.na": 14434,
+        "respect.unordered.factors.ohe.INVALID": 14392,
+        "respect.unordered.factors.ohe.TRUE": 14520,
     },
 }
 SEARCH_SPACE_7609 = {
     "name": "7609",
-    "positions_hps": {
-        "num.trees": 0,
-        "sample.fraction": 2,
-        "min.node.size": 3,
-        "mtry": 4,
-    },
-    "positions_categorical": {"respect": [6, 7], "replace": [8, 9]},
     "config_space": {
-        "num.trees": uniform(0.0, 1.0),
-        "mtry": uniform(0.0, 1.0),
-        "min.node.size": uniform(0.0, 1.0),
-        "sample.fraction": uniform(0.0, 1.0),
-        # "respect": choice(["_INVALID", "_TRUE"]),
-        "respect": choice([0.0, 1.0]),
-        # "replace": choice(["_FALSE", "_INVALID"]),
-        "replace": choice([0.0, 1.0]),
+        "num.trees": uniform(0.0, 2000.0),
+        "num.trees.na": uniform(0.0, 1.0),
+        "mtry": uniform(1.0, 1776.0),
+        "min.node.size": loguniform(1.0, 45280.0),
+        "sample.fraction": uniform(0.1, 1.0),
+        "replace.ohe.FALSE": 32943,
+        "replace.ohe.na": 33003,
+        "respect.unordered.factors.ohe.INVALID": 33007,
+        "respect.unordered.factors.ohe.TRUE": 32939,
     },
 }
 SEARCH_SPACE_5889 = {
     "name": "5889",
-    "positions_hps": {"num.trees": 0, "mtry": 1, "sample.fraction": 2, "replace": 3},
-    "positions_categorical": {},
     "config_space": {
-        "num.trees": uniform(0.0, 1.0),
-        "mtry": uniform(0.0, 1.0),
+        "num.trees": loguniform(0.0001, 2000.0),
+        "num.trees.na": uniform(0.0, 1.0),
+        "mtry": loguniform(1.0, 1324.0),
         "sample.fraction": uniform(0.1, 1.0),
-        # "replace": choice(["_FALSE", "_INVALID"]),
-        "replace": choice([0.0, 1.0]),
+        "replace.ohe.FALSE": 1215,
+        "replace.ohe.na": 1226,
     },
 }
-
-
 RESOURCE_ATTR = "hp_epoch"
 MAX_RESOURCE_LEVEL = 100
 
@@ -426,40 +373,7 @@ def convert_dataset(search_space, dataset):
     hps = np.zeros((n_evals, n_hps))
 
     for i, config in enumerate(dataset["X"]):
-        final_config = []
-
-        for hp in search_space["positions_hps"]:
-            pos = search_space["positions_hps"][hp]
-            final_config.append(config[pos])
-
-        # Handle categorical hyperparameters
-        if search_space["positions_categorical"]:
-            for hp in search_space["positions_categorical"]:
-                positions = search_space["positions_categorical"][hp]
-                if hp == "booster":
-                    if config[positions[0]] == 1.0:
-                        final_config.append(0.0)
-                    else:
-                        final_config.append(1.0)
-                elif hp == "respect":
-                    if config[positions[0]] == 1.0:
-                        final_config.append(0.0)
-                    else:
-                        final_config.append(1.0)
-                elif hp == "replace":
-                    if config[positions[0]] == 1.0:
-                        final_config.append(0.0)
-                    else:
-                        final_config.append(1.0)
-                elif hp == "kernel":
-                    if config[positions[0]] == 1.0:
-                        final_config.append(0.0)
-                    elif config[positions[1]] == 1.0:
-                        final_config.append(1.0)
-                    else:
-                        final_config.append(2.0)
-
-        hps[i] = final_config
+        hps[i] = config
 
     hyperparameters = pd.DataFrame(data=hps, columns=hp_cols)
 

--- a/syne_tune/blackbox_repository/conversion_scripts/scripts/hpob_import.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/scripts/hpob_import.py
@@ -53,8 +53,8 @@ SEARCH_SPACE_5527 = {
         "cost": uniform(0.0, 1.0),
         "gamma": uniform(0.0, 1.0),
         "degree": uniform(0.0, 1.0),
-        #"kernel": choice(["_INVALID", "_linear", "_polynomial"]),
-        "kernel": choice([0.0,1.0,2.0])
+        # "kernel": choice(["_INVALID", "_linear", "_polynomial"]),
+        "kernel": choice([0.0, 1.0, 2.0]),
     },
 }
 SEARCH_SPACE_5636 = {
@@ -96,16 +96,22 @@ SEARCH_SPACE_5891 = {
         "cost": uniform(0.0, 1.0),
         "gamma": uniform(0.0, 1.0),
         "degree": uniform(0.0, 1.0),
-        #"kernel": choice(["_INVALID", "_linear", "_polynomial"]),
-        "kernel": choice([0.0,1.0,2.0])
+        # "kernel": choice(["_INVALID", "_linear", "_polynomial"]),
+        "kernel": choice([0.0, 1.0, 2.0]),
     },
 }
 SEARCH_SPACE_5906 = {
     "name": "5906",
     "positions_hps": {
-        "eta": 0, "max_depth": 1, "min_child_weight": 3, "subsample": 5,
-        "colsample_bytree": 6, "colsample_bylevel": 8,
-        "lambda": 10, "alpha": 11, "nrounds": 12,
+        "eta": 0,
+        "max_depth": 1,
+        "min_child_weight": 3,
+        "subsample": 5,
+        "colsample_bytree": 6,
+        "colsample_bylevel": 8,
+        "lambda": 10,
+        "alpha": 11,
+        "nrounds": 12,
     },
     "positions_categorical": {"booster": [14, 15]},
     "config_space": {
@@ -118,25 +124,27 @@ SEARCH_SPACE_5906 = {
         "lambda": uniform(0.0, 1.0),
         "alpha": uniform(0.0, 1.0),
         "nrounds": uniform(0.0, 1.0),
-        #"booster": choice(["_INVALID", "_gblinear"]),
-        "booster": choice([0.0,1.0])
+        # "booster": choice(["_INVALID", "_gblinear"]),
+        "booster": choice([0.0, 1.0]),
     },
 }
 SEARCH_SPACE_5965 = {
     "name": "5965",
-    "positions_hps": {"num.trees": 0, "sample.fraction": 2, "min.node.size": 3, "mtry": 4},
-    "positions_categorical": {
-        "replace": [6, 7],
-        "respect": [8, 9]
+    "positions_hps": {
+        "num.trees": 0,
+        "sample.fraction": 2,
+        "min.node.size": 3,
+        "mtry": 4,
     },
+    "positions_categorical": {"replace": [6, 7], "respect": [8, 9]},
     "config_space": {
         "num.trees": uniform(0.0, 1.0),
         "mtry": uniform(0.0, 1.0),
         "sample.fraction": uniform(0.0, 1.0),
         "min.node.size": uniform(0.0, 1.0),
-        #"replace": choice(["_FALSE", "_INVALID"]),
+        # "replace": choice(["_FALSE", "_INVALID"]),
         "replace": choice([0.0, 1.0]),
-        #"respect": choice(["_INVALID", "_TRUE"]),
+        # "respect": choice(["_INVALID", "_TRUE"]),
         "respect": choice([0.0, 1.0]),
     },
 }
@@ -152,9 +160,15 @@ SEARCH_SPACE_5970 = {
 SEARCH_SPACE_5971 = {
     "name": "5971",
     "positions_hps": {
-        "eta": 0, "max_depth": 1, "min_child_weight": 3, "subsample": 5,
-        "colsample_bytree": 6, "colsample_bylevel": 8,
-        "lambda": 10, "alpha": 11, "nrounds": 12,
+        "eta": 0,
+        "max_depth": 1,
+        "min_child_weight": 3,
+        "subsample": 5,
+        "colsample_bytree": 6,
+        "colsample_bylevel": 8,
+        "lambda": 10,
+        "alpha": 11,
+        "nrounds": 12,
     },
     "positions_categorical": {"booster": [14, 15]},
     "config_space": {
@@ -167,7 +181,7 @@ SEARCH_SPACE_5971 = {
         "lambda": uniform(0.0, 1.0),
         "alpha": uniform(0.0, 1.0),
         "nrounds": uniform(0.0, 1.0),
-        #"booster": choice(["_INVALID", "_gblinear"]),
+        # "booster": choice(["_INVALID", "_gblinear"]),
         "booster": choice([0.0, 1.0]),
     },
 }
@@ -183,10 +197,16 @@ SEARCH_SPACE_6766 = {
 SEARCH_SPACE_6767 = {
     "name": "6767",
     "positions_hps": {
-        "eta": 0, "subsample": 1, "lambda": 2, "alpha": 3,
-        "nthread": 4, "nrounds": 6, "max_depth": 8,
-        "min_child_weight": 10, "colsample_bytree": 12,
-        "colsample_bylevel": 14
+        "eta": 0,
+        "subsample": 1,
+        "lambda": 2,
+        "alpha": 3,
+        "nthread": 4,
+        "nrounds": 6,
+        "max_depth": 8,
+        "min_child_weight": 10,
+        "colsample_bytree": 12,
+        "colsample_bylevel": 14,
     },
     "positions_categorical": {"booster": [16, 17]},
     "config_space": {
@@ -200,61 +220,67 @@ SEARCH_SPACE_6767 = {
         "min_child_weight": uniform(0.0, 1.0),
         "colsample_bytree": uniform(0.0, 1.0),
         "colsample_bylevel": uniform(0.0, 1.0),
-        #"booster": choice(["_INVALID", "_gblinear"]),
+        # "booster": choice(["_INVALID", "_gblinear"]),
         "booster": choice([0.0, 1.0]),
     },
 }
 SEARCH_SPACE_6794 = {
     "name": "6794",
-    "positions_hps": {"num.trees": 0, "sample.fraction": 2, "min.node.size": 3, "mtry": 4},
-    "positions_categorical": {
-        "replace": [6, 7],
-        "respect": [8, 9]
+    "positions_hps": {
+        "num.trees": 0,
+        "sample.fraction": 2,
+        "min.node.size": 3,
+        "mtry": 4,
     },
+    "positions_categorical": {"replace": [6, 7], "respect": [8, 9]},
     "config_space": {
         "num.trees": uniform(0.0, 1.0),
         "mtry": uniform(0.0, 1.0),
         "sample.fraction": uniform(0.0, 1.0),
         "min.node.size": uniform(0.0, 1.0),
-        #"replace": choice(["_FALSE", "_INVALID"]),
+        # "replace": choice(["_FALSE", "_INVALID"]),
         "replace": choice([0.0, 1.0]),
-        #"respect": choice(["_INVALID", "_TRUE"]),
+        # "respect": choice(["_INVALID", "_TRUE"]),
         "respect": choice([0.0, 1.0]),
     },
 }
 SEARCH_SPACE_7607 = {
     "name": "7607",
-    "positions_hps": {"num.trees": 0, "min.node.size": 2, "sample.fraction": 3, "mtry": 4},
-    "positions_categorical": {
-        "replace": [5, 6],
-        "respect": [7, 8]
+    "positions_hps": {
+        "num.trees": 0,
+        "min.node.size": 2,
+        "sample.fraction": 3,
+        "mtry": 4,
     },
+    "positions_categorical": {"replace": [5, 6], "respect": [7, 8]},
     "config_space": {
         "num.trees": uniform(0.0, 1.0),
         "mtry": uniform(0.0, 1.0),
         "min.node.size": uniform(0.0, 1.0),
         "sample.fraction": uniform(0.0, 1.0),
-        #"respect": choice(["_INVALID", "_TRUE"]),
+        # "respect": choice(["_INVALID", "_TRUE"]),
         "respect": choice([0.0, 1.0]),
-        #"replace": choice(["_FALSE", "_INVALID"]),
+        # "replace": choice(["_FALSE", "_INVALID"]),
         "replace": choice([0.0, 1.0]),
     },
 }
 SEARCH_SPACE_7609 = {
     "name": "7609",
-    "positions_hps": {"num.trees": 0, "sample.fraction": 2, "min.node.size": 3, "mtry": 4},
-    "positions_categorical": {
-        "respect": [6, 7],
-        "replace": [8, 9]
+    "positions_hps": {
+        "num.trees": 0,
+        "sample.fraction": 2,
+        "min.node.size": 3,
+        "mtry": 4,
     },
+    "positions_categorical": {"respect": [6, 7], "replace": [8, 9]},
     "config_space": {
         "num.trees": uniform(0.0, 1.0),
         "mtry": uniform(0.0, 1.0),
         "min.node.size": uniform(0.0, 1.0),
         "sample.fraction": uniform(0.0, 1.0),
-        #"respect": choice(["_INVALID", "_TRUE"]),
+        # "respect": choice(["_INVALID", "_TRUE"]),
         "respect": choice([0.0, 1.0]),
-        #"replace": choice(["_FALSE", "_INVALID"]),
+        # "replace": choice(["_FALSE", "_INVALID"]),
         "replace": choice([0.0, 1.0]),
     },
 }
@@ -266,7 +292,7 @@ SEARCH_SPACE_5889 = {
         "num.trees": uniform(0.0, 1.0),
         "mtry": uniform(0.0, 1.0),
         "sample.fraction": uniform(0.1, 1.0),
-        #"replace": choice(["_FALSE", "_INVALID"]),
+        # "replace": choice(["_FALSE", "_INVALID"]),
         "replace": choice([0.0, 1.0]),
     },
 }
@@ -462,7 +488,6 @@ def convert_dataset(search_space, dataset):
         objectives_names=objective_names,
         fidelity_space=fidelity_space,
     )
-
 
 
 def load_data():

--- a/syne_tune/blackbox_repository/conversion_scripts/scripts/hpob_import.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/scripts/hpob_import.py
@@ -15,8 +15,8 @@ from syne_tune.blackbox_repository.conversion_scripts.blackbox_recipe import (
 )
 from syne_tune.config_space import (
     uniform,
-    loguniform,
     randint,
+    choice,
     config_space_to_json_dict,
     config_space_from_json_dict,
 )
@@ -33,218 +33,245 @@ BLACKBOX_NAME = "hpob_"
 METRIC_ELAPSED_TIME = "metric_elapsed_time"
 
 # configuration_space values taken from "https://raw.githubusercontent.com/machinelearningnuremberg/HPO-B/refs/heads/main/hpob-data/meta-dataset-descriptors.json"
+
 SEARCH_SPACE_4796 = {
     "name": "4796",
+    "positions_hps": {"minsplit": 0, "minbucket": 1, "cp": 2},
+    "positions_categorical": {},
     "config_space": {
-        "minsplit": loguniform(2.0, 128.0),
-        "minbucket": loguniform(1.0, 64.0),
-        "cp": loguniform(0.0002, 0.1),
+        "minsplit": uniform(0.0, 1.0),
+        "minbucket": uniform(0.0, 1.0),
+        "cp": uniform(0.0, 1.0),
     },
 }
 
 SEARCH_SPACE_5527 = {
     "name": "5527",
+    "positions_hps": {"cost": 0, "gamma": 1, "degree": 3},
+    "positions_categorical": {"kernel": [4, 5, 6]},
     "config_space": {
-        "cost": loguniform(0.001, 1024.0),
-        "gamma": loguniform(0.0001, 1024.0),
-        "gamma.na": uniform(0.0, 1.0),
-        "degree": uniform(0.0, 5.0),
-        "degree.na": uniform(0.0, 1.0),
-        "kernel.ohe.na": 308190.0,
-        "kernel.ohe.linear": 316563.0,
-        "kernel.ohe.polynomial": 311266.0,
+        "cost": uniform(0.0, 1.0),
+        "gamma": uniform(0.0, 1.0),
+        "degree": uniform(0.0, 1.0),
+        #"kernel": choice(["_INVALID", "_linear", "_polynomial"]),
+        "kernel": choice([0.0,1.0,2.0])
     },
 }
 SEARCH_SPACE_5636 = {
     "name": "5636",
+    "positions_hps": {"minsplit": 0, "cp": 2, "maxdepth": 3, "minbucket": 4},
+    "positions_categorical": {},
     "config_space": {
-        "minsplit": uniform(0.0, 60.0),
-        "minsplit.na": uniform(0.0, 1.0),
-        "minbucket": uniform(1.0, 60.0),
-        "cp": uniform(-9.2, 9.906167518025702e-5),
-        "maxdepth": uniform(0.0, 29.0),
-        "maxdepth.na": uniform(0.0, 1.0),
+        "minsplit": uniform(0.0, 1.0),
+        "minbucket": uniform(0.0, 1.0),
+        "cp": uniform(0.0, 1.0),
+        "maxdepth": uniform(0.0, 1.0),
     },
 }
 SEARCH_SPACE_5859 = {
     "name": "5859",
+    "positions_hps": {"minsplit": 0, "cp": 2, "maxdepth": 3, "minbucket": 4},
+    "positions_categorical": {},
     "config_space": {
-        "minsplit": uniform(0.0, 60.0),
-        "minsplit.na": uniform(0.0, 1.0),
-        "minbucket": uniform(1.0, 60.0),
-        "cp": loguniform(0.0001, 1.0),
-        "maxdepth": uniform(0.0, 29.0),
-        "maxdepth.na": uniform(0.0, 1.0),
+        "minsplit": uniform(0.0, 1.0),
+        "minbucket": uniform(1.0, 1.0),
+        "cp": uniform(0.0, 1.0),
+        "maxdepth": uniform(0.0, 1.0),
     },
 }
 SEARCH_SPACE_5860 = {
     "name": "5860",
+    "positions_hps": {"alpha": 0, "lambda": 1},
+    "positions_categorical": {},
     "config_space": {
-        "alpha": loguniform(0.000578, 1.0),
-        "lambda": loguniform(0.001, 1019.35),
+        "alpha": uniform(0.0, 1.0),
+        "lambda": uniform(0.0, 1.0),
     },
 }
 SEARCH_SPACE_5891 = {
     "name": "5891",
+    "positions_hps": {"cost": 0, "gamma": 1, "degree": 3},
+    "positions_categorical": {"kernel": [5, 6, 7]},
     "config_space": {
-        "cost": uniform(0.001, 1024.0),
-        "gamma": uniform(0.0, 1024.0),
-        "gamma.na": uniform(0.0, 1.0),
-        "degree": uniform(0.0, 5.0),
-        "degree.na": uniform(0.0, 1.0),
-        "kernel.ohe.na": 24627,
-        "kernel.ohe.linear": 24952,
-        "kernel.ohe.polynomial": 24813,
+        "cost": uniform(0.0, 1.0),
+        "gamma": uniform(0.0, 1.0),
+        "degree": uniform(0.0, 1.0),
+        #"kernel": choice(["_INVALID", "_linear", "_polynomial"]),
+        "kernel": choice([0.0,1.0,2.0])
     },
 }
 SEARCH_SPACE_5906 = {
     "name": "5906",
+    "positions_hps": {
+        "eta": 0, "max_depth": 1, "min_child_weight": 3, "subsample": 5,
+        "colsample_bytree": 6, "colsample_bylevel": 8,
+        "lambda": 10, "alpha": 11, "nrounds": 12,
+    },
+    "positions_categorical": {"booster": [14, 15]},
     "config_space": {
-        "eta": loguniform(0.001, 1.0),
-        "max_depth": uniform(0.0, 15.0),
-        "max_depth.na": uniform(0.0, 1.0),
-        "min_child_weight": loguniform(0.0001, 128.0),
-        "min_child_weight.na": uniform(0.0, 1.0),
-        "subsample": uniform(0.1, 1.0),
-        "colsample_bytree": loguniform(0.0001, 1.0),
-        "colsample_bytree.na": uniform(0.0, 1.0),
+        "eta": uniform(0.0, 1.0),
+        "max_depth": uniform(0.0, 1.0),
+        "min_child_weight": uniform(0.0, 1.0),
+        "subsample": uniform(0.0, 1.0),
+        "colsample_bytree": uniform(0.0, 1.0),
         "colsample_bylevel": uniform(0.0, 1.0),
-        "colsample_bylevel.na": uniform(0.0, 1.0),
-        "lambda": loguniform(0.001, 1020.8),
-        "alpha": loguniform(0.001, 1024.0),
-        "nrounds": loguniform(0.0001, 5000.0),
-        "nrounds.na": uniform(0.0, 1.0),
-        "booster.ohe.na": 1449,
-        "booster.ohe.gblinear": 1937,
+        "lambda": uniform(0.0, 1.0),
+        "alpha": uniform(0.0, 1.0),
+        "nrounds": uniform(0.0, 1.0),
+        #"booster": choice(["_INVALID", "_gblinear"]),
+        "booster": choice([0.0,1.0])
     },
 }
 SEARCH_SPACE_5965 = {
     "name": "5965",
+    "positions_hps": {"num.trees": 0, "sample.fraction": 2, "min.node.size": 3, "mtry": 4},
+    "positions_categorical": {
+        "replace": [6, 7],
+        "respect": [8, 9]
+    },
     "config_space": {
-        "num.trees": loguniform(0.0001, 2000.0),
-        "num.trees.na": uniform(0.0, 1.0),
-        "mtry": loguniform(1.0, 1776.0),
-        "sample.fraction": uniform(0.1, 1.0),
-        "min.node.size": loguniform(0.0001, 45310.0),
-        "min.node.size.na": uniform(0.0, 1.0),
-        "replace.ohe.FALSE": 295436,
-        "replace.ohe.na": 296498,
-        "respect.unordered.factors.ohe.INVALID": 294378,
-        "respect.unordered.factors.ohe.TRUE": 297556,
+        "num.trees": uniform(0.0, 1.0),
+        "mtry": uniform(0.0, 1.0),
+        "sample.fraction": uniform(0.0, 1.0),
+        "min.node.size": uniform(0.0, 1.0),
+        #"replace": choice(["_FALSE", "_INVALID"]),
+        "replace": choice([0.0, 1.0]),
+        #"respect": choice(["_INVALID", "_TRUE"]),
+        "respect": choice([0.0, 1.0]),
     },
 }
 SEARCH_SPACE_5970 = {
     "name": "5970",
+    "positions_hps": {"alpha": 0, "lambda": 1},
+    "positions_categorical": {},
     "config_space": {
-        "alpha": loguniform(1.0, 2.72),
-        "lambda": loguniform(0.001, 1024.0),
+        "alpha": uniform(0.0, 1.0),
+        "lambda": uniform(0.0, 1.0),
     },
 }
 SEARCH_SPACE_5971 = {
     "name": "5971",
+    "positions_hps": {
+        "eta": 0, "max_depth": 1, "min_child_weight": 3, "subsample": 5,
+        "colsample_bytree": 6, "colsample_bylevel": 8,
+        "lambda": 10, "alpha": 11, "nrounds": 12,
+    },
+    "positions_categorical": {"booster": [14, 15]},
     "config_space": {
-        "eta": loguniform(0.001, 1.0),
-        "max_depth": uniform(0.0, 15.0),
-        "max_depth.na": uniform(0.0, 1.0),
-        "min_child_weight": loguniform(0.0001, 128.0),
-        "min_child_weight.na": uniform(0.0, 1.0),
-        "subsample": uniform(0.1, 1.0),
+        "eta": uniform(0.0, 1.0),
+        "max_depth": uniform(0.0, 1.0),
+        "min_child_weight": uniform(0.0, 1.0),
+        "subsample": uniform(0.0, 1.0),
         "colsample_bytree": uniform(0.0, 1.0),
-        "colsample_bytree.na": uniform(0.0, 1.0),
         "colsample_bylevel": uniform(0.0, 1.0),
-        "colsample_bylevel.na": uniform(0.0, 1.0),
-        "lambda": loguniform(0.001, 1024.0),
-        "alpha": loguniform(0.001, 1024.0),
-        "nrounds": uniform(0, 5000),
-        "nrounds.na": uniform(0.0, 1.0),
-        "booster.ohe.na": 34130,
-        "booster.ohe.gblinear": 45096,
+        "lambda": uniform(0.0, 1.0),
+        "alpha": uniform(0.0, 1.0),
+        "nrounds": uniform(0.0, 1.0),
+        #"booster": choice(["_INVALID", "_gblinear"]),
+        "booster": choice([0.0, 1.0]),
     },
 }
 SEARCH_SPACE_6766 = {
     "name": "6766",
+    "positions_hps": {"alpha": 0, "lambda": 1},
+    "positions_categorical": {},
     "config_space": {
-        "alpha": loguniform(1.0, 2.72),
-        "lambda": loguniform(0.001, 1024.0),
+        "alpha": uniform(0.0, 1.0),
+        "lambda": uniform(0.0, 1.0),
     },
 }
 SEARCH_SPACE_6767 = {
     "name": "6767",
+    "positions_hps": {
+        "eta": 0, "subsample": 1, "lambda": 2, "alpha": 3,
+        "nthread": 4, "nrounds": 6, "max_depth": 8,
+        "min_child_weight": 10, "colsample_bytree": 12,
+        "colsample_bylevel": 14
+    },
+    "positions_categorical": {"booster": [16, 17]},
     "config_space": {
-        "eta": uniform(0.001, 1.0),
-        "subsample": uniform(0.1, 1.0),
-        "lambda": uniform(0.001, 1024.0),
-        "alpha": uniform(0.001, 1024.0),
+        "eta": uniform(0.0, 1.0),
+        "subsample": uniform(0.0, 1.0),
+        "lambda": uniform(0.0, 1.0),
+        "alpha": uniform(0.0, 1.0),
         "nthread": uniform(0.0, 1.0),
-        "nthread.na": uniform(0.0, 1.0),
-        "nrounds": uniform(0.0, 5000.0),
-        "nrounds.na": uniform(0.0, 1.0),
-        "max_depth": uniform(0.0, 15.0),
-        "max_depth.na": uniform(0.0, 1.0),
-        "min_child_weight": uniform(0.0, 128.0),
-        "min_child_weight.na": uniform(0.0, 1.0),
+        "nrounds": uniform(0.0, 1.0),
+        "max_depth": uniform(0.0, 1.0),
+        "min_child_weight": uniform(0.0, 1.0),
         "colsample_bytree": uniform(0.0, 1.0),
-        "colsample_bytree.na": uniform(0.0, 1.0),
         "colsample_bylevel": uniform(0.0, 1.0),
-        "colsample_bylevel.na": uniform(0.0, 1.0),
-        "booster.ohe.na": 430736,
-        "booster.ohe.gblinear": 620644,
+        #"booster": choice(["_INVALID", "_gblinear"]),
+        "booster": choice([0.0, 1.0]),
     },
 }
 SEARCH_SPACE_6794 = {
     "name": "6794",
+    "positions_hps": {"num.trees": 0, "sample.fraction": 2, "min.node.size": 3, "mtry": 4},
+    "positions_categorical": {
+        "replace": [6, 7],
+        "respect": [8, 9]
+    },
     "config_space": {
-        "num.trees": uniform(0.0, 2000.0),
-        "num.trees.na": uniform(0.0, 1.0),
-        "mtry": uniform(1.0, 1558.0),
-        "sample.fraction": uniform(0.1, 1.0),
-        "min.node.size": uniform(-9.21, 10.72),
-        "min.node.size.na": uniform(0.0, 3195.0),
-        "replace.ohe.FALSE": 623218,
-        "replace.ohe.na": 625345,
-        "respect.unordered.factors.ohe.INVALID": 625034,
-        "respect.unordered.factors.ohe.TRUE": 623529,
+        "num.trees": uniform(0.0, 1.0),
+        "mtry": uniform(0.0, 1.0),
+        "sample.fraction": uniform(0.0, 1.0),
+        "min.node.size": uniform(0.0, 1.0),
+        #"replace": choice(["_FALSE", "_INVALID"]),
+        "replace": choice([0.0, 1.0]),
+        #"respect": choice(["_INVALID", "_TRUE"]),
+        "respect": choice([0.0, 1.0]),
     },
 }
 SEARCH_SPACE_7607 = {
     "name": "7607",
+    "positions_hps": {"num.trees": 0, "min.node.size": 2, "sample.fraction": 3, "mtry": 4},
+    "positions_categorical": {
+        "replace": [5, 6],
+        "respect": [7, 8]
+    },
     "config_space": {
-        "num.trees": uniform(0.0, 2000.0),
-        "num.trees.na": uniform(0.0, 1.0),
-        "mtry": uniform(1.0, 1775.0),
-        "min.node.size": loguniform(1.0, 44808.0),
-        "sample.fraction": uniform(0.1, 1.0),
-        "replace.ohe.FALSE": 14478,
-        "replace.ohe.na": 14434,
-        "respect.unordered.factors.ohe.INVALID": 14392,
-        "respect.unordered.factors.ohe.TRUE": 14520,
+        "num.trees": uniform(0.0, 1.0),
+        "mtry": uniform(0.0, 1.0),
+        "min.node.size": uniform(0.0, 1.0),
+        "sample.fraction": uniform(0.0, 1.0),
+        #"respect": choice(["_INVALID", "_TRUE"]),
+        "respect": choice([0.0, 1.0]),
+        #"replace": choice(["_FALSE", "_INVALID"]),
+        "replace": choice([0.0, 1.0]),
     },
 }
 SEARCH_SPACE_7609 = {
     "name": "7609",
+    "positions_hps": {"num.trees": 0, "sample.fraction": 2, "min.node.size": 3, "mtry": 4},
+    "positions_categorical": {
+        "respect": [6, 7],
+        "replace": [8, 9]
+    },
     "config_space": {
-        "num.trees": uniform(0.0, 2000.0),
-        "num.trees.na": uniform(0.0, 1.0),
-        "mtry": uniform(1.0, 1776.0),
-        "min.node.size": loguniform(1.0, 45280.0),
-        "sample.fraction": uniform(0.1, 1.0),
-        "replace.ohe.FALSE": 32943,
-        "replace.ohe.na": 33003,
-        "respect.unordered.factors.ohe.INVALID": 33007,
-        "respect.unordered.factors.ohe.TRUE": 32939,
+        "num.trees": uniform(0.0, 1.0),
+        "mtry": uniform(0.0, 1.0),
+        "min.node.size": uniform(0.0, 1.0),
+        "sample.fraction": uniform(0.0, 1.0),
+        #"respect": choice(["_INVALID", "_TRUE"]),
+        "respect": choice([0.0, 1.0]),
+        #"replace": choice(["_FALSE", "_INVALID"]),
+        "replace": choice([0.0, 1.0]),
     },
 }
 SEARCH_SPACE_5889 = {
     "name": "5889",
+    "positions_hps": {"num.trees": 0, "mtry": 1, "sample.fraction": 2, "replace": 3},
+    "positions_categorical": {},
     "config_space": {
-        "num.trees": loguniform(0.0001, 2000.0),
-        "num.trees.na": uniform(0.0, 1.0),
-        "mtry": loguniform(1.0, 1324.0),
+        "num.trees": uniform(0.0, 1.0),
+        "mtry": uniform(0.0, 1.0),
         "sample.fraction": uniform(0.1, 1.0),
-        "replace.ohe.FALSE": 1215,
-        "replace.ohe.na": 1226,
+        #"replace": choice(["_FALSE", "_INVALID"]),
+        "replace": choice([0.0, 1.0]),
     },
 }
+
+
 RESOURCE_ATTR = "hp_epoch"
 MAX_RESOURCE_LEVEL = 100
 
@@ -373,7 +400,40 @@ def convert_dataset(search_space, dataset):
     hps = np.zeros((n_evals, n_hps))
 
     for i, config in enumerate(dataset["X"]):
-        hps[i] = config
+        final_config = []
+
+        for hp in search_space["positions_hps"]:
+            pos = search_space["positions_hps"][hp]
+            final_config.append(config[pos])
+
+        # Handle categorical hyperparameters
+        if search_space["positions_categorical"]:
+            for hp in search_space["positions_categorical"]:
+                positions = search_space["positions_categorical"][hp]
+                if hp == "booster":
+                    if config[positions[0]] == 1.0:
+                        final_config.append(0.0)
+                    else:
+                        final_config.append(1.0)
+                elif hp == "respect":
+                    if config[positions[0]] == 1.0:
+                        final_config.append(0.0)
+                    else:
+                        final_config.append(1.0)
+                elif hp == "replace":
+                    if config[positions[0]] == 1.0:
+                        final_config.append(0.0)
+                    else:
+                        final_config.append(1.0)
+                elif hp == "kernel":
+                    if config[positions[0]] == 1.0:
+                        final_config.append(0.0)
+                    elif config[positions[1]] == 1.0:
+                        final_config.append(1.0)
+                    else:
+                        final_config.append(2.0)
+
+        hps[i] = final_config
 
     hyperparameters = pd.DataFrame(data=hps, columns=hp_cols)
 
@@ -402,6 +462,7 @@ def convert_dataset(search_space, dataset):
         objectives_names=objective_names,
         fidelity_space=fidelity_space,
     )
+
 
 
 def load_data():

--- a/syne_tune/blackbox_repository/conversion_scripts/scripts/hpob_import.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/scripts/hpob_import.py
@@ -645,4 +645,4 @@ if __name__ == "__main__":
 
     for recipe in recipes:
         instance = recipe()
-        instance.generate(upload_on_hub=False)
+        instance.generate(upload_on_hub=True)


### PR DESCRIPTION
This PR fixes the hpob_import.

- [x] Hyperparameter values need to be normalized in the search space 
- [x] `.na` entries need to be removed from the search spaces
- [x] categorical values will need to be added 
- [x] adapt import logic for categorical values and removal of `.na` values


Closes #949.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
