### PR TITLE
fix: constrain scipy version

### DIFF
--- a/requirements-gpsearchers.txt
+++ b/requirements-gpsearchers.txt
@@ -1,2 +1,2 @@
-scipy>=1.3.3
+scipy<1.15.3  # 1.16 is not compatible with the current statsmodels version
 autograd>=1.3


### PR DESCRIPTION
scipy 16.1 is not compatible with the current statsmodels version

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
