### PR TITLE
Remove typing imports

### DIFF
--- a/benchmarking/baselines.py
+++ b/benchmarking/baselines.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Optional, List
 
 from syne_tune.blackbox_repository.simulated_tabular_backend import (
     BlackboxRepositoryBackend,
@@ -18,12 +17,12 @@ class MethodArguments:
     mode: str
     random_seed: int
     resource_attr: str
-    points_to_evaluate: List[dict]
-    max_t: Optional[int] = None
-    max_resource_attr: Optional[str] = None
+    points_to_evaluate: list[dict]
+    max_t: int | None = None
+    max_resource_attr: str | None = None
     use_surrogates: bool = False
-    num_brackets: Optional[int] = 1
-    verbose: Optional[bool] = False
+    num_brackets: int | None = 1
+    verbose: bool | None = False
 
 
 class Methods:

--- a/benchmarking/benchmarks.py
+++ b/benchmarking/benchmarks.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Optional, List, Dict
 
 from syne_tune.blackbox_repository.conversion_scripts.scripts.tabrepo_import import (
     TABREPO_DATASETS,
@@ -15,10 +14,10 @@ class BenchmarkDefinition:
     mode: str
     blackbox_name: str
     dataset_name: str
-    max_num_evaluations: Optional[int] = None
-    surrogate: Optional[str] = None
-    surrogate_kwargs: Optional[Dict] = None
-    datasets: Optional[List[str]] = None
+    max_num_evaluations: int | None= None
+    surrogate: str | None = None
+    surrogate_kwargs: dict | None = None
+    datasets: list[str] | None = None
 
 
 n_full_evals = 200

--- a/benchmarking/benchmarks.py
+++ b/benchmarking/benchmarks.py
@@ -14,7 +14,7 @@ class BenchmarkDefinition:
     mode: str
     blackbox_name: str
     dataset_name: str
-    max_num_evaluations: int | None= None
+    max_num_evaluations: int | None = None
     surrogate: str | None = None
     surrogate_kwargs: dict | None = None
     datasets: list[str] | None = None

--- a/benchmarking/results_analysis/load_experiments_parallel.py
+++ b/benchmarking/results_analysis/load_experiments_parallel.py
@@ -3,7 +3,6 @@ import logging
 from collections import defaultdict
 from json import JSONDecodeError
 from pathlib import Path
-from typing import Dict, Tuple
 
 import numpy as np
 import pandas as pd
@@ -153,7 +152,7 @@ def load_benchmark_results(
     max_seed: int = None,
     experiment_filter=None,
     engine: str = "joblib",
-) -> Dict[str, Tuple[np.array, Dict[str, np.array]]]:
+) -> dict[str, tuple[np.array, dict[str, np.array]]]:
     """
     :param path: where results are stored
     :param methods: list of methods to consider

--- a/benchmarking/results_analysis/show_results.py
+++ b/benchmarking/results_analysis/show_results.py
@@ -1,7 +1,6 @@
 import logging
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Dict, Tuple, Optional, List
 
 import dill
 import matplotlib
@@ -73,7 +72,7 @@ benchmark_names = {
 
 def plot_result_benchmark(
     t_range: np.array,
-    method_dict: Dict[str, np.array],
+    method_dict: dict[str, np.array],
     title: str,
     rename_dict: dict,
     ax=None,
@@ -126,7 +125,7 @@ def plot_result_benchmark(
 
 
 def plot_task_performance_over_time(
-    benchmark_results: Dict[str, Tuple[np.array, Dict[str, np.array]]],
+    benchmark_results: dict[str, tuple[np.array, dict[str, np.array]]],
     rename_dict: dict,
     result_folder: Path,
     title: str = None,
@@ -163,7 +162,7 @@ def plot_task_performance_over_time(
 
 def load_and_cache(
     path: Path,
-    methods: Optional[List[str]] = None,
+    methods: list[str] | None = None,
     load_cache_if_exists: bool = True,
     num_time_steps=100,
     max_seed=10,
@@ -197,7 +196,7 @@ def plot_ranks(
     title: str,
     rename_dict: dict,
     result_folder: Path,
-    methods_to_show: List[str],
+    methods_to_show: list[str],
 ):
     plt.figure()
     # (num_methods, num_benchmarks, num_min_seeds, num_time_steps)
@@ -222,10 +221,10 @@ def plot_ranks(
 
 
 def stack_benchmark_results(
-    benchmark_results_dict: Dict[str, Tuple[np.array, Dict[str, np.array]]],
-    methods_to_show: Optional[List[str]],
-    benchmark_families: List[str],
-) -> Dict[str, np.array]:
+    benchmark_results_dict: dict[str, tuple[np.array, dict[str, np.array]]],
+    methods_to_show: list[str] | None,
+    benchmark_families: list[str],
+) -> dict[str, np.array]:
     """
     Stack benchmark results between benchmarks of the same family.
     :param benchmark_results_dict:
@@ -294,9 +293,9 @@ def stack_benchmark_results(
 
 
 def generate_rank_results(
-    benchmark_families: List[str],
-    stacked_benchmark_results: Dict[str, np.array],
-    methods_to_show: Optional[List[str]],
+    benchmark_families: list[str],
+    stacked_benchmark_results: dict[str, np.array],
+    methods_to_show: list[str] | None,
     rename_dict: dict,
     result_folder: Path,
 ):

--- a/examples/training_scripts/checkpoint_example/train_height_checkpoint.py
+++ b/examples/training_scripts/checkpoint_example/train_height_checkpoint.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from typing import Optional, Dict, Any
+from typing import Any
 import json
 from pathlib import Path
 import os
@@ -25,7 +25,7 @@ METRIC_MODE = "min"
 MAX_RESOURCE_ATTR = "steps"
 
 
-def load_checkpoint(checkpoint_path: Path) -> Dict[str, Any]:
+def load_checkpoint(checkpoint_path: Path) -> dict[str, Any]:
     with open(checkpoint_path, "r") as f:
         return json.load(f)
 
@@ -61,8 +61,8 @@ def train_height_delta(step: int, width: float, height: float, value: float) -> 
 
 
 def height_config_space(
-    max_steps: int, sleep_time: Optional[float] = None
-) -> Dict[str, Any]:
+    max_steps: int, sleep_time: float | None = None
+) -> dict[str, Any]:
     kwargs = {"sleep_time": sleep_time} if sleep_time is not None else dict()
     return {
         MAX_RESOURCE_ATTR: max_steps,

--- a/examples/training_scripts/height_example/blackbox_height.py
+++ b/examples/training_scripts/height_example/blackbox_height.py
@@ -1,4 +1,4 @@
-from typing import  Any
+from typing import Any
 import numpy as np
 
 from syne_tune.blackbox_repository.blackbox import Blackbox, ObjectiveFunctionResult

--- a/examples/training_scripts/height_example/blackbox_height.py
+++ b/examples/training_scripts/height_example/blackbox_height.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any
+from typing import  Any
 import numpy as np
 
 from syne_tune.blackbox_repository.blackbox import Blackbox, ObjectiveFunctionResult
@@ -31,9 +31,9 @@ class HeightExampleBlackbox(Blackbox):
 
     def _objective_function(
         self,
-        configuration: Dict[str, Any],
-        fidelity: Optional[dict] = None,
-        seed: Optional[int] = None,
+        configuration: dict[str, Any],
+        fidelity: dict | None = None,
+        seed: int | None = None,
     ) -> ObjectiveFunctionResult:
         assert seed is None or seed == 0, "Blackbox has one seed only"
         width, height = configuration["width"], configuration["height"]
@@ -59,5 +59,5 @@ class HeightExampleBlackbox(Blackbox):
             )
 
     @property
-    def fidelity_values(self) -> Optional[np.array]:
+    def fidelity_values(self) -> np.array | None:
         return np.arange(1, self._max_steps + 1)

--- a/examples/training_scripts/height_example/train_height.py
+++ b/examples/training_scripts/height_example/train_height.py
@@ -3,7 +3,7 @@ Example similar to Raytune, https://github.com/ray-project/ray/blob/master/pytho
 """
 import logging
 import time
-from typing import Optional, Dict, Any
+from typing import Any
 
 from syne_tune import Reporter
 from argparse import ArgumentParser
@@ -28,8 +28,8 @@ def train_height(step: int, width: float, height: float) -> float:
 
 
 def height_config_space(
-    max_steps: int, sleep_time: Optional[float] = None
-) -> Dict[str, Any]:
+    max_steps: int, sleep_time: float | None = None
+) -> dict[str, Any]:
     kwargs = {"sleep_time": sleep_time} if sleep_time is not None else dict()
     return {
         MAX_RESOURCE_ATTR: max_steps,

--- a/examples/training_scripts/height_example/train_height_config_json.py
+++ b/examples/training_scripts/height_example/train_height_config_json.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from typing import Optional, Dict, Any
+from typing import Any
 from argparse import ArgumentParser
 
 from syne_tune import Reporter
@@ -25,8 +25,8 @@ def train_height(step: int, width: float, height: float) -> float:
 
 
 def height_config_space(
-    max_steps: int, sleep_time: Optional[float] = None
-) -> Dict[str, Any]:
+    max_steps: int, sleep_time: float | None = None
+) -> dict[str, Any]:
     if sleep_time is None:
         sleep_time = 0.1
     return {
@@ -48,7 +48,7 @@ def height_config_space(
     }
 
 
-def _check_extra_args(config: Dict[str, Any]):
+def _check_extra_args(config: dict[str, Any]):
     config_space = height_config_space(5)
     for k in ("list_arg", "dict_arg"):
         a, b = config[k], config_space[k]

--- a/syne_tune/backend/local_backend.py
+++ b/syne_tune/backend/local_backend.py
@@ -358,9 +358,7 @@ class LocalBackend(TrialBackend):
         with open(self.trial_path(trial_id=trial_id) / "std.err", "r") as f:
             return f.readlines()
 
-    def set_path(
-        self, results_root: str | None = None, tuner_name: str | None = None
-    ):
+    def set_path(self, results_root: str | None = None, tuner_name: str | None = None):
         self.local_path = Path(results_root)
 
     def entrypoint_path(self) -> Path:

--- a/syne_tune/backend/local_backend.py
+++ b/syne_tune/backend/local_backend.py
@@ -6,7 +6,7 @@ from operator import itemgetter
 import subprocess
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional, Tuple, Dict, Any
+from typing import Any
 
 from syne_tune.backend.trial_backend import TrialBackend, BUSY_STATUS
 from syne_tune.num_gpu import get_num_gpus
@@ -57,7 +57,7 @@ class LocalBackend(TrialBackend):
         pass_args_as_json: bool = False,
         rotate_gpus: bool = True,
         num_gpus_per_trial: int = 1,
-        gpus_to_use: Optional[List[int]] = None,
+        gpus_to_use: list[int] | None = None,
     ):
         super(LocalBackend, self).__init__(
             delete_checkpoints=delete_checkpoints, pass_args_as_json=pass_args_as_json
@@ -152,7 +152,7 @@ class LocalBackend(TrialBackend):
                 # Nothing to rotate over
                 self.rotate_gpus = False
 
-    def _gpus_for_new_trial(self) -> List[int]:
+    def _gpus_for_new_trial(self) -> list[int]:
         """
         Selects ``num_gpus_per_trial`` GPUs for trial to be scheduled on. GPUs
         not assigned to other running trials have precedence. Ties are resolved
@@ -184,7 +184,7 @@ class LocalBackend(TrialBackend):
             self.gpu_times_assigned[gpu] += 1
         return res_gpu
 
-    def _schedule(self, trial_id: int, config: Dict[str, Any]):
+    def _schedule(self, trial_id: int, config: dict[str, Any]):
         self._prepare_for_schedule()
         trial_path = self.trial_path(trial_id)
         os.makedirs(trial_path, exist_ok=True)
@@ -216,7 +216,7 @@ class LocalBackend(TrialBackend):
                 )
         self._busy_trial_id_candidates.add(trial_id)  # Mark trial as busy
 
-    def _allocate_gpu(self, trial_id: int, env: Dict[str, Any]):
+    def _allocate_gpu(self, trial_id: int, env: dict[str, Any]):
         if self.rotate_gpus:
             gpus = self._gpus_for_new_trial()
             if self.gpus_to_use is not None:
@@ -233,7 +233,7 @@ class LocalBackend(TrialBackend):
         if self.rotate_gpus and trial_id in self.trial_gpu:
             del self.trial_gpu[trial_id]
 
-    def _all_trial_results(self, trial_ids: List[int]) -> List[TrialResult]:
+    def _all_trial_results(self, trial_ids: list[int]) -> list[TrialResult]:
         res = []
         for trial_id in trial_ids:
             trial_path = self.trial_path(trial_id)
@@ -271,7 +271,7 @@ class LocalBackend(TrialBackend):
         if trial_id in self._busy_trial_id_candidates:
             self._busy_trial_id_candidates.remove(trial_id)
 
-    def _pause_trial(self, trial_id: int, result: Optional[dict]):
+    def _pause_trial(self, trial_id: int, result: dict | None):
         self._file_path(trial_id=trial_id, filename="pause").touch()
         self._kill_process(trial_id)
         self._deallocate_gpu(trial_id)
@@ -284,7 +284,7 @@ class LocalBackend(TrialBackend):
         except FileNotFoundError:
             logger.info(f"Pause lock file {str(pause_path)} not found")
 
-    def _stop_trial(self, trial_id: int, result: Optional[dict]):
+    def _stop_trial(self, trial_id: int, result: dict | None):
         self._file_path(trial_id=trial_id, filename="stop").touch()
         self._kill_process(trial_id)
         self._deallocate_gpu(trial_id)
@@ -329,7 +329,7 @@ class LocalBackend(TrialBackend):
                 else:
                     return Status.failed
 
-    def _get_busy_trial_ids(self) -> List[Tuple[int, str]]:
+    def _get_busy_trial_ids(self) -> list[tuple[int, str]]:
         busy_list = []
         for trial_id in self._busy_trial_id_candidates:
             status = self._read_status(trial_id)
@@ -337,7 +337,7 @@ class LocalBackend(TrialBackend):
                 busy_list.append((trial_id, status))
         return busy_list
 
-    def busy_trial_ids(self) -> List[Tuple[int, str]]:
+    def busy_trial_ids(self) -> list[tuple[int, str]]:
         # Note that at this point, ``self._busy_trial_id_candidates`` contains
         # trials whose jobs have been busy in the past, but they may have
         # stopped or terminated since. We query the current status for all
@@ -350,16 +350,16 @@ class LocalBackend(TrialBackend):
         else:
             return []
 
-    def stdout(self, trial_id: int) -> List[str]:
+    def stdout(self, trial_id: int) -> list[str]:
         with open(self.trial_path(trial_id=trial_id) / "std.out", "r") as f:
             return f.readlines()
 
-    def stderr(self, trial_id: int) -> List[str]:
+    def stderr(self, trial_id: int) -> list[str]:
         with open(self.trial_path(trial_id=trial_id) / "std.err", "r") as f:
             return f.readlines()
 
     def set_path(
-        self, results_root: Optional[str] = None, tuner_name: Optional[str] = None
+        self, results_root: str | None = None, tuner_name: str | None = None
     ):
         self.local_path = Path(results_root)
 

--- a/syne_tune/backend/python_backend/python_backend.py
+++ b/syne_tune/backend/python_backend/python_backend.py
@@ -2,7 +2,8 @@ import hashlib
 import logging
 import types
 from pathlib import Path
-from typing import Callable, Dict, Optional, Any
+from typing import Any
+from collections.abc import Callable
 
 import dill
 
@@ -67,7 +68,7 @@ class PythonBackend(LocalBackend):
     def __init__(
         self,
         tune_function: Callable,
-        config_space: Dict[str, object],
+        config_space: dict[str, object],
         rotate_gpus: bool = True,
         delete_checkpoints: bool = False,
     ):
@@ -86,7 +87,7 @@ class PythonBackend(LocalBackend):
         return self.local_path / "tune_function"
 
     def set_path(
-        self, results_root: Optional[str] = None, tuner_name: Optional[str] = None
+        self, results_root: str | None = None, tuner_name: str | None = None
     ):
         super(PythonBackend, self).set_path(
             results_root=results_root, tuner_name=tuner_name
@@ -96,7 +97,7 @@ class PythonBackend(LocalBackend):
                 f"Path {self.local_path} already exists, make sure you have a unique tuner name."
             )
 
-    def _schedule(self, trial_id: int, config: Dict[str, Any]):
+    def _schedule(self, trial_id: int, config: dict[str, Any]):
         if not (self.tune_function_path / "tune_function.dill").exists():
             self.save_tune_function(self.tune_function)
         config = config.copy()

--- a/syne_tune/backend/python_backend/python_backend.py
+++ b/syne_tune/backend/python_backend/python_backend.py
@@ -86,9 +86,7 @@ class PythonBackend(LocalBackend):
     def tune_function_path(self) -> Path:
         return self.local_path / "tune_function"
 
-    def set_path(
-        self, results_root: str | None = None, tuner_name: str | None = None
-    ):
+    def set_path(self, results_root: str | None = None, tuner_name: str | None = None):
         super(PythonBackend, self).set_path(
             results_root=results_root, tuner_name=tuner_name
         )

--- a/syne_tune/backend/simulator_backend/events.py
+++ b/syne_tune/backend/simulator_backend/events.py
@@ -68,9 +68,7 @@ class SimulatorState:
 
     """
 
-    def __init__(
-        self, event_heap: EventHeapType | None = None, events_added: int = 0
-    ):
+    def __init__(self, event_heap: EventHeapType | None = None, events_added: int = 0):
         if event_heap is None:
             event_heap = []
         self.event_heap = event_heap

--- a/syne_tune/backend/simulator_backend/events.py
+++ b/syne_tune/backend/simulator_backend/events.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Tuple, Optional, Dict, Any
+from typing import Any
 import heapq
 
 
@@ -51,10 +51,10 @@ class OnTrialResultEvent(Event):
 
     """
 
-    result: Dict[str, Any]
+    result: dict[str, Any]
 
 
-EventHeapType = List[Tuple[float, int, Event]]
+EventHeapType = list[tuple[float, int, Event]]
 
 
 class SimulatorState:
@@ -69,7 +69,7 @@ class SimulatorState:
     """
 
     def __init__(
-        self, event_heap: Optional[EventHeapType] = None, events_added: int = 0
+        self, event_heap: EventHeapType | None = None, events_added: int = 0
     ):
         if event_heap is None:
             event_heap = []
@@ -97,7 +97,7 @@ class SimulatorState:
         ]
         heapq.heapify(self.event_heap)
 
-    def next_until(self, time_until: float) -> Optional[Tuple[float, Event]]:
+    def next_until(self, time_until: float) -> tuple[float, Event] | None:
         """
         Returns (and pops) event on top of heap, if event time is <=
         ``time_until``. Otherwise, returns None.

--- a/syne_tune/backend/simulator_backend/simulator_backend.py
+++ b/syne_tune/backend/simulator_backend/simulator_backend.py
@@ -2,7 +2,6 @@ import logging
 import os
 from datetime import timedelta
 import copy
-from typing import Dict, List, Optional, Tuple
 from dataclasses import dataclass
 import subprocess
 
@@ -120,9 +119,9 @@ class SimulatorBackend(LocalBackend):
         self,
         entry_point: str,
         elapsed_time_attr: str,
-        simulator_config: Optional[SimulatorConfig] = None,
+        simulator_config: SimulatorConfig | None = None,
         tuner_sleep_time: float = TUNER_DEFAULT_SLEEP_TIME,
-        debug_resource_attr: Optional[str] = None,
+        debug_resource_attr: str | None = None,
     ):
         super().__init__(entry_point=entry_point, rotate_gpus=False)
         self.elapsed_time_attr = elapsed_time_attr
@@ -156,7 +155,7 @@ class SimulatorBackend(LocalBackend):
         logger.debug(msg)
 
     def start_trial(
-        self, config: Dict, checkpoint_trial_id: Optional[int] = None
+        self, config: dict, checkpoint_trial_id: int | None = None
     ) -> Trial:
         # Overwritten to record the correct ``creation_time``
         trial_id = self.new_trial_id()
@@ -198,7 +197,7 @@ class SimulatorBackend(LocalBackend):
             next_event = self._simulator_state.next_until(time_now)
 
     def _process_start_event(
-        self, trial_id: int, time_event: float, config: Optional[dict] = None
+        self, trial_id: int, time_event: float, config: dict | None = None
     ):
         self._debug_message("StartEvent", time=time_event, trial_id=trial_id)
         # Run training script and record results
@@ -314,7 +313,7 @@ class SimulatorBackend(LocalBackend):
         self._time_keeper.advance(self._time_keeper.real_time_since_last_recent_exit())
 
     def fetch_status_results(
-        self, trial_ids: List[int]
+        self, trial_ids: list[int]
     ) -> (TrialAndStatusInformation, TrialIdAndResultList):
         self._advance_by_outside_time()
         # Process all events in the past
@@ -370,7 +369,7 @@ class SimulatorBackend(LocalBackend):
         self._time_keeper.mark_exit()
         return trial_status_dict, results
 
-    def _schedule(self, trial_id: int, config: Dict):
+    def _schedule(self, trial_id: int, config: dict):
         """
         This is called by :meth:`start_trial` or :meth:`resume_trial`. We register a start
         event here. ``config`` can be ignored, it will be in
@@ -394,7 +393,7 @@ class SimulatorBackend(LocalBackend):
         logger.debug(f"Simulated time since start: {_time_start:.2f} secs")
         self._time_keeper.mark_exit()
 
-    def _all_trial_results(self, trial_ids: List[int]) -> List[TrialResult]:
+    def _all_trial_results(self, trial_ids: list[int]) -> list[TrialResult]:
         """
         Note: Since this is not used anymore in :meth:`fetch_results`, it can
         simply just return all registered trials which already have some
@@ -410,13 +409,13 @@ class SimulatorBackend(LocalBackend):
                 results.append(trial_result)
         return results
 
-    def _pause_trial(self, trial_id: int, result: Optional[dict]):
+    def _pause_trial(self, trial_id: int, result: dict | None):
         self._stop_or_pause_trial(trial_id, status=Status.paused)
 
     def _resume_trial(self, trial_id: int):
         pass
 
-    def _stop_trial(self, trial_id: int, result: Optional[dict]):
+    def _stop_trial(self, trial_id: int, result: dict | None):
         self._stop_or_pause_trial(trial_id, status=Status.stopped)
 
     def _stop_or_pause_trial(self, trial_id: int, status: str):
@@ -454,8 +453,8 @@ class SimulatorBackend(LocalBackend):
         self._time_keeper.mark_exit()
 
     def _run_job_and_collect_results(
-        self, trial_id: int, config: Optional[dict] = None
-    ) -> (str, List[dict]):
+        self, trial_id: int, config: dict | None = None
+    ) -> (str, list[dict]):
         """
         Runs training evaluation script for trial ``trial_id``, using the config
         ``trial(trial_id).config``. This is a blocking call, we wait for the
@@ -506,6 +505,6 @@ class SimulatorBackend(LocalBackend):
         results = all_results[num_already_before:]
         return status, results
 
-    def busy_trial_ids(self) -> List[Tuple[int, str]]:
+    def busy_trial_ids(self) -> list[tuple[int, str]]:
         self._process_events_until_now()
         return [(trial_id, Status.in_progress) for trial_id in self._busy_trial_ids]

--- a/syne_tune/backend/simulator_backend/simulator_callback.py
+++ b/syne_tune/backend/simulator_backend/simulator_callback.py
@@ -1,4 +1,3 @@
-from typing import Optional
 import logging
 
 from syne_tune.results_callback import StoreResultsCallback, ExtraResultsComposer
@@ -40,7 +39,7 @@ class SimulatorCallback(StoreResultsCallback):
         extra columns to the results dataframe
     """
 
-    def __init__(self, extra_results_composer: Optional[ExtraResultsComposer] = None):
+    def __init__(self, extra_results_composer: ExtraResultsComposer | None = None):
         # Note: ``results_update_interval`` is w.r.t. real time, not
         # simulated time. Storing results intermediately is not important for
         # the simulator backend, so the default is larger

--- a/syne_tune/backend/trial_backend.py
+++ b/syne_tune/backend/trial_backend.py
@@ -312,9 +312,7 @@ class TrialBackend:
                 self.delete_checkpoint(trial_id=trial_id)
                 self._cleanup_after_trial(trial_id)
 
-    def set_path(
-        self, results_root: str | None = None, tuner_name: str | None = None
-    ):
+    def set_path(self, results_root: str | None = None, tuner_name: str | None = None):
         """
         :param results_root: The local folder that should contain the results of
             the tuning experiment. Used by :class:`~syne_tune.Tuner` to indicate

--- a/syne_tune/backend/trial_backend.py
+++ b/syne_tune/backend/trial_backend.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Tuple, Optional, Any
+from typing import Any
 import logging
 
 from syne_tune.backend.trial_status import TrialResult, Trial, Status
@@ -11,10 +11,10 @@ from syne_tune.constants import ST_WORKER_TIMESTAMP
 logger = logging.getLogger(__name__)
 
 
-TrialAndStatusInformation = Dict[int, Tuple[Trial, str]]
+TrialAndStatusInformation = dict[int, tuple[Trial, str]]
 
 
-TrialIdAndResultList = List[Tuple[int, dict]]
+TrialIdAndResultList = list[tuple[int, dict]]
 
 
 BUSY_STATUS = {Status.in_progress, Status.stopping}
@@ -57,7 +57,7 @@ class TrialBackend:
         self._last_metric_seen_index = defaultdict(lambda: 0)
 
     def start_trial(
-        self, config: Dict[str, Any], checkpoint_trial_id: Optional[int] = None
+        self, config: dict[str, Any], checkpoint_trial_id: int | None = None
     ) -> TrialResult:
         """Start new trial with new trial ID
 
@@ -104,7 +104,7 @@ class TrialBackend:
         raise NotImplementedError
 
     def resume_trial(
-        self, trial_id: int, new_config: Optional[dict] = None
+        self, trial_id: int, new_config: dict | None = None
     ) -> TrialResult:
         """Resume paused trial
 
@@ -137,7 +137,7 @@ class TrialBackend:
         """
         raise NotImplementedError
 
-    def pause_trial(self, trial_id: int, result: Optional[dict] = None):
+    def pause_trial(self, trial_id: int, result: dict | None = None):
         """Pauses a running trial
 
         Checks that the operation is valid and calls backend internal
@@ -153,7 +153,7 @@ class TrialBackend:
         self._pause_trial(trial_id=trial_id, result=result)
         self._cleanup_after_trial(trial_id)
 
-    def _pause_trial(self, trial_id: int, result: Optional[dict]):
+    def _pause_trial(self, trial_id: int, result: dict | None):
         """Implements :meth:`pause_trial`.
 
         :param trial_id: ID of trial to pause
@@ -162,7 +162,7 @@ class TrialBackend:
         """
         raise NotImplementedError
 
-    def stop_trial(self, trial_id: int, result: Optional[dict] = None):
+    def stop_trial(self, trial_id: int, result: dict | None = None):
         """Stops (and terminates) a running trial
 
         Checks that the operation is valid and calls backend internal
@@ -191,7 +191,7 @@ class TrialBackend:
         """
         pass
 
-    def _stop_trial(self, trial_id: int, result: Optional[dict]):
+    def _stop_trial(self, trial_id: int, result: dict | None):
         """Backend specific operation that stops the trial.
 
         :param trial_id: ID of trial to stop
@@ -203,7 +203,7 @@ class TrialBackend:
     def new_trial_id(self) -> int:
         return len(self.trial_ids)
 
-    def _schedule(self, trial_id: int, config: Dict[str, Any]):
+    def _schedule(self, trial_id: int, config: dict[str, Any]):
         """Schedules job for trial evaluation.
 
         Called by :meth:`start_trial`, :meth:`resume_trial`.
@@ -213,7 +213,7 @@ class TrialBackend:
         """
         raise NotImplementedError
 
-    def _all_trial_results(self, trial_ids: List[int]) -> List[TrialResult]:
+    def _all_trial_results(self, trial_ids: list[int]) -> list[TrialResult]:
         """Returns results for selected trials
 
         :param trial_ids: IDs of trials for which results are to be queried
@@ -223,7 +223,7 @@ class TrialBackend:
         raise NotImplementedError
 
     def fetch_status_results(
-        self, trial_ids: List[int]
+        self, trial_ids: list[int]
     ) -> (TrialAndStatusInformation, TrialIdAndResultList):
         """
         :param trial_ids: Trials whose information should be fetched.
@@ -267,7 +267,7 @@ class TrialBackend:
         results = sorted(results, key=lambda result: result[1][ST_WORKER_TIMESTAMP])
         return trial_status_dict, results
 
-    def busy_trial_ids(self) -> List[Tuple[int, str]]:
+    def busy_trial_ids(self) -> list[tuple[int, str]]:
         """Returns list of ids for currently busy trials
 
         A trial is busy if its status is
@@ -281,7 +281,7 @@ class TrialBackend:
         """
         raise NotImplementedError
 
-    def stdout(self, trial_id: int) -> List[str]:
+    def stdout(self, trial_id: int) -> list[str]:
         """Fetch ``stdout`` log for trial
 
         :param trial_id: ID of trial
@@ -289,7 +289,7 @@ class TrialBackend:
         """
         raise NotImplementedError
 
-    def stderr(self, trial_id: int) -> List[str]:
+    def stderr(self, trial_id: int) -> list[str]:
         """Fetch ``stderr`` log for trial
 
         :param trial_id: ID of trial
@@ -313,7 +313,7 @@ class TrialBackend:
                 self._cleanup_after_trial(trial_id)
 
     def set_path(
-        self, results_root: Optional[str] = None, tuner_name: Optional[str] = None
+        self, results_root: str | None = None, tuner_name: str | None = None
     ):
         """
         :param results_root: The local folder that should contain the results of

--- a/syne_tune/backend/trial_status.py
+++ b/syne_tune/backend/trial_status.py
@@ -2,7 +2,6 @@
 import logging
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Dict, Optional, List
 
 try:
     from typing_extensions import Literal
@@ -26,7 +25,7 @@ class Status:
 @dataclass
 class Trial:
     trial_id: int
-    config: Dict[str, object]
+    config: dict[str, object]
     creation_time: datetime
 
     def add_results(self, metrics, status, training_end_time):
@@ -44,7 +43,7 @@ class Trial:
 class TrialResult(Trial):
     # Metrics recorded for each call of ``report``. Each metric is a dictionary from metric name to value (
     # could be numeric or string, the only constrain is that it must be compatible with json).
-    metrics: List[Dict[str, object]]
+    metrics: list[dict[str, object]]
     status: Literal[
         Status.completed,
         Status.in_progress,
@@ -53,7 +52,7 @@ class TrialResult(Trial):
         Status.stopping,
     ]
 
-    training_end_time: Optional[datetime] = None
+    training_end_time: datetime | None = None
 
     @property
     def seconds(self):

--- a/syne_tune/blackbox_repository/blackbox.py
+++ b/syne_tune/blackbox_repository/blackbox.py
@@ -1,11 +1,12 @@
 from numbers import Number
 
 import pandas as pd
-from typing import Optional, Callable, List, Tuple, Union, Dict, Any
+from typing import Any
+from collections.abc import Callable
 import numpy as np
 
 
-ObjectiveFunctionResult = Union[Dict[str, float], np.ndarray]
+ObjectiveFunctionResult = dict[str, float] | np.ndarray
 
 
 class Blackbox:
@@ -23,9 +24,9 @@ class Blackbox:
 
     def __init__(
         self,
-        configuration_space: Dict[str, Any],
-        fidelity_space: Optional[dict] = None,
-        objectives_names: Optional[List[str]] = None,
+        configuration_space: dict[str, Any],
+        fidelity_space: dict | None = None,
+        objectives_names: list[str] | None = None,
     ):
         self.configuration_space = configuration_space
         self.fidelity_space = fidelity_space
@@ -33,9 +34,9 @@ class Blackbox:
 
     def objective_function(
         self,
-        configuration: Dict[str, Any],
-        fidelity: Union[dict, Number] = None,
-        seed: Optional[int] = None,
+        configuration: dict[str, Any],
+        fidelity: dict | Number = None,
+        seed: int | None = None,
     ) -> ObjectiveFunctionResult:
         """Returns an evaluation of the blackbox.
 
@@ -81,9 +82,9 @@ class Blackbox:
 
     def _objective_function(
         self,
-        configuration: Dict[str, Any],
-        fidelity: Optional[dict] = None,
-        seed: Optional[int] = None,
+        configuration: dict[str, Any],
+        fidelity: dict | None = None,
+        seed: int | None = None,
     ) -> ObjectiveFunctionResult:
         """Override this method to provide your benchmark function.
 
@@ -118,7 +119,7 @@ class Blackbox:
 
     def hyperparameter_objectives_values(
         self, predict_curves: bool = False
-    ) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
         """
         If ``predict_curves`` is False, the shape of ``X`` is
         ``(num_evals * num_seeds * num_fidelities, num_hps + 1)``, the shape of ``y``
@@ -140,7 +141,7 @@ class Blackbox:
         pass
 
     @property
-    def fidelity_values(self) -> Optional[np.array]:
+    def fidelity_values(self) -> np.array | None:
         """
         :return: Fidelity values; or None if the blackbox has none
         """
@@ -157,7 +158,7 @@ class Blackbox:
 
     def configuration_space_with_max_resource_attr(
         self, max_resource_attr: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         It is best practice to have one attribute in the configuration space to
         represent the maximum fidelity value used for evaluation (e.g., the
@@ -179,10 +180,10 @@ class Blackbox:
 
 
 def from_function(
-    configuration_space: Dict[str, Any],
+    configuration_space: dict[str, Any],
     eval_fun: Callable,
-    fidelity_space: Optional[dict] = None,
-    objectives_names: Optional[List[str]] = None,
+    fidelity_space: dict | None = None,
+    objectives_names: list[str] | None = None,
 ) -> Blackbox:
     """
     Helper to create a blackbox from a function, useful for test or to wrap-up
@@ -206,9 +207,9 @@ def from_function(
 
         def objective_function(
             self,
-            configuration: Dict[str, Any],
-            fidelity: Optional[dict] = None,
-            seed: Optional[int] = None,
+            configuration: dict[str, Any],
+            fidelity: dict | None = None,
+            seed: int | None = None,
         ) -> ObjectiveFunctionResult:
             return eval_fun(configuration, fidelity, seed)
 

--- a/syne_tune/blackbox_repository/blackbox_offline.py
+++ b/syne_tune/blackbox_repository/blackbox_offline.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, List, Optional, Union, Any
+from typing import Any
 
 import pandas as pd
 
@@ -33,10 +33,10 @@ class BlackboxOffline(Blackbox):
     def __init__(
         self,
         df_evaluations: pd.DataFrame,
-        configuration_space: Dict[str, Any],
-        fidelity_space: Optional[dict] = None,
-        objectives_names: Optional[List[str]] = None,
-        seed_col: Optional[str] = None,
+        configuration_space: dict[str, Any],
+        fidelity_space: dict | None = None,
+        objectives_names: list[str] | None = None,
+        seed_col: str | None = None,
     ):
         if objectives_names is not None:
             for col in objectives_names:
@@ -85,9 +85,9 @@ class BlackboxOffline(Blackbox):
 
     def _objective_function(
         self,
-        configuration: Dict[str, Any],
-        fidelity: Optional[dict] = None,
-        seed: Optional[int] = None,
+        configuration: dict[str, Any],
+        fidelity: dict | None = None,
+        seed: int | None = None,
     ) -> ObjectiveFunctionResult:
         """
         Return the dictionary of objectives for a configuration/fidelity/seed.
@@ -133,7 +133,7 @@ class BlackboxOffline(Blackbox):
 
 
 def serialize(
-    bb_dict: Dict[str, BlackboxOffline], path: str, categorical_cols: List[str] = []
+    bb_dict: dict[str, BlackboxOffline], path: str, categorical_cols: list[str] = []
 ):
     """
     :param bb_dict:
@@ -186,7 +186,7 @@ def serialize(
     )
 
 
-def deserialize(path: str) -> Union[Dict[str, BlackboxOffline], BlackboxOffline]:
+def deserialize(path: str) -> dict[str, BlackboxOffline] | BlackboxOffline:
     """
     :param path: where to find blackbox serialized information (at least data.csv.zip and configspace.json)
     :param groupby_col: separate evaluations into a list of blackbox with different task if the column is provided

--- a/syne_tune/blackbox_repository/blackbox_surrogate.py
+++ b/syne_tune/blackbox_repository/blackbox_surrogate.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, List, Dict, Any
+from typing import Any
 import pandas as pd
 from sklearn.neighbors import KNeighborsRegressor
 from sklearn.pipeline import Pipeline, FeatureUnion, make_pipeline
@@ -104,16 +104,16 @@ class BlackboxSurrogate(Blackbox):
         self,
         X: pd.DataFrame,
         y: pd.DataFrame,
-        configuration_space: Dict[str, Any],
-        objectives_names: List[str],
-        fidelity_space: Optional[dict] = None,
-        fidelity_values: Optional[np.array] = None,
+        configuration_space: dict[str, Any],
+        objectives_names: list[str],
+        fidelity_space: dict | None = None,
+        fidelity_values: np.array | None = None,
         surrogate=None,
         predict_curves: bool = False,
         num_seeds: int = 1,
-        fit_differences: Optional[List[str]] = None,
-        max_fit_samples: Optional[int] = None,
-        name: Optional[str] = None,
+        fit_differences: list[str] | None = None,
+        max_fit_samples: int | None = None,
+        name: str | None = None,
     ):
         super(BlackboxSurrogate, self).__init__(
             configuration_space=configuration_space,
@@ -148,8 +148,8 @@ class BlackboxSurrogate(Blackbox):
         X: pd.DataFrame,
         y: pd.DataFrame,
         predict_curves: bool,
-        fidelity_values: Optional[np.ndarray],
-        num_seeds: Optional[int],
+        fidelity_values: np.ndarray | None,
+        num_seeds: int | None,
         num_objectives: int,
     ):
         assert X.ndim == 2 and y.ndim == 2
@@ -173,7 +173,7 @@ class BlackboxSurrogate(Blackbox):
             ), f"y.shape[1] = {y.shape[1]} != {num_objectives}"
 
     @property
-    def fidelity_values(self) -> Optional[np.array]:
+    def fidelity_values(self) -> np.array | None:
         return self._fidelity_values
 
     @property
@@ -352,9 +352,9 @@ class BlackboxSurrogate(Blackbox):
 
     def _objective_function(
         self,
-        configuration: Dict[str, Any],
-        fidelity: Optional[dict] = None,
-        seed: Optional[int] = None,
+        configuration: dict[str, Any],
+        fidelity: dict | None = None,
+        seed: int | None = None,
     ) -> ObjectiveFunctionResult:
         if seed is None:
             seed = np.random.randint(0, self.num_seeds)
@@ -419,17 +419,17 @@ class BlackboxSurrogate(Blackbox):
 
     def hyperparameter_objectives_values(
         self, predict_curves: bool = False
-    ) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
         raise NotImplementedError("This is a surrogate already!")
 
 
 def add_surrogate(
     blackbox: Blackbox,
     surrogate=None,
-    configuration_space: Optional[dict] = None,
-    predict_curves: Optional[bool] = None,
+    configuration_space: dict | None = None,
+    predict_curves: bool | None = None,
     separate_seeds: bool = False,
-    fit_differences: Optional[List[str]] = None,
+    fit_differences: list[str] | None = None,
 ):
     """
     Fits a blackbox surrogates that can be evaluated anywhere, which can be useful

--- a/syne_tune/blackbox_repository/blackbox_tabular.py
+++ b/syne_tune/blackbox_repository/blackbox_tabular.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Dict, Optional, Tuple, Union, Any
+from typing import Any
 import pandas as pd
 import numpy as np
 
@@ -38,11 +38,11 @@ class BlackboxTabular(Blackbox):
     def __init__(
         self,
         hyperparameters: pd.DataFrame,
-        configuration_space: Dict[str, Any],
-        fidelity_space: Dict[str, Any],
+        configuration_space: dict[str, Any],
+        fidelity_space: dict[str, Any],
         objectives_evaluations: np.array,
-        fidelity_values: Optional[np.array] = None,
-        objectives_names: Optional[List[str]] = None,
+        fidelity_values: np.array | None = None,
+        objectives_names: list[str] | None = None,
     ):
         super(BlackboxTabular, self).__init__(
             configuration_space=configuration_space,
@@ -104,9 +104,9 @@ class BlackboxTabular(Blackbox):
 
     def _objective_function(
         self,
-        configuration: Union[dict, int],
-        fidelity: Optional[dict] = None,
-        seed: Optional[int] = None,
+        configuration: dict | int,
+        fidelity: dict | None = None,
+        seed: int | None = None,
     ) -> ObjectiveFunctionResult:
         if seed is not None:
             assert 0 <= seed < self.num_seeds
@@ -143,7 +143,7 @@ class BlackboxTabular(Blackbox):
     def fidelity_values(self) -> np.array:
         return self._fidelity_values
 
-    def _impute_objectives_values(self) -> Tuple[pd.DataFrame, np.array]:
+    def _impute_objectives_values(self) -> tuple[pd.DataFrame, np.array]:
         """Replaces nan values in objectives with first previous non-nan value.
 
         Time objective should be cumulative, otherwise each step will consume additional time.
@@ -184,7 +184,7 @@ class BlackboxTabular(Blackbox):
     # to understand if this was not done
     def hyperparameter_objectives_values(
         self, predict_curves: bool = False
-    ) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
         """
         If ``predict_curves`` is False, the shape of ``X`` is
         ``(num_evals * num_seeds * num_fidelities, num_hps + 1)``, the shape of ``y``
@@ -241,7 +241,7 @@ class BlackboxTabular(Blackbox):
         return X, y
 
     def rename_objectives(
-        self, objective_name_mapping: Dict[str, str]
+        self, objective_name_mapping: dict[str, str]
     ) -> "BlackboxTabular":
         """
         :param objective_name_mapping: dictionary from old objective name to
@@ -269,7 +269,7 @@ class BlackboxTabular(Blackbox):
             objectives_names=list(objective_name_mapping.values()),
         )
 
-    def all_configurations(self) -> List[Dict[str, Any]]:
+    def all_configurations(self) -> list[dict[str, Any]]:
         """
         This method is useful in order to set ``restrict_configurations`` in
         :class:`~syne_tune.optimizer.schedulers.searchers.StochasticAndFilterDuplicatesSearcher`
@@ -304,7 +304,7 @@ class BlackboxTabular(Blackbox):
 
 
 def serialize(
-    bb_dict: Dict[str, BlackboxTabular], path: str, metadata: Optional[dict] = None
+    bb_dict: dict[str, BlackboxTabular], path: str, metadata: dict | None = None
 ):
     # check all blackboxes share the same search space and have evaluated the same hyperparameters
     # pick an arbitrary blackbox
@@ -360,7 +360,7 @@ def serialize(
     )
 
 
-def deserialize(path: str) -> Dict[str, BlackboxTabular]:
+def deserialize(path: str) -> dict[str, BlackboxTabular]:
     """
     Deserialize blackboxes contained in a path that were saved with :func:`serialize`
     above.

--- a/syne_tune/blackbox_repository/conversion_scripts/scripts/hpob_import.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/scripts/hpob_import.py
@@ -4,7 +4,6 @@ import json
 import pandas as pd
 import numpy as np
 from pathlib import Path
-from typing import Dict, Optional
 from syne_tune.blackbox_repository.blackbox_tabular import BlackboxTabular
 from syne_tune.blackbox_repository.conversion_scripts.scripts import metric_elapsed_time
 from syne_tune.blackbox_repository.conversion_scripts.utils import (
@@ -306,7 +305,7 @@ MAX_RESOURCE_LEVEL = 100
 # since the HPO-B dataset does not provide the same number of evaluations for each blackbox.
 # This is a constraint in the original serialize() function.
 def serialize(
-    bb_dict: Dict[str, BlackboxTabular], path: str, metadata: Optional[Dict] = None
+    bb_dict: dict[str, BlackboxTabular], path: str, metadata: dict | None = None
 ):
     # check all blackboxes share the objectives
     bb_first = next(iter(bb_dict.values()))
@@ -357,7 +356,7 @@ def serialize(
     )
 
 
-def deserialize(path: str) -> Dict[str, BlackboxTabular]:
+def deserialize(path: str) -> dict[str, BlackboxTabular]:
     """
     Deserialize blackboxes contained in a path that were saved with ``serialize`` above.
     TODO: the API is currently dissonant with ``serialize``, ``deserialize`` for BlackboxOffline as ``serialize`` is there a member.

--- a/syne_tune/blackbox_repository/conversion_scripts/scripts/pd1_import.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/scripts/pd1_import.py
@@ -3,7 +3,6 @@ import logging
 import os
 import tarfile
 from pathlib import Path
-from typing import Dict, Optional
 
 import numpy as np
 import pandas as pd
@@ -137,7 +136,7 @@ class PD1Recipe(BlackboxRecipe):
         else:
             logger.info(f"Skip downloading since {file_name} is available locally.")
 
-    def _convert_data(self) -> Dict[str, BlackboxTabular]:
+    def _convert_data(self) -> dict[str, BlackboxTabular]:
         with tarfile.open(repository_path / f"{BLACKBOX_NAME}.tar.gz") as f:
 
             def is_within_directory(directory, target):
@@ -210,7 +209,7 @@ class PD1Recipe(BlackboxRecipe):
                 bb_dict[task_name] = convert_task(task_data)
         return bb_dict
 
-    def _save_data(self, bb_dict: Dict[str, BlackboxTabular]) -> None:
+    def _save_data(self, bb_dict: dict[str, BlackboxTabular]) -> None:
         with catchtime("saving to disk"):
             serialize(
                 bb_dict=bb_dict,
@@ -229,7 +228,7 @@ class PD1Recipe(BlackboxRecipe):
 
 
 def serialize(
-    bb_dict: Dict[str, BlackboxTabular], path: str, metadata: Optional[Dict] = None
+    bb_dict: dict[str, BlackboxTabular], path: str, metadata: dict | None = None
 ):
     # check all blackboxes share the objectives
     bb_first = next(iter(bb_dict.values()))
@@ -280,7 +279,7 @@ def serialize(
     )
 
 
-def deserialize(path: str) -> Dict[str, BlackboxTabular]:
+def deserialize(path: str) -> dict[str, BlackboxTabular]:
     """
     Deserialize blackboxes contained in a path that were saved with ``serialize`` above.
     TODO: the API is currently dissonant with ``serialize``, ``deserialize`` for BlackboxOffline as ``serialize`` is there a member.

--- a/syne_tune/blackbox_repository/conversion_scripts/scripts/yahpo_import.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/scripts/yahpo_import.py
@@ -3,7 +3,7 @@ Wrap Surrogates from
 YAHPO Gym - An Efficient Multi-Objective Multi-Fidelity Benchmark for Hyperparameter Optimization
 Florian Pfisterer, Lennart Schneider, Julia Moosbauer, Martin Binder, Bernd Bischl
 """
-from typing import Optional, List, Dict, Any
+from typing import Any
 import logging
 import shutil
 
@@ -99,7 +99,7 @@ class BlackBoxYAHPO(Blackbox):
     def __init__(
         self,
         benchmark: BenchmarkSet,
-        fidelities: Optional[List[int]] = None,
+        fidelities: list[int] | None = None,
     ):
         self.benchmark = benchmark
         super(BlackBoxYAHPO, self).__init__(
@@ -163,7 +163,7 @@ class BlackBoxYAHPO(Blackbox):
             }
             self._shortened_keys = set(shortened_keys)
 
-    def _adjust_fidelity_space(self, fidelities: Optional[List[int]]):
+    def _adjust_fidelity_space(self, fidelities: list[int] | None):
         assert len(self.fidelity_space) == 1, "Only one fidelity is supported"
         self._fidelity_name, domain = next(iter(self.fidelity_space.items()))
         assert (
@@ -181,7 +181,7 @@ class BlackBoxYAHPO(Blackbox):
             self._fidelity_values = np.array(fidelities)
             self.fidelity_space[self._fidelity_name] = cs.ordinal(fidelities.copy())
 
-    def _map_configuration(self, config: Dict[str, Any]) -> Dict[str, Any]:
+    def _map_configuration(self, config: dict[str, Any]) -> dict[str, Any]:
         if self._is_nb301:
 
             def map_key(k: str) -> str:
@@ -195,8 +195,8 @@ class BlackBoxYAHPO(Blackbox):
             return config
 
     def _prepare_yahpo_configuration(
-        self, configuration: Dict[str, Any], fidelity: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, configuration: dict[str, Any], fidelity: dict[str, Any]
+    ) -> dict[str, Any]:
         """Some of the hyperparameters are only active for certain values of other
         hyperparameters. We filter out the inactive ones, and add the fidelity to the
         configuration in order to interface with YAHPO.
@@ -212,7 +212,7 @@ class BlackBoxYAHPO(Blackbox):
         )
         return {k: v for k, v in configuration.items() if k in active_hyperparameters}
 
-    def _parse_fidelity(self, fidelity: Dict[str, Any]) -> Dict[str, Any]:
+    def _parse_fidelity(self, fidelity: dict[str, Any]) -> dict[str, Any]:
         if self._is_iaml or self._is_rbv2:
             k = "trainsize"
             fidelity_value = fidelity.get(k)
@@ -227,10 +227,10 @@ class BlackBoxYAHPO(Blackbox):
 
     def _objective_function(
         self,
-        configuration: Dict[str, Any],
-        fidelity: Optional[dict] = None,
-        seed: Optional[int] = None,
-    ) -> Dict[str, Any]:
+        configuration: dict[str, Any],
+        fidelity: dict | None = None,
+        seed: int | None = None,
+    ) -> dict[str, Any]:
         configuration = self._map_configuration(configuration.copy())
 
         if fidelity is not None:
@@ -335,7 +335,7 @@ def cs_to_synetune(config_space):
 def instantiate_yahpo(
     scenario: str,
     check: bool = False,
-    fidelities: Optional[List[int]] = None,
+    fidelities: list[int] | None = None,
 ):
     """
     Instantiates a dict of ``BlackBoxYAHPO``, one entry for each instance.

--- a/syne_tune/blackbox_repository/conversion_scripts/utils.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/utils.py
@@ -1,6 +1,5 @@
 import os
 from pathlib import Path
-from typing import Optional
 
 repository_path = Path("~/.blackbox-repository/").expanduser()
 repo_id = "synetune/blackbox-repository"
@@ -25,7 +24,7 @@ def blackbox_local_path(name: str) -> Path:
     return Path(repository_path) / subdir / subname
 
 
-def upload_blackbox(name: str, custom_repo_id: Optional[str] = None):
+def upload_blackbox(name: str, custom_repo_id: str | None = None):
     """
     Uploads a blackbox locally present in repository_path to HuggingFace hub
     :param name: folder must be available in repository_path/name

--- a/syne_tune/blackbox_repository/repository.py
+++ b/syne_tune/blackbox_repository/repository.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List, Union, Dict, Optional
 
 from huggingface_hub import snapshot_download
 
@@ -29,7 +28,7 @@ from syne_tune.blackbox_repository.conversion_scripts.utils import (
 logger = logging.getLogger(__name__)
 
 
-def blackbox_list() -> List[str]:
+def blackbox_list() -> list[str]:
     """
     :return: list of blackboxes available
     """
@@ -38,12 +37,12 @@ def blackbox_list() -> List[str]:
 
 def load_blackbox(
     name: str,
-    custom_repo_id: Optional[str] = None,
-    yahpo_kwargs: Optional[dict] = None,
+    custom_repo_id: str | None = None,
+    yahpo_kwargs: dict | None = None,
     local_files_only: bool = False,
     force_download: bool = False,
     **snapshot_download_kwargs,
-) -> Union[Dict[str, Blackbox], Blackbox]:
+) -> dict[str, Blackbox] | Blackbox:
     """
     :param name: name of a blackbox present in the repository, see
         :func:`blackbox_list` to get list of available blackboxes. Syne Tune

--- a/syne_tune/blackbox_repository/serialize.py
+++ b/syne_tune/blackbox_repository/serialize.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Optional, Dict
 import json
 
 from syne_tune.config_space import (
@@ -10,7 +9,7 @@ from syne_tune.util import dump_json_with_numpy
 
 
 def serialize_configspace(
-    path: str, configuration_space: Dict, fidelity_space: Optional[Dict] = None
+    path: str, configuration_space: dict, fidelity_space: dict | None = None
 ):
     path = Path(path)
     dump_json_with_numpy(

--- a/syne_tune/blackbox_repository/simulated_tabular_backend.py
+++ b/syne_tune/blackbox_repository/simulated_tabular_backend.py
@@ -146,9 +146,7 @@ class _BlackboxSimulatorBackend(SimulatorBackend):
         return status, results
 
 
-def make_surrogate(
-    surrogate: str | None = None, surrogate_kwargs: dict | None = None
-):
+def make_surrogate(surrogate: str | None = None, surrogate_kwargs: dict | None = None):
     """Creates surrogate model (scikit-learn estimater)
 
     :param surrogate: A model that is fitted to predict objectives given any

--- a/syne_tune/blackbox_repository/simulated_tabular_backend.py
+++ b/syne_tune/blackbox_repository/simulated_tabular_backend.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import List, Optional, Dict, Any
+from typing import Any
 
 import numpy as np
 
@@ -29,8 +29,8 @@ class _BlackboxSimulatorBackend(SimulatorBackend):
     def __init__(
         self,
         elapsed_time_attr: str,
-        max_resource_attr: Optional[str] = None,
-        seed: Optional[int] = None,
+        max_resource_attr: str | None = None,
+        seed: int | None = None,
         support_checkpointing: bool = True,
         **simulatorbackend_kwargs,
     ):
@@ -54,7 +54,7 @@ class _BlackboxSimulatorBackend(SimulatorBackend):
     def resource_attr(self):
         return self.blackbox.fidelity_name()
 
-    def _pause_trial(self, trial_id: int, result: Optional[dict]):
+    def _pause_trial(self, trial_id: int, result: dict | None):
         """
         From ``result``, we obtain the resource level at which the trial is
         paused by the scheduler. This is required in order to properly
@@ -66,11 +66,11 @@ class _BlackboxSimulatorBackend(SimulatorBackend):
             resource = int(result[resource_attr])
             self._resource_paused_for_trial[trial_id] = resource
 
-    def _filter_config(self, config: Dict[str, Any]) -> Dict[str, Any]:
+    def _filter_config(self, config: dict[str, Any]) -> dict[str, Any]:
         config_space = self.blackbox.configuration_space
         return {k: v for k, v in config.items() if k in config_space}
 
-    def config_objectives(self, config: Dict[str, Any], seed: int) -> List[dict]:
+    def config_objectives(self, config: dict[str, Any], seed: int) -> list[dict]:
         mattr = self._max_resource_attr
         if mattr is not None and mattr in config:
             max_resource = int(config[mattr])
@@ -89,8 +89,8 @@ class _BlackboxSimulatorBackend(SimulatorBackend):
         )
 
     def _run_job_and_collect_results(
-        self, trial_id: int, config: Optional[dict] = None
-    ) -> (str, List[dict]):
+        self, trial_id: int, config: dict | None = None
+    ) -> (str, list[dict]):
         assert (
             trial_id in self._trial_dict
         ), f"Trial with trial_id = {trial_id} not registered with backend"
@@ -147,7 +147,7 @@ class _BlackboxSimulatorBackend(SimulatorBackend):
 
 
 def make_surrogate(
-    surrogate: Optional[str] = None, surrogate_kwargs: Optional[dict] = None
+    surrogate: str | None = None, surrogate_kwargs: dict | None = None
 ):
     """Creates surrogate model (scikit-learn estimater)
 
@@ -275,14 +275,14 @@ class BlackboxRepositoryBackend(_BlackboxSimulatorBackend):
         self,
         blackbox_name: str,
         elapsed_time_attr: str,
-        max_resource_attr: Optional[str] = None,
-        seed: Optional[int] = None,
+        max_resource_attr: str | None = None,
+        seed: int | None = None,
         support_checkpointing: bool = True,
-        dataset: Optional[str] = None,
-        surrogate: Optional[str] = None,
-        surrogate_kwargs: Optional[dict] = None,
-        add_surrogate_kwargs: Optional[dict] = None,
-        config_space_surrogate: Optional[dict] = None,
+        dataset: str | None = None,
+        surrogate: str | None = None,
+        surrogate_kwargs: dict | None = None,
+        add_surrogate_kwargs: dict | None = None,
+        config_space_surrogate: dict | None = None,
         **simulatorbackend_kwargs,
     ):
         assert (
@@ -402,8 +402,8 @@ class UserBlackboxBackend(_BlackboxSimulatorBackend):
         self,
         blackbox: Blackbox,
         elapsed_time_attr: str,
-        max_resource_attr: Optional[str] = None,
-        seed: Optional[int] = None,
+        max_resource_attr: str | None = None,
+        seed: int | None = None,
         support_checkpointing: bool = True,
         **simulatorbackend_kwargs,
     ):

--- a/syne_tune/blackbox_repository/utils.py
+++ b/syne_tune/blackbox_repository/utils.py
@@ -1,15 +1,15 @@
-from typing import List, Optional, Tuple, Dict, Any
+from typing import Any
 
 from syne_tune.blackbox_repository.blackbox import Blackbox
 
 
 def metrics_for_configuration(
     blackbox: Blackbox,
-    config: Dict[str, Any],
+    config: dict[str, Any],
     resource_attr: str,
-    fidelity_range: Optional[Tuple[float, float]] = None,
-    seed: Optional[int] = None,
-) -> List[dict]:
+    fidelity_range: tuple[float, float] | None = None,
+    seed: int | None = None,
+) -> list[dict]:
     """
     Returns all results for configuration ``config`` at fidelities in range
     ``fidelity_range``.

--- a/syne_tune/callbacks/tensorboard_callback.py
+++ b/syne_tune/callbacks/tensorboard_callback.py
@@ -1,7 +1,7 @@
 import numbers
 import os
 from time import perf_counter
-from typing import Optional, List, Dict, Any
+from typing import Any
 import logging
 
 from syne_tune.backend.trial_status import Trial
@@ -29,9 +29,9 @@ class TensorboardCallback(TunerCallback):
 
     def __init__(
         self,
-        ignore_metrics: Optional[List[str]] = None,
-        target_metric: Optional[str] = None,
-        mode: Optional[str] = None,
+        ignore_metrics: list[str] | None = None,
+        target_metric: str | None = None,
+        mode: str | None = None,
         log_hyperparameters: bool = True,
     ):
         if mode is None:
@@ -57,7 +57,7 @@ class TensorboardCallback(TunerCallback):
         self.output_path = None
         self.log_hyperparameters = log_hyperparameters
 
-    def _set_time_fields(self, result: Dict[str, Any]):
+    def _set_time_fields(self, result: dict[str, Any]):
         """
         Note that we only add wallclock time to the result if this has not
         already been done (by the backend)
@@ -66,7 +66,7 @@ class TensorboardCallback(TunerCallback):
             result[ST_TUNER_TIME] = perf_counter() - self.start_time_stamp
 
     def on_trial_result(
-        self, trial: Trial, status: str, result: Dict[str, Any], decision: str
+        self, trial: Trial, status: str, result: dict[str, Any], decision: str
     ):
         self._set_time_fields(result)
         walltime = result[ST_TUNER_TIME]

--- a/syne_tune/config_space.py
+++ b/syne_tune/config_space.py
@@ -64,7 +64,7 @@ class Domain:
 
     def sample(
         self,
-        spec: list[dict] | dict | None= None,
+        spec: list[dict] | dict | None = None,
         size: int = 1,
         random_state: np.random.RandomState | None = None,
     ) -> Any | list[Any]:

--- a/syne_tune/config_space.py
+++ b/syne_tune/config_space.py
@@ -5,7 +5,8 @@ import logging
 from copy import copy
 from math import isclose
 import sys
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any
+from collections.abc import Sequence
 import argparse
 
 import numpy as np
@@ -63,10 +64,10 @@ class Domain:
 
     def sample(
         self,
-        spec: Optional[Union[List[dict], dict]] = None,
+        spec: list[dict] | dict | None= None,
         size: int = 1,
-        random_state: Optional[np.random.RandomState] = None,
-    ) -> Union[Any, List[Any]]:
+        random_state: np.random.RandomState | None = None,
+    ) -> Any | list[Any]:
         """
         :param spec: Passed to sampler
         :param size: Number of values to sample, defaults to 1
@@ -123,9 +124,9 @@ class Sampler:
     def sample(
         self,
         domain: Domain,
-        spec: Optional[Union[List[dict], dict]] = None,
+        spec: list[dict] | dict | None = None,
         size: int = 1,
-        random_state: Optional[np.random.RandomState] = None,
+        random_state: np.random.RandomState | None = None,
     ):
         raise NotImplementedError
 
@@ -191,9 +192,9 @@ class Grid(Sampler):
     def sample(
         self,
         domain: Domain,
-        spec: Optional[Union[List[dict], dict]] = None,
+        spec: list[dict] | dict | None = None,
         size: int = 1,
-        random_state: Optional[np.random.RandomState] = None,
+        random_state: np.random.RandomState | None = None,
     ):
         return RuntimeError("Do not call ``sample()`` on grid.")
 
@@ -220,9 +221,9 @@ class Float(Domain):
         def sample(
             self,
             domain: "Float",
-            spec: Optional[Union[List[dict], dict]] = None,
+            spec: list[dict] | dict | None = None,
             size: int = 1,
-            random_state: Optional[np.random.RandomState] = None,
+            random_state: np.random.RandomState | None = None,
         ):
             assert domain.lower > float("-inf"), "Uniform needs a lower bound"
             assert domain.upper < float("inf"), "Uniform needs a upper bound"
@@ -235,9 +236,9 @@ class Float(Domain):
         def sample(
             self,
             domain: "Float",
-            spec: Optional[Union[List[dict], dict]] = None,
+            spec: list[dict] | dict | None = None,
             size: int = 1,
-            random_state: Optional[np.random.RandomState] = None,
+            random_state: np.random.RandomState | None = None,
         ):
             assert domain.lower > 0, "LogUniform needs a lower bound greater than 0"
             assert (
@@ -258,9 +259,9 @@ class Float(Domain):
         def sample(
             self,
             domain: "Float",
-            spec: Optional[Union[List[dict], dict]] = None,
+            spec: list[dict] | dict | None = None,
             size: int = 1,
-            random_state: Optional[np.random.RandomState] = None,
+            random_state: np.random.RandomState | None = None,
         ):
             assert 0 <= domain.lower <= domain.upper < 1
             logmin = -np.log1p(-domain.lower)
@@ -275,9 +276,9 @@ class Float(Domain):
         def sample(
             self,
             domain: "Float",
-            spec: Optional[Union[List[dict], dict]] = None,
+            spec: list[dict] | dict | None = None,
             size: int = 1,
-            random_state: Optional[np.random.RandomState] = None,
+            random_state: np.random.RandomState | None = None,
         ):
             assert not domain.lower or domain.lower == float(
                 "-inf"
@@ -397,9 +398,9 @@ class Integer(Domain):
         def sample(
             self,
             domain: "Integer",
-            spec: Optional[Union[List[dict], dict]] = None,
+            spec: list[dict] | dict | None = None,
             size: int = 1,
-            random_state: Optional[np.random.RandomState] = None,
+            random_state: np.random.RandomState | None = None,
         ):
             if random_state is None:
                 random_state = np.random
@@ -412,9 +413,9 @@ class Integer(Domain):
         def sample(
             self,
             domain: "Integer",
-            spec: Optional[Union[List[dict], dict]] = None,
+            spec: list[dict] | dict | None = None,
             size: int = 1,
-            random_state: Optional[np.random.RandomState] = None,
+            random_state: np.random.RandomState | None = None,
         ):
             assert domain.lower > 0, "LogUniform needs a lower bound greater than 0"
             assert (
@@ -505,9 +506,9 @@ class Categorical(Domain):
         def sample(
             self,
             domain: "Categorical",
-            spec: Optional[Union[List[dict], dict]] = None,
+            spec: list[dict] | dict | None = None,
             size: int = 1,
-            random_state: Optional[np.random.RandomState] = None,
+            random_state: np.random.RandomState | None = None,
         ):
             if random_state is None:
                 random_state = np.random
@@ -678,15 +679,15 @@ class OrdinalNearestNeighbor(Ordinal):
             self._upper_int = self._categories_int[-1] + avg_dist
 
     @property
-    def lower_int(self) -> Optional[float]:
+    def lower_int(self) -> float | None:
         return self._lower_int
 
     @property
-    def upper_int(self) -> Optional[float]:
+    def upper_int(self) -> float | None:
         return self._upper_int
 
     @property
-    def categories_int(self) -> Optional[np.ndarray]:
+    def categories_int(self) -> np.ndarray | None:
         return self._categories_int
 
     def cast_int(self, value_int: float):
@@ -708,10 +709,10 @@ class OrdinalNearestNeighbor(Ordinal):
 
     def sample(
         self,
-        spec: Optional[Union[List[dict], dict]] = None,
+        spec: Optional[Union[list[dict], dict]] = None,
         size: int = 1,
         random_state: Optional[np.random.RandomState] = None,
-    ) -> Union[Any, List[Any]]:
+    ) -> Union[Any, list[Any]]:
         if random_state is None:
             random_state = np.random
         items = random_state.uniform(self._lower_int, self._upper_int, size=size)
@@ -812,10 +813,10 @@ class FiniteRange(Domain):
 
     def sample(
         self,
-        spec: Optional[Union[List[dict], dict]] = None,
+        spec: Optional[Union[list[dict], dict]] = None,
         size: int = 1,
         random_state: Optional[np.random.RandomState] = None,
-    ) -> Union[Any, List[Any]]:
+    ) -> Union[Any, list[Any]]:
         int_sample = self._uniform_int.sample(spec, size, random_state)
         if size > 1:
             return [self._values[x] for x in int_sample]
@@ -902,7 +903,7 @@ def choice(categories: list):
     return Categorical(categories).uniform()
 
 
-def ordinal(categories: list, kind: Optional[str] = None):
+def ordinal(categories: list, kind: str | None = None):
     """
     Ordinal value from list ``categories``. Different variants are selected by
     ``kind``.
@@ -1022,7 +1023,7 @@ def is_uniform_space(domain: Domain) -> bool:
         )
 
 
-def add_to_argparse(parser: argparse.ArgumentParser, config_space: Dict[str, Any]):
+def add_to_argparse(parser: argparse.ArgumentParser, config_space: dict[str, Any]):
     """
     Use this to prepare argument parser in endpoint script, for the
     non-fixed parameters in ``config_space``.
@@ -1036,8 +1037,8 @@ def add_to_argparse(parser: argparse.ArgumentParser, config_space: Dict[str, Any
 
 
 def cast_config_values(
-    config: Dict[str, Any], config_space: Dict[str, Any]
-) -> Dict[str, Any]:
+    config: dict[str, Any], config_space: dict[str, Any]
+) -> dict[str, Any]:
     """
     Returns config with keys, values of ``config``, but values are cast to
     their specific types.
@@ -1054,8 +1055,8 @@ def cast_config_values(
 
 
 def postprocess_config(
-    config: Dict[str, Any], config_space: Dict[str, Any]
-) -> Dict[str, Any]:
+    config: dict[str, Any], config_space: dict[str, Any]
+) -> dict[str, Any]:
     """Post-processes a config as returned by a searcher
 
     * Adding parameters which are constant, therefore do not feature
@@ -1073,8 +1074,8 @@ def postprocess_config(
 
 
 def remove_constant_and_cast(
-    config: Dict[str, Any], config_space: Dict[str, Any]
-) -> Dict[str, Any]:
+    config: dict[str, Any], config_space: dict[str, Any]
+) -> dict[str, Any]:
     """Pre-processes a config before passing it to a searcher
 
     * Removing parameters which are constant in ``config_space`` (these do
@@ -1093,7 +1094,7 @@ def remove_constant_and_cast(
     )
 
 
-def non_constant_hyperparameter_keys(config_space: Dict[str, Any]) -> List[str]:
+def non_constant_hyperparameter_keys(config_space: dict[str, Any]) -> list[str]:
     """
     :param config_space: Configuration space
     :return: Keys corresponding to (non-fixed) hyperparameters
@@ -1102,8 +1103,8 @@ def non_constant_hyperparameter_keys(config_space: Dict[str, Any]) -> List[str]:
 
 
 def config_space_size(
-    config_space: Dict[str, Any], upper_limit: int = 2**20
-) -> Optional[int]:
+    config_space: dict[str, Any], upper_limit: int = 2**20
+) -> int | None:
     """
     Counts the number of distinct configurations in the configuration space
     ``config_space``. If this is infinite (due to real-valued parameters) or
@@ -1128,7 +1129,7 @@ def config_space_size(
 
 
 def config_to_match_string(
-    config: Dict[str, Any], config_space: Dict[str, Any], keys: List[str]
+    config: dict[str, Any], config_space: dict[str, Any], keys: list[str]
 ) -> str:
     """
     Maps configuration to a match string, which can be used to compare configs
@@ -1147,7 +1148,7 @@ def config_to_match_string(
     return ",".join(parts)
 
 
-def to_dict(x: Domain) -> Dict[str, Any]:
+def to_dict(x: Domain) -> dict[str, Any]:
     """
     We assume that for each :class:`Domain` subclass, the :meth:`__init__`
     kwargs are also members, and all other members start with ``_``.
@@ -1168,7 +1169,7 @@ def to_dict(x: Domain) -> Dict[str, Any]:
     return result
 
 
-def from_dict(d: Dict[str, Any]) -> Domain:
+def from_dict(d: dict[str, Any]) -> Domain:
     """
     :param d: Representation of :class:`Domain` object as ``dict``
     :return: Decoded :class:`Domain` object
@@ -1185,8 +1186,8 @@ def from_dict(d: Dict[str, Any]) -> Domain:
 
 
 def config_space_to_json_dict(
-    config_space: Dict[str, Union[Domain, int, float, str]]
-) -> Dict[str, Union[int, float, str]]:
+    config_space: dict[str, Union[Domain, int, float, str]]
+) -> dict[str, Union[int, float, str]]:
     """Converts ``config_space`` into a dictionary that can be saved as a json file.
 
     :param config_space: Configuration space
@@ -1198,8 +1199,8 @@ def config_space_to_json_dict(
 
 
 def config_space_from_json_dict(
-    config_space_dict: Dict[str, Union[int, float, str]]
-) -> Dict[str, Union[Domain, int, float, str]]:
+    config_space_dict: dict[str, Union[int, float, str]]
+) -> dict[str, Union[Domain, int, float, str]]:
     """Converts the given dictionary into a Syne Tune search space.
 
     Reverse of :func:`config_space_to_json_dict`.
@@ -1267,9 +1268,9 @@ class Quantized(Sampler):
     def sample(
         self,
         domain: Domain,
-        spec: Optional[Union[List[dict], dict]] = None,
+        spec: list[dict] | dict | None = None,
         size: int = 1,
-        random_state: Optional[np.random.RandomState] = None,
+        random_state: np.random.RandomState | None = None,
     ):
         values = self.sampler.sample(domain, spec, size, random_state)
         quantized = np.round(np.divide(values, self.q)) * self.q

--- a/syne_tune/experiments/experiment_result.py
+++ b/syne_tune/experiments/experiment_result.py
@@ -4,7 +4,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from json.decoder import JSONDecodeError
 from pathlib import Path
-from typing import List, Dict, Callable, Optional, Union, Any, Tuple
+from typing import Any
+from collections.abc import Callable
 
 import numpy as np
 import pandas as pd
@@ -35,7 +36,7 @@ class ExperimentResult:
 
     name: str
     results: pd.DataFrame
-    metadata: Dict[str, Any]
+    metadata: dict[str, Any]
     tuner: Tuner
     path: Path
 
@@ -53,7 +54,7 @@ class ExperimentResult:
 
     def plot_hypervolume(
         self,
-        metrics_to_plot: Union[List[int], List[str]] = None,
+        metrics_to_plot: list[int] | list[str] = None,
         reference_point: np.ndarray = None,
         figure_path: str = None,
         **plt_kwargs,
@@ -104,7 +105,7 @@ class ExperimentResult:
                 fig.show()
 
     def plot(
-        self, metric_to_plot: Union[str, int] = 0, figure_path: str = None, **plt_kwargs
+        self, metric_to_plot: str | int = 0, figure_path: str = None, **plt_kwargs
     ):
         """Plot best metric value as function of wallclock time
 
@@ -138,7 +139,7 @@ class ExperimentResult:
                 fig.show()
 
     def plot_trials_over_time(
-        self, metric_to_plot: Union[str, int] = 0, figure_path: str = None, figsize=None
+        self, metric_to_plot: str | int = 0, figure_path: str = None, figsize=None
     ):
         """Plot trials results over as function of wallclock time
 
@@ -176,16 +177,16 @@ class ExperimentResult:
         else:
             fig.show()
 
-    def metric_mode(self) -> Union[str, List[str]]:
+    def metric_mode(self) -> str | list[str]:
         return self.metadata["metric_mode"]
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return self.metadata["metric_names"]
 
     def entrypoint_name(self) -> str:
         return self.metadata["entrypoint"]
 
-    def best_config(self, metric: Union[str, int] = 0) -> Dict[str, Any]:
+    def best_config(self, metric: str | int = 0) -> dict[str, Any]:
         """
         Return the best config found for the specified metric
         :param metric: Indicates which metric to use, can be the index or a name of the metric.
@@ -204,7 +205,7 @@ class ExperimentResult:
         # Don't include internal fields
         return {k: v for k, v in res.items() if not k.startswith("st_")}
 
-    def _metric_name_mode(self, metric: Union[str, int]) -> Tuple[str, str]:
+    def _metric_name_mode(self, metric: str | int) -> tuple[str, str]:
         """
         Determine the name and its mode given ambiguous input.
         :param metric: Index or name of the selected metric
@@ -219,8 +220,8 @@ class ExperimentResult:
 def load_experiment(
     tuner_name: str,
     load_tuner: bool = False,
-    local_path: Optional[str] = None,
-    experiment_name: Optional[str] = None,
+    local_path: str | None = None,
+    experiment_name: str | None = None,
 ) -> ExperimentResult:
     """Load results from an experiment
 
@@ -270,10 +271,10 @@ PathFilter = Callable[[str], bool]
 ExperimentFilter = Callable[[ExperimentResult], bool]
 
 
-PathOrExperimentFilter = Union[PathFilter, ExperimentFilter]
+PathOrExperimentFilter = PathFilter | ExperimentFilter
 
 
-def _impute_filter(filt: Optional[PathOrExperimentFilter]) -> PathOrExperimentFilter:
+def _impute_filter(filt: PathOrExperimentFilter | None) -> PathOrExperimentFilter:
     if filt is None:
 
         def filt(path) -> bool:
@@ -283,8 +284,8 @@ def _impute_filter(filt: Optional[PathOrExperimentFilter]) -> PathOrExperimentFi
 
 
 def get_metadata(
-    path_filter: Optional[PathFilter] = None, root: Path = experiment_path()
-) -> Dict[str, dict]:
+    path_filter: PathFilter  | None = None, root: Path = experiment_path()
+) -> dict[str, dict]:
     """Load meta-data for a number of experiments
 
     :param path_filter: If passed then only experiments whose path matching
@@ -317,11 +318,11 @@ def get_metadata(
 
 
 def list_experiments(
-    path_filter: Optional[PathFilter] = None,
-    experiment_filter: Optional[ExperimentFilter] = None,
+    path_filter: PathFilter  | None = None,
+    experiment_filter: ExperimentFilter | None = None,
     root: Path = experiment_path(),
     load_tuner: bool = False,
-) -> List[ExperimentResult]:
+) -> list[ExperimentResult]:
     """List experiments for which results are found
 
     :param path_filter: If passed then only experiments whose path matching
@@ -357,8 +358,8 @@ def list_experiments(
 
 
 def load_experiments_df(
-    path_filter: Optional[PathFilter] = None,
-    experiment_filter: Optional[ExperimentFilter] = None,
+    path_filter: PathFilter | None = None,
+    experiment_filter: ExperimentFilter  | None = None,
     root: Path = experiment_path(),
     load_tuner: bool = False,
 ) -> pd.DataFrame:
@@ -398,7 +399,7 @@ def load_experiments_df(
         df = experiment.results
         df["tuner_name"] = experiment.name
         for k, v in experiment.metadata.items():
-            if isinstance(v, List):
+            if isinstance(v, list):
                 if len(v) > 1:
                     for i, x in enumerate(v):
                         df[f"{k}-{i}"] = x

--- a/syne_tune/experiments/experiment_result.py
+++ b/syne_tune/experiments/experiment_result.py
@@ -284,7 +284,7 @@ def _impute_filter(filt: PathOrExperimentFilter | None) -> PathOrExperimentFilte
 
 
 def get_metadata(
-    path_filter: PathFilter  | None = None, root: Path = experiment_path()
+    path_filter: PathFilter | None = None, root: Path = experiment_path()
 ) -> dict[str, dict]:
     """Load meta-data for a number of experiments
 
@@ -318,7 +318,7 @@ def get_metadata(
 
 
 def list_experiments(
-    path_filter: PathFilter  | None = None,
+    path_filter: PathFilter | None = None,
     experiment_filter: ExperimentFilter | None = None,
     root: Path = experiment_path(),
     load_tuner: bool = False,
@@ -359,7 +359,7 @@ def list_experiments(
 
 def load_experiments_df(
     path_filter: PathFilter | None = None,
-    experiment_filter: ExperimentFilter  | None = None,
+    experiment_filter: ExperimentFilter | None = None,
     root: Path = experiment_path(),
     load_tuner: bool = False,
 ) -> pd.DataFrame:

--- a/syne_tune/experiments/multiobjective.py
+++ b/syne_tune/experiments/multiobjective.py
@@ -1,5 +1,3 @@
-from typing import List, Tuple, Optional
-
 import pandas as pd
 import numpy as np
 
@@ -7,8 +5,8 @@ from syne_tune.optimizer.schedulers.multiobjective.utils import hypervolume_cumu
 
 
 def hypervolume_indicator_column_generator(
-    metrics_and_modes: List[Tuple[str, str]],
-    reference_point: Optional[np.ndarray] = None,
+    metrics_and_modes: list[tuple[str, str]],
+    reference_point: np.ndarray | None = None,
     increment: int = 1,
 ):
     """

--- a/syne_tune/experiments/util.py
+++ b/syne_tune/experiments/util.py
@@ -1,11 +1,10 @@
 import logging
-from typing import Dict, Tuple, List
 
 import pandas as pd
 
 from syne_tune.constants import ST_TUNER_TIME
 
-DataFrameGroups = Dict[Tuple[int, str], List[Tuple[str, pd.DataFrame]]]
+DataFrameGroups = dict[tuple[int, str], list[tuple[str, pd.DataFrame]]]
 
 logger = logging.getLogger(__name__)
 

--- a/syne_tune/optimizer/baselines.py
+++ b/syne_tune/optimizer/baselines.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Any, List
+from typing import Any
 import logging
 
 from syne_tune.optimizer.schedulers.asha import AsynchronousSuccessiveHalving
@@ -40,11 +40,11 @@ class RandomSearch(SingleFidelityScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        metrics: List[str],
-        do_minimize: Optional[bool] = True,
-        random_seed: Optional[int] = None,
-        points_to_evaluate: Optional[List[dict]] = None,
+        config_space: dict[str, Any],
+        metrics: list[str],
+        do_minimize: bool | None = True,
+        random_seed: int | None = None,
+        points_to_evaluate: list[dict] | None = None,
     ):
         super(RandomSearch, self).__init__(
             config_space=config_space,
@@ -77,11 +77,11 @@ class BORE(SingleObjectiveScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        do_minimize: Optional[bool] = True,
-        random_seed: Optional[int] = None,
-        points_to_evaluate: Optional[List[dict]] = None,
+        do_minimize: bool | None = True,
+        random_seed: int | None = None,
+        points_to_evaluate: list[dict] | None = None,
     ):
         super(BORE, self).__init__(
             config_space=config_space,
@@ -134,12 +134,12 @@ class TPE(SingleObjectiveScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        do_minimize: Optional[bool] = True,
-        random_seed: Optional[int] = None,
-        points_to_evaluate: Optional[List[dict]] = None,
-        num_min_data_points: Optional[int] = None,
+        do_minimize: bool | None = True,
+        random_seed: int | None = None,
+        points_to_evaluate: list[dict] | None = None,
+        num_min_data_points: int | None = None,
         top_n_percent: int = 15,
         min_bandwidth: float = 1e-3,
         num_candidates: int = 64,
@@ -185,13 +185,13 @@ class REA(SingleObjectiveScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        do_minimize: Optional[bool] = True,
-        random_seed: Optional[int] = None,
+        do_minimize: bool | None = True,
+        random_seed: int | None = None,
         population_size: int = 100,
         sample_size: int = 10,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: list[dict] | None = None,
     ):
         super(REA, self).__init__(
             config_space=config_space,
@@ -221,11 +221,11 @@ class BOTorch(SingleObjectiveScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        do_minimize: Optional[bool] = True,
-        random_seed: Optional[int] = None,
-        points_to_evaluate: Optional[List[dict]] = None,
+        do_minimize: bool | None = True,
+        random_seed: int | None = None,
+        points_to_evaluate: list[dict] | None = None,
     ):
         super(BOTorch, self).__init__(
             config_space=config_space,
@@ -266,13 +266,13 @@ class ASHA(AsynchronousSuccessiveHalving):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         time_attr: str,
         max_t: int,
-        do_minimize: Optional[bool] = True,
-        random_seed: Optional[int] = None,
-        points_to_evaluate: Optional[List[dict]] = None,
+        do_minimize: bool | None = True,
+        random_seed: int | None = None,
+        points_to_evaluate: list[dict] | None = None,
     ):
         super(ASHA, self).__init__(
             config_space=config_space,
@@ -307,13 +307,13 @@ class ASHABORE(AsynchronousSuccessiveHalving):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         time_attr: str,
         max_t: int,
-        do_minimize: Optional[bool] = True,
-        random_seed: Optional[int] = None,
-        points_to_evaluate: Optional[List[dict]] = None,
+        do_minimize: bool | None = True,
+        random_seed: int | None = None,
+        points_to_evaluate: list[dict] | None = None,
     ):
         super(ASHABORE, self).__init__(
             config_space=config_space,
@@ -348,13 +348,13 @@ class ASHACQR(AsynchronousSuccessiveHalving):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         time_attr: str,
         max_t: int,
-        do_minimize: Optional[bool] = True,
-        random_seed: Optional[int] = None,
-        points_to_evaluate: Optional[List[dict]] = None,
+        do_minimize: bool | None = True,
+        random_seed: int | None = None,
+        points_to_evaluate: list[dict] | None = None,
     ):
         super(ASHACQR, self).__init__(
             config_space=config_space,
@@ -389,19 +389,19 @@ class BOHB(AsynchronousSuccessiveHalving):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         time_attr: str,
         max_t: int,
-        do_minimize: Optional[bool] = True,
-        random_seed: Optional[int] = None,
-        num_min_data_points: Optional[int] = None,
+        do_minimize: bool | None = True,
+        random_seed: int | None = None,
+        num_min_data_points: int | None = None,
         top_n_percent: int = 15,
         min_bandwidth: float = 1e-3,
         num_candidates: int = 64,
         bandwidth_factor: int = 3,
         random_fraction: float = 0.33,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: list[dict] | None = None,
     ):
         super(BOHB, self).__init__(
             config_space=config_space,
@@ -443,11 +443,11 @@ class CQR(SingleObjectiveScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        do_minimize: Optional[bool] = True,
-        random_seed: Optional[int] = None,
-        points_to_evaluate: Optional[List[dict]] = None,
+        do_minimize: bool | None = True,
+        random_seed: int | None = None,
+        points_to_evaluate: list[dict] | None = None,
     ):
         super(CQR, self).__init__(
             config_space=config_space,

--- a/syne_tune/optimizer/scheduler.py
+++ b/syne_tune/optimizer/scheduler.py
@@ -2,7 +2,7 @@ import numpy as np
 import logging
 
 from dataclasses import dataclass
-from typing import Optional, Dict, Any
+from typing import Any
 
 from syne_tune.backend.trial_status import Trial
 
@@ -37,8 +37,8 @@ class TrialSuggestion:
     """
 
     spawn_new_trial_id: bool = True
-    checkpoint_trial_id: Optional[int] = None
-    config: Optional[dict] = None
+    checkpoint_trial_id: int | None = None
+    config: dict | None = None
 
     def __post_init__(self):
         if self.spawn_new_trial_id:
@@ -52,7 +52,7 @@ class TrialSuggestion:
 
     @staticmethod
     def start_suggestion(
-        config: Dict[str, Any], checkpoint_trial_id: Optional[int] = None
+        config: dict[str, Any], checkpoint_trial_id: int | None = None
     ) -> "TrialSuggestion":
         """Suggestion to start new trial
 
@@ -71,7 +71,7 @@ class TrialSuggestion:
 
     @staticmethod
     def resume_suggestion(
-        trial_id: int, config: Optional[dict] = None
+        trial_id: int, config: dict | None = None
     ) -> "TrialSuggestion":
         """Suggestion to resume a paused trial
 
@@ -117,7 +117,7 @@ class TrialScheduler:
         else:
             self.random_seed = random_seed
 
-    def suggest(self) -> Optional[TrialSuggestion]:
+    def suggest(self) -> TrialSuggestion | None:
         """Returns a suggestion for a new trial, or one to be resumed
 
         This method returns ``suggestion`` of type :class:`TrialSuggestion` (unless
@@ -158,7 +158,7 @@ class TrialScheduler:
     def on_trial_error(self, trial: Trial):
         pass
 
-    def on_trial_result(self, trial: Trial, result: Dict[str, Any]) -> str:
+    def on_trial_result(self, trial: Trial, result: dict[str, Any]) -> str:
         """Called on each intermediate result reported by a trial.
 
         At this point, the trial scheduler can make a decision by returning
@@ -172,7 +172,7 @@ class TrialScheduler:
         """
         return SchedulerDecision.CONTINUE
 
-    def on_trial_complete(self, trial: Trial, result: Dict[str, Any]):
+    def on_trial_complete(self, trial: Trial, result: dict[str, Any]):
         """Notification for the completion of trial.
 
         Note that :meth:`on_trial_result` is called with the same result before.
@@ -194,7 +194,7 @@ class TrialScheduler:
         """
         pass
 
-    def metadata(self) -> Dict[str, Any]:
+    def metadata(self) -> dict[str, Any]:
         """
         :return: Metadata for the scheduler
         """

--- a/syne_tune/optimizer/schedulers/asha.py
+++ b/syne_tune/optimizer/schedulers/asha.py
@@ -68,10 +68,10 @@ class AsynchronousSuccessiveHalving(TrialScheduler):
         config_space: dict[str, Any],
         metric: str,
         do_minimize: bool | None = True,
-        searcher:
-            str | IndependentMultiFidelitySearcher | LastValueMultiFidelitySearcher
-            | None
-        = "random_search",
+        searcher: str
+        | IndependentMultiFidelitySearcher
+        | LastValueMultiFidelitySearcher
+        | None = "random_search",
         time_attr: str = "training_iteration",
         max_t: int = 100,
         grace_period: int = 1,

--- a/syne_tune/optimizer/schedulers/ask_tell_scheduler.py
+++ b/syne_tune/optimizer/schedulers/ask_tell_scheduler.py
@@ -1,4 +1,3 @@
-from typing import Dict
 import datetime
 
 from syne_tune.backend.trial_status import Trial, Status, TrialResult
@@ -8,7 +7,7 @@ from syne_tune.optimizer.scheduler import TrialScheduler
 class AskTellScheduler:
     base_scheduler: TrialScheduler
     trial_counter: int
-    completed_experiments: Dict[int, TrialResult]
+    completed_experiments: dict[int, TrialResult]
 
     def __init__(self, base_scheduler: TrialScheduler):
         """
@@ -42,7 +41,7 @@ class AskTellScheduler:
         self.trial_counter += 1
         return trial
 
-    def tell(self, trial: Trial, experiment_result: Dict[str, float]):
+    def tell(self, trial: Trial, experiment_result: dict[str, float]):
         """
         Feed experiment results back to the Scheduler
 

--- a/syne_tune/optimizer/schedulers/median_stopping_rule.py
+++ b/syne_tune/optimizer/schedulers/median_stopping_rule.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-from typing import Optional, Dict, Any, List
+from typing import Any
 
 import numpy as np
 
@@ -56,12 +56,12 @@ class MedianStoppingRule(TrialScheduler):
         scheduler: TrialScheduler,
         resource_attr: str,
         running_average: bool = True,
-        metric: Optional[str] = None,
-        grace_time: Optional[int] = 1,
+        metric: str | None = None,
+        grace_time: int | None = 1,
         grace_population: int = 5,
         rank_cutoff: float = 0.5,
         random_seed: int = None,
-        do_minimize: Optional[bool] = True,
+        do_minimize: bool | None = True,
     ):
         super(MedianStoppingRule, self).__init__(random_seed=random_seed)
         if metric is None and hasattr(scheduler, "metric"):
@@ -80,10 +80,10 @@ class MedianStoppingRule(TrialScheduler):
         if running_average:
             self.trial_to_results = defaultdict(list)
 
-    def suggest(self) -> Optional[TrialSuggestion]:
+    def suggest(self) -> TrialSuggestion | None:
         return self.scheduler.suggest()
 
-    def on_trial_result(self, trial: Trial, result: Dict) -> str:
+    def on_trial_result(self, trial: Trial, result: dict) -> str:
         new_metric = result[self.metric] * self.metric_multiplier
 
         time_step = result[self.resource_attr]
@@ -127,7 +127,7 @@ class MedianStoppingRule(TrialScheduler):
             return True
         return False
 
-    def metadata(self) -> Dict[str, Any]:
+    def metadata(self) -> dict[str, Any]:
         """
         :return: Metadata for the scheduler
         """
@@ -136,7 +136,7 @@ class MedianStoppingRule(TrialScheduler):
 
         return metadata_scheduler | metadata
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return self.metric
 
     def metric_mode(self) -> str:

--- a/syne_tune/optimizer/schedulers/multi_fidelity.py
+++ b/syne_tune/optimizer/schedulers/multi_fidelity.py
@@ -1,5 +1,3 @@
-
-
 class MultiFidelitySchedulerMixin:
     """
     Declares properties which are required for multi-fidelity schedulers.

--- a/syne_tune/optimizer/schedulers/multi_fidelity.py
+++ b/syne_tune/optimizer/schedulers/multi_fidelity.py
@@ -1,4 +1,3 @@
-from typing import List
 
 
 class MultiFidelitySchedulerMixin:
@@ -21,7 +20,7 @@ class MultiFidelitySchedulerMixin:
         raise NotImplementedError
 
     @property
-    def rung_levels(self) -> List[int]:
+    def rung_levels(self) -> list[int]:
         """
         :return: Rung levels (positive int; increasing), may or may not
             include ``max_resource_level``

--- a/syne_tune/optimizer/schedulers/multiobjective/expected_hyper_volume_improvement.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/expected_hyper_volume_improvement.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any
+from typing import Any
 import logging
 
 import numpy as np
@@ -68,11 +68,11 @@ class ExpectedHyperVolumeImprovement(BaseSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        points_to_evaluate: Optional[List[dict]] = None,
+        config_space: dict[str, Any],
+        points_to_evaluate: list[dict] | None = None,
         num_init_random: int = 3,
         no_fantasizing: bool = False,
-        max_num_observations: Optional[int] = 200,
+        max_num_observations: int | None = 200,
         input_warping: bool = True,
         random_seed: int = None,
     ):
@@ -97,7 +97,7 @@ class ExpectedHyperVolumeImprovement(BaseSearcher):
         self.random_state = np.random.RandomState(self.random_seed)
 
     def on_trial_complete(
-        self, trial_id: int, config: Dict[str, Any], metrics: List[float]
+        self, trial_id: int, config: dict[str, Any], metrics: list[float]
     ):
 
         self.trial_observations[trial_id] = metrics
@@ -108,7 +108,7 @@ class ExpectedHyperVolumeImprovement(BaseSearcher):
     def num_suggestions(self):
         return len(self.trial_configs)
 
-    def suggest(self) -> Optional[dict]:
+    def suggest(self) -> dict | None:
         config_suggested = self._next_points_to_evaluate()
 
         if config_suggested is None:
@@ -127,8 +127,8 @@ class ExpectedHyperVolumeImprovement(BaseSearcher):
     def register_pending(
         self,
         trial_id: str,
-        config: Optional[dict] = None,
-        milestone: Optional[int] = None,
+        config: dict | None = None,
+        milestone: int | None = None,
     ):
         self.pending_trials.add(int(trial_id))
 
@@ -155,7 +155,7 @@ class ExpectedHyperVolumeImprovement(BaseSearcher):
             for k, v in self.config_space.items()
         }
 
-    def _sample_next_candidate(self) -> Optional[dict]:
+    def _sample_next_candidate(self) -> dict | None:
         """
         :return: A next candidate to evaluate, if possible it is obtained by
             fitting a GP on past data and maximizing EI. If this fails because
@@ -240,7 +240,7 @@ class ExpectedHyperVolumeImprovement(BaseSearcher):
             warp_tf = None
         return SingleTaskGP(X_tensor, Y_tensor, input_transform=warp_tf)
 
-    def _config_to_feature_matrix(self, configs: List[dict]):
+    def _config_to_feature_matrix(self, configs: list[dict]):
         bounds = Tensor(self._hp_ranges.get_ndarray_bounds()).T
         X = Tensor(self._hp_ranges.to_ndarray_matrix(configs))
         return normalize(X, bounds)
@@ -248,14 +248,14 @@ class ExpectedHyperVolumeImprovement(BaseSearcher):
     def objectives(self):
         return np.array(list(self.trial_observations.values()))
 
-    def _configs_with_results(self) -> List[dict]:
+    def _configs_with_results(self) -> list[dict]:
         return [
             config
             for trial, config in self.trial_configs.items()
             if not trial in self.pending_trials
         ]
 
-    def _configs_pending(self) -> List[dict]:
+    def _configs_pending(self) -> list[dict]:
         return [
             config
             for trial, config in self.trial_configs.items()

--- a/syne_tune/optimizer/schedulers/multiobjective/multi_objective_regularized_evolution.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/multi_objective_regularized_evolution.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from typing import Optional, List, Dict, Any
+from typing import Any
 from collections import deque
 
 from syne_tune.optimizer.schedulers.searchers.regularized_evolution import (
@@ -33,10 +33,10 @@ class MultiObjectiveRegularizedEvolution(BaseSearcher):
     def __init__(
         self,
         config_space,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: list[dict] | None = None,
         population_size: int = 100,
         sample_size: int = 10,
-        multiobjective_priority: Optional[MOPriority] = None,
+        multiobjective_priority: MOPriority | None = None,
         random_seed: int = None,
     ):
 
@@ -59,7 +59,7 @@ class MultiObjectiveRegularizedEvolution(BaseSearcher):
         else:
             self._multiobjective_priority = multiobjective_priority
 
-    def suggest(self, **kwargs) -> Optional[dict]:
+    def suggest(self, **kwargs) -> dict | None:
         initial_config = self._next_points_to_evaluate()
         if initial_config is not None:
             return initial_config
@@ -83,8 +83,8 @@ class MultiObjectiveRegularizedEvolution(BaseSearcher):
     def on_trial_complete(
         self,
         trial_id: int,
-        config: Dict[str, Any],
-        metrics: List[float],
+        config: dict[str, Any],
+        metrics: list[float],
     ):
 
         # Add element to the population

--- a/syne_tune/optimizer/schedulers/multiobjective/multi_surrogate_multi_objective_searcher.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/multi_surrogate_multi_objective_searcher.py
@@ -1,6 +1,6 @@
 import logging
 from functools import partial
-from typing import Optional, List, Dict, Any, Union
+from typing import Any
 
 from syne_tune.optimizer.schedulers.multiobjective.random_scalarization import (
     MultiObjectiveLCBRandomLinearScalarization,
@@ -58,16 +58,16 @@ class MultiObjectiveMultiSurrogateSearcher(BayesianOptimizationSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        metric: List[str],
-        estimators: Dict[str, Estimator],
-        mode: Union[List[str], str] = "min",
-        points_to_evaluate: Optional[List[Dict[str, Any]]] = None,
-        scoring_class: Optional[ScoringFunctionConstructor] = None,
+        config_space: dict[str, Any],
+        metric: list[str],
+        estimators: dict[str, Estimator],
+        mode: list[str] | str = "min",
+        points_to_evaluate: list[dict[str, Any]] | None = None,
+        scoring_class: ScoringFunctionConstructor | None = None,
         num_initial_candidates: int = DEFAULT_NUM_INITIAL_CANDIDATES,
         num_initial_random_choices: int = DEFAULT_NUM_INITIAL_RANDOM_EVALUATIONS,
         allow_duplicates: bool = False,
-        restrict_configurations: Optional[List[Dict[str, Any]]] = None,
+        restrict_configurations: list[dict[str, Any]] | None = None,
         clone_from_state: bool = False,
         **kwargs,
     ):
@@ -119,7 +119,7 @@ class MultiObjectiveMultiSurrogateSearcher(BayesianOptimizationSearcher):
             mode = self._mode
         self._metric_to_internal_signs = [-1 if m == "max" else 1 for m in mode]
 
-    def _update(self, trial_id: str, config: Dict[str, Any], result: Dict[str, Any]):
+    def _update(self, trial_id: str, config: dict[str, Any], result: dict[str, Any]):
         # Gather metrics
         metrics = {
             name: result[name] * self._metric_to_internal_signs[pos]

--- a/syne_tune/optimizer/schedulers/multiobjective/multiobjective_priority.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/multiobjective_priority.py
@@ -1,5 +1,3 @@
-from typing import Optional, List
-
 import numpy as np
 from syne_tune.optimizer.schedulers.multiobjective.non_dominated_priority import (
     nondominated_sort,
@@ -7,7 +5,7 @@ from syne_tune.optimizer.schedulers.multiobjective.non_dominated_priority import
 
 
 class MOPriority:
-    def __init__(self, metrics: Optional[List[str]] = None):
+    def __init__(self, metrics: list[str] | None = None):
         """
         :param metrics: name of the objectives, optional if not passed anonymous names are created when seeing the
         first objectives to rank.
@@ -33,7 +31,7 @@ class MOPriority:
 
 class LinearScalarizationPriority(MOPriority):
     def __init__(
-        self, metrics: Optional[List[str]] = None, weights: Optional[np.array] = None
+        self, metrics: list[str] | None = None, weights: np.array | None = None
     ):
         """
         A simple multiobjective scalarization strategy that do a weighed sum to assign a priority to the objectives.
@@ -58,7 +56,7 @@ class LinearScalarizationPriority(MOPriority):
 
 
 class FixedObjectivePriority(MOPriority):
-    def __init__(self, metrics: Optional[List[str]] = None, dim: Optional[int] = None):
+    def __init__(self, metrics: list[str] | None = None, dim: int | None = None):
         """
         Optimizes a fixed objective, the first one by default.
         :param metrics:
@@ -74,9 +72,9 @@ class FixedObjectivePriority(MOPriority):
 class NonDominatedPriority(MOPriority):
     def __init__(
         self,
-        metrics: Optional[List[str]] = None,
-        dim: Optional[int] = 0,
-        max_num_samples: Optional[int] = None,
+        metrics: list[str] | None = None,
+        dim: int | None = 0,
+        max_num_samples: int | None = None,
     ):
         """
         A non-dominated sort strategy that uses an epsilon-net strategy instead of crowding distance proposed in:

--- a/syne_tune/optimizer/schedulers/multiobjective/non_dominated_priority.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/non_dominated_priority.py
@@ -1,5 +1,3 @@
-from typing import Optional, List, Union
-
 import numpy as np
 
 
@@ -36,7 +34,7 @@ def pareto_efficient(X: np.ndarray) -> np.ndarray:
     return mask
 
 
-def compute_epsilon_net(X: np.ndarray, dim: Optional[int] = None) -> np.ndarray:
+def compute_epsilon_net(X: np.ndarray, dim: int | None = None) -> np.ndarray:
     """
     Outputs an order of the items in the provided array such that the items are spaced well. This
     means that after choosing a seed item, the next item is chosen to be the farthest from the seed
@@ -92,10 +90,10 @@ def compute_epsilon_net(X: np.ndarray, dim: Optional[int] = None) -> np.ndarray:
 
 def nondominated_sort(
     X: np.ndarray,
-    dim: Optional[int] = None,
-    max_items: Optional[int] = None,
+    dim: int | None = None,
+    max_items: int | None = None,
     flatten: bool = True,
-) -> Union[List[int], List[List[int]]]:
+) -> list[int] | list[list[int]]:
     """
     Performs a multi-objective sort by iteratively computing the Pareto front and sparsifying the
     items within the Pareto front. This is a non-dominated sort leveraging an epsilon-net.

--- a/syne_tune/optimizer/schedulers/multiobjective/utils.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/utils.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 import numpy as np
 
 try:
@@ -35,7 +34,7 @@ def hypervolume(
     return indicator_fn(results_array)
 
 
-def linear_interpolate(hv_indicator: np.ndarray, indices: List[int]):
+def linear_interpolate(hv_indicator: np.ndarray, indices: list[int]):
     for first, last in zip(indices[:-1], indices[1:]):
         num = last - first + 1
         v_first = hv_indicator[first]

--- a/syne_tune/optimizer/schedulers/pbt.py
+++ b/syne_tune/optimizer/schedulers/pbt.py
@@ -5,7 +5,8 @@ import numpy as np
 
 from dataclasses import dataclass
 from collections import deque
-from typing import Callable, List, Optional, Tuple, Dict, Any
+from typing import Any
+from collections.abc import Callable
 
 from syne_tune.config_space import (
     Domain,
@@ -98,12 +99,12 @@ class PopulationBasedTraining(TrialScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         resource_attr: str,
         max_t: int = 100,
-        custom_explore_fn: Optional[Callable[[dict], dict]] = None,
-        do_minimize: Optional[bool] = True,
+        custom_explore_fn: Callable[[dict], dict] | None = None,
+        do_minimize: bool | None = True,
         random_seed: int = None,
         population_size: int = 4,
         perturbation_interval: int = 60,
@@ -169,7 +170,7 @@ class PopulationBasedTraining(TrialScheduler):
         else:
             return trial_id
 
-    def on_trial_result(self, trial: Trial, result: Dict[str, Any]) -> str:
+    def on_trial_result(self, trial: Trial, result: dict[str, Any]) -> str:
         for name, value in [
             ("resource_attr", self.resource_attr),
             ("metric", self.metric),
@@ -218,7 +219,7 @@ class PopulationBasedTraining(TrialScheduler):
             return SchedulerDecision.STOP
 
     def _save_trial_state(
-        self, state: PBTTrialState, time: int, result: Dict[str, Any]
+        self, state: PBTTrialState, time: int, result: dict[str, Any]
     ) -> float:
         """Saves necessary trial information when result is received.
 
@@ -236,7 +237,7 @@ class PopulationBasedTraining(TrialScheduler):
         state.last_result = result
         return score
 
-    def _quantiles(self) -> Tuple[List[Trial], List[Trial]]:
+    def _quantiles(self) -> tuple[list[Trial], list[Trial]]:
         """Returns trials in the lower and upper ``quantile`` of the population.
 
         If there is not enough data to compute this, returns empty lists.
@@ -260,7 +261,7 @@ class PopulationBasedTraining(TrialScheduler):
                 num_trials_in_quantile = int(math.floor(len(trials) / 2))
             return trials[:num_trials_in_quantile], trials[-num_trials_in_quantile:]
 
-    def suggest(self) -> Optional[TrialSuggestion]:
+    def suggest(self) -> TrialSuggestion | None:
         if len(self.trial_decisions_stack) == 0:
             # If our stack is empty, we simply start a new random configuration.
             config = self.searcher.suggest()
@@ -275,7 +276,7 @@ class PopulationBasedTraining(TrialScheduler):
                 config=config, checkpoint_trial_id=trial_id_to_continue
             )
 
-    def _explore(self, config: Dict[str, Any]) -> Dict[str, Any]:
+    def _explore(self, config: dict[str, Any]) -> dict[str, Any]:
         """Return a config perturbed as specified.
 
         :param config: Original hyperparameter configuration from the cloned trial
@@ -323,7 +324,7 @@ class PopulationBasedTraining(TrialScheduler):
 
         return new_config
 
-    def metadata(self) -> Dict[str, Any]:
+    def metadata(self) -> dict[str, Any]:
         """
         :return: Metadata for the scheduler
         """
@@ -336,7 +337,7 @@ class PopulationBasedTraining(TrialScheduler):
         metadata["metric_mode"] = self.metric_mode()
         return metadata
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return [self.metric]
 
     def metric_mode(self) -> str:

--- a/syne_tune/optimizer/schedulers/remove_checkpoints.py
+++ b/syne_tune/optimizer/schedulers/remove_checkpoints.py
@@ -1,4 +1,4 @@
-from typing import Optional, Callable
+from collections.abc import Callable
 
 from syne_tune.tuner_callback import TunerCallback
 from syne_tune.tuning_status import TuningStatus
@@ -20,7 +20,7 @@ class RemoveCheckpointsSchedulerMixin:
 
     def callback_for_checkpoint_removal(
         self, stop_criterion: Callable[[TuningStatus], bool]
-    ) -> Optional[TunerCallback]:
+    ) -> TunerCallback | None:
         """
         :param stop_criterion: Stopping criterion, as passed to
             :class:`~syne_tune.Tuner`

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/common.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/common.py
@@ -1,4 +1,3 @@
-from typing import Union, Dict, Optional, List
 from dataclasses import dataclass
 import numpy as np
 
@@ -14,7 +13,7 @@ def dictionarize_objective(x):
     return {INTERNAL_METRIC_NAME: x}
 
 
-MetricValues = Union[float, Dict[str, float]]
+MetricValues = float | dict[str, float]
 
 
 @dataclass
@@ -26,10 +25,10 @@ class TrialEvaluations:
     """
 
     trial_id: str
-    metrics: Dict[str, MetricValues]
+    metrics: dict[str, MetricValues]
 
     def num_cases(
-        self, metric_name: str = INTERNAL_METRIC_NAME, resource: Optional[int] = None
+        self, metric_name: str = INTERNAL_METRIC_NAME, resource: int | None = None
     ) -> int:
         """
         Counts the number of observations for metric ``metric_name``.
@@ -52,7 +51,7 @@ class TrialEvaluations:
 
     def _map_value_for_matching(
         self, value: MetricValues
-    ) -> (Optional[List[str]], np.ndarray):
+    ) -> (list[str] | None, np.ndarray):
         if isinstance(value, dict):
             keys = list(sorted(value.keys()))
             vals = np.array(value[k] for k in keys)
@@ -84,7 +83,7 @@ class PendingEvaluation:
     The minimum information is the candidate which has been queried.
     """
 
-    def __init__(self, trial_id: str, resource: Optional[int] = None):
+    def __init__(self, trial_id: str, resource: int | None = None):
         self._trial_id = trial_id
         self._resource = resource
 
@@ -93,7 +92,7 @@ class PendingEvaluation:
         return self._trial_id
 
     @property
-    def resource(self) -> Optional[int]:
+    def resource(self) -> int | None:
         return self._resource
 
 
@@ -106,8 +105,8 @@ class FantasizedPendingEvaluation(PendingEvaluation):
     def __init__(
         self,
         trial_id: str,
-        fantasies: Dict[str, np.ndarray],
-        resource: Optional[int] = None,
+        fantasies: dict[str, np.ndarray],
+        resource: int | None = None,
     ):
         super().__init__(trial_id, resource)
         fantasy_sizes = [fantasy_values.size for fantasy_values in fantasies.values()]

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/config_ext.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/config_ext.py
@@ -1,4 +1,3 @@
-from typing import Tuple
 import copy
 
 from syne_tune.config_space import randint
@@ -29,7 +28,7 @@ class ExtendedConfiguration:
         self,
         hp_ranges: HyperparameterRanges,
         resource_attr_key: str,
-        resource_attr_range: Tuple[int, int],
+        resource_attr_range: tuple[int, int],
     ):
         assert resource_attr_range[0] >= 1
         assert resource_attr_range[1] >= resource_attr_range[0]

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/tuning_job_state.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/tuning_job_state.py
@@ -1,5 +1,3 @@
-from typing import List, Dict, Optional
-
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common import (
     TrialEvaluations,
     PendingEvaluation,
@@ -35,10 +33,10 @@ class TuningJobState:
     def __init__(
         self,
         hp_ranges: HyperparameterRanges,
-        config_for_trial: Dict[str, Configuration],
-        trials_evaluations: List[TrialEvaluations],
-        failed_trials: List[str] = None,
-        pending_evaluations: List[PendingEvaluation] = None,
+        config_for_trial: dict[str, Configuration],
+        trials_evaluations: list[TrialEvaluations],
+        failed_trials: list[str] = None,
+        pending_evaluations: list[PendingEvaluation] = None,
     ):
         if failed_trials is None:
             failed_trials = []
@@ -54,7 +52,7 @@ class TuningJobState:
         self.pending_evaluations = pending_evaluations
 
     @staticmethod
-    def _check_all_string(trial_ids: List[str], name: str):
+    def _check_all_string(trial_ids: list[str], name: str):
         assert all(
             isinstance(x, str) for x in trial_ids
         ), f"trial_ids in {name} contain non-string values:\n{trial_ids}"
@@ -94,7 +92,7 @@ class TuningJobState:
         except StopIteration:
             return -1
 
-    def _find_pending(self, trial_id: str, resource: Optional[int] = None) -> int:
+    def _find_pending(self, trial_id: str, resource: int | None = None) -> int:
         try:
             return next(
                 i
@@ -105,7 +103,7 @@ class TuningJobState:
             return -1
 
     def _register_config_for_trial(
-        self, trial_id: str, config: Optional[Configuration] = None
+        self, trial_id: str, config: Configuration | None = None
     ):
         if config is None:
             assert trial_id in self.config_for_trial, (
@@ -116,7 +114,7 @@ class TuningJobState:
             self.config_for_trial[trial_id] = config.copy()
 
     def metrics_for_trial(
-        self, trial_id: str, config: Optional[Configuration] = None
+        self, trial_id: str, config: Configuration | None = None
     ) -> MetricValues:
         """
         Helper for inserting new entry into ``trials_evaluations``. If ``trial_id``
@@ -142,7 +140,7 @@ class TuningJobState:
         return metrics
 
     def num_observed_cases(
-        self, metric_name: str = INTERNAL_METRIC_NAME, resource: Optional[int] = None
+        self, metric_name: str = INTERNAL_METRIC_NAME, resource: int | None = None
     ) -> int:
         """
         Counts the number of observations for metric ``metric_name``.
@@ -158,7 +156,7 @@ class TuningJobState:
 
     def observed_data_for_metric(
         self, metric_name: str = INTERNAL_METRIC_NAME, resource_attr_name: str = None
-    ) -> (List[Configuration], List[float]):
+    ) -> (list[Configuration], list[float]):
         """
         Extracts datapoints from ``trials_evaluations`` for particular
         metric ``metric_name``, in the form of a list of configs and a list of
@@ -198,14 +196,14 @@ class TuningJobState:
                     metric_values.append(metric_entry)
         return configs, metric_values
 
-    def is_pending(self, trial_id: str, resource: Optional[int] = None) -> bool:
+    def is_pending(self, trial_id: str, resource: int | None = None) -> bool:
         return self._find_pending(trial_id, resource) != -1
 
     def is_labeled(
         self,
         trial_id: str,
         metric_name: str = INTERNAL_METRIC_NAME,
-        resource: Optional[int] = None,
+        resource: int | None = None,
     ) -> bool:
         """
         Checks whether ``trial_id`` has observed data under ``metric_name``. If
@@ -226,8 +224,8 @@ class TuningJobState:
     def append_pending(
         self,
         trial_id: str,
-        config: Optional[Configuration] = None,
-        resource: Optional[int] = None,
+        config: Configuration | None = None,
+        resource: int | None = None,
     ):
         """
         Appends new pending evaluation. If the trial has not been registered
@@ -240,7 +238,7 @@ class TuningJobState:
             PendingEvaluation(trial_id=trial_id, resource=resource)
         )
 
-    def remove_pending(self, trial_id: str, resource: Optional[int] = None) -> bool:
+    def remove_pending(self, trial_id: str, resource: int | None = None) -> bool:
         pos = self._find_pending(trial_id, resource)
         if pos != -1:
             self.pending_evaluations.pop(pos)
@@ -250,7 +248,7 @@ class TuningJobState:
 
     def pending_configurations(
         self, resource_attr_name: str = None
-    ) -> List[Configuration]:
+    ) -> list[Configuration]:
         """
         Returns list of configurations corresponding to pending evaluations.
         If the latter have resource values, the configs are extended.
@@ -271,8 +269,8 @@ class TuningJobState:
         return configs
 
     def _map_configs_for_matching(
-        self, config_for_trial: Dict[str, Configuration]
-    ) -> Dict[str, str]:
+        self, config_for_trial: dict[str, Configuration]
+    ) -> dict[str, str]:
         return {
             trial_id: self.hp_ranges.config_to_match_string(config)
             for trial_id, config in config_for_trial.items()
@@ -295,8 +293,8 @@ class TuningJobState:
         ) == self._map_configs_for_matching(other.config_for_trial)
 
     def all_configurations(
-        self, filter_observed_data: Optional[ConfigurationFilter] = None
-    ) -> List[Configuration]:
+        self, filter_observed_data: ConfigurationFilter | None = None
+    ) -> list[Configuration]:
         """
         Returns list of configurations for all trials represented here, whether
         observed, pending, or failed. If ``filter_observed_data`` is given, the

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/gluon.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/gluon.py
@@ -511,7 +511,7 @@ class ParameterDict:
         name : str
             Name of the desired Parameter. It will be prepended with this dictionary's
             prefix.
-        **kwargs : Dict[str, Any]
+        **kwargs : dict[str, Any]
             The rest of key-word arguments for the created :py:class:`Parameter`.
         Returns
         -------

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/gp_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/gp_model.py
@@ -1,7 +1,7 @@
 import numpy as np
 import autograd.numpy as anp
 from autograd.builtins import isinstance
-from typing import List, Optional, Dict, Any
+from typing import Any
 import logging
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.constants import (
@@ -40,14 +40,14 @@ class GaussianProcessModel:
         return self._random_state
 
     @property
-    def states(self) -> Optional[List[PosteriorState]]:
+    def states(self) -> list[PosteriorState] | None:
         """
         :return: Current posterior states (one per MCMC sample; just a single
             state if model parameters are optimized)
         """
         raise NotImplementedError
 
-    def fit(self, data: Dict[str, Any]):
+    def fit(self, data: dict[str, Any]):
         """
         Adjust model parameters based on training data ``data``. Can be done via
         optimization or MCMC sampling. The posterior states are computed at the
@@ -57,7 +57,7 @@ class GaussianProcessModel:
         """
         raise NotImplementedError
 
-    def recompute_states(self, data: Dict[str, Any]):
+    def recompute_states(self, data: dict[str, Any]):
         """
         Recomputes posterior states for current model parameters.
 
@@ -169,7 +169,7 @@ class GaussianProcessModel:
         return _concatenate_samples(samples_list)
 
 
-def _concatenate_samples(samples_list: List[anp.ndarray]) -> anp.ndarray:
+def _concatenate_samples(samples_list: list[anp.ndarray]) -> anp.ndarray:
     return anp.concatenate(samples_list, axis=-1)
 
 
@@ -181,7 +181,7 @@ class GaussianProcessOptimizeModel(GaussianProcessModel):
 
     def __init__(
         self,
-        optimization_config: Optional[OptimizationConfig] = None,
+        optimization_config: OptimizationConfig | None = None,
         random_seed=None,
         fit_reset_params: bool = True,
     ):
@@ -193,14 +193,14 @@ class GaussianProcessOptimizeModel(GaussianProcessModel):
         self.optimization_config = optimization_config
 
     @property
-    def states(self) -> Optional[List[PosteriorState]]:
+    def states(self) -> list[PosteriorState] | None:
         return self._states
 
     @property
     def likelihood(self) -> MarginalLikelihood:
         raise NotImplementedError
 
-    def fit(self, data: Dict[str, Any]):
+    def fit(self, data: dict[str, Any]):
         """
         Fit the model parameters by optimizing the marginal likelihood,
         and set posterior states.
@@ -262,23 +262,23 @@ class GaussianProcessOptimizeModel(GaussianProcessModel):
         # Recompute posterior state for new hyperparameters
         self._recompute_states(data)
 
-    def _set_likelihood_params(self, params: Dict[str, Any]):
+    def _set_likelihood_params(self, params: dict[str, Any]):
         for param in self.likelihood.collect_params().values():
             vec = params.get(param.name)
             if vec is not None:
                 param.set_data(vec)
 
-    def recompute_states(self, data: Dict[str, Any]):
+    def recompute_states(self, data: dict[str, Any]):
         self._recompute_states(data)
 
-    def _recompute_states(self, data: Dict[str, Any]):
+    def _recompute_states(self, data: dict[str, Any]):
         self.likelihood.data_precomputations(data)
         self._states = [self.likelihood.get_posterior_state(data)]
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return self.likelihood.get_params()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         self.likelihood.set_params(param_dict)
 
     def reset_params(self):

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/gp_regression.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/gp_regression.py
@@ -1,4 +1,3 @@
-from typing import Optional
 import logging
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.constants import (
@@ -48,10 +47,10 @@ class GaussianProcessRegression(GaussianProcessOptimizeModel):
     def __init__(
         self,
         kernel: KernelFunction,
-        mean: Optional[MeanFunction] = None,
-        target_transform: Optional[ScalarTargetTransform] = None,
-        initial_noise_variance: Optional[float] = None,
-        optimization_config: Optional[OptimizationConfig] = None,
+        mean: MeanFunction | None = None,
+        target_transform: ScalarTargetTransform | None = None,
+        initial_noise_variance: float | None = None,
+        optimization_config: OptimizationConfig | None = None,
         random_seed=None,
         fit_reset_params: bool = True,
     ):

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/gpr_mcmc.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/gpr_mcmc.py
@@ -1,4 +1,5 @@
-from typing import Callable, Optional, List, Dict, Any
+from typing import Any
+from collections.abc import Callable
 import autograd.numpy as anp
 from autograd.builtins import isinstance
 from numpy.random import RandomState
@@ -50,14 +51,14 @@ class GPRegressionMCMC(GaussianProcessModel):
         self.build_kernel = build_kernel
 
     @property
-    def states(self) -> Optional[List[GaussProcPosteriorState]]:
+    def states(self) -> list[GaussProcPosteriorState] | None:
         return self._states
 
     @property
     def number_samples(self) -> int:
         return self.mcmc_config.n_samples
 
-    def fit(self, data: Dict[str, Any]):
+    def fit(self, data: dict[str, Any]):
         features, targets = self._check_features_targets(
             features=data["features"], targets=data["targets"]
         )
@@ -96,7 +97,7 @@ class GPRegressionMCMC(GaussianProcessModel):
         )
         self._states = self._create_posterior_states(self.samples, features, targets)
 
-    def recompute_states(self, data: Dict[str, Any]):
+    def recompute_states(self, data: dict[str, Any]):
         """
         Supports fantasizing, in that targets can be a matrix. Then,
         ycols = targets.shape[1] must be a multiple of self.number_samples.

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/hypertune/gp_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/hypertune/gp_model.py
@@ -1,4 +1,5 @@
-from typing import Callable, Tuple, List, Optional, Dict, Any
+from typing import Any
+from collections.abc import Callable
 from dataclasses import dataclass
 import numpy as np
 
@@ -39,7 +40,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.target_transfo
 @dataclass
 class HyperTuneDistributionArguments:
     num_samples: int
-    num_brackets: Optional[int] = None
+    num_brackets: int | None = None
 
     def __post_init__(self):
         assert self.num_brackets is None or self.num_brackets >= 1
@@ -54,7 +55,7 @@ class HyperTuneModelMixin:
         # this signature is different in ``fit``, the distribution is recomputed
         self._hypertune_distribution_signature = None
 
-    def hypertune_bracket_distribution(self) -> Optional[np.ndarray]:
+    def hypertune_bracket_distribution(self) -> np.ndarray | None:
         """
         Distribution [w_k] of support size ``num_supp_brackets``, where
         ``num_supp_brackets <= args.num_brackets`` (the latter is maximum if
@@ -66,7 +67,7 @@ class HyperTuneModelMixin:
         """
         return self._bracket_distribution
 
-    def hypertune_ensemble_distribution(self) -> Optional[Dict[int, float]]:
+    def hypertune_ensemble_distribution(self) -> dict[int, float] | None:
         """
         Distribution [theta_r] which is used to create an ensemble predictive
         distribution fed into the acquisition function.
@@ -78,10 +79,10 @@ class HyperTuneModelMixin:
     def fit_distributions(
         self,
         poster_state: PerResourcePosteriorState,
-        data: Dict[str, Any],
-        resource_attr_range: Tuple[int, int],
+        data: dict[str, Any],
+        resource_attr_range: tuple[int, int],
         random_state: np.random.RandomState,
-    ) -> Optional[Dict[int, float]]:
+    ) -> dict[int, float] | None:
         ensemble_distribution = None
         args = self.hypertune_distribution_args
         (
@@ -159,13 +160,13 @@ class HyperTuneIndependentGPModel(IndependentGPPerResourceModel, HyperTuneModelM
         self,
         kernel: KernelFunction,
         mean_factory: Callable[[int], MeanFunction],
-        resource_attr_range: Tuple[int, int],
+        resource_attr_range: tuple[int, int],
         hypertune_distribution_args: HyperTuneDistributionArguments,
-        target_transform: Optional[ScalarTargetTransform] = None,
+        target_transform: ScalarTargetTransform | None = None,
         separate_noise_variances: bool = False,
-        initial_noise_variance: Optional[float] = None,
-        initial_covariance_scale: Optional[float] = None,
-        optimization_config: Optional[OptimizationConfig] = None,
+        initial_noise_variance: float | None = None,
+        initial_covariance_scale: float | None = None,
+        optimization_config: OptimizationConfig | None = None,
         random_seed=None,
         fit_reset_params: bool = True,
     ):
@@ -186,7 +187,7 @@ class HyperTuneIndependentGPModel(IndependentGPPerResourceModel, HyperTuneModelM
             self, hypertune_distribution_args=hypertune_distribution_args
         )
 
-    def create_likelihood(self, rung_levels: List[int]):
+    def create_likelihood(self, rung_levels: list[int]):
         """
         Delayed creation of likelihood, needs to know rung levels of Hyperband
         scheduler.
@@ -206,13 +207,13 @@ class HyperTuneIndependentGPModel(IndependentGPPerResourceModel, HyperTuneModelM
         )
         self.reset_params()
 
-    def hypertune_ensemble_distribution(self) -> Optional[Dict[int, float]]:
+    def hypertune_ensemble_distribution(self) -> dict[int, float] | None:
         if self._likelihood is not None:
             return self._likelihood.ensemble_distribution
         else:
             return None
 
-    def fit(self, data: Dict[str, Any]):
+    def fit(self, data: dict[str, Any]):
         super().fit(data)
         poster_state: IndependentGPPerResourcePosteriorState = self.states[0]
         ensemble_distribution = self.fit_distributions(
@@ -244,12 +245,12 @@ class HyperTuneJointGPModel(GaussianProcessRegression, HyperTuneModelMixin):
     def __init__(
         self,
         kernel: KernelFunction,
-        resource_attr_range: Tuple[int, int],
+        resource_attr_range: tuple[int, int],
         hypertune_distribution_args: HyperTuneDistributionArguments,
-        mean: Optional[MeanFunction] = None,
-        target_transform: Optional[ScalarTargetTransform] = None,
-        initial_noise_variance: Optional[float] = None,
-        optimization_config: Optional[OptimizationConfig] = None,
+        mean: MeanFunction | None = None,
+        target_transform: ScalarTargetTransform | None = None,
+        initial_noise_variance: float | None = None,
+        optimization_config: OptimizationConfig | None = None,
         random_seed=None,
         fit_reset_params: bool = True,
     ):
@@ -278,7 +279,7 @@ class HyperTuneJointGPModel(GaussianProcessRegression, HyperTuneModelMixin):
         self._likelihood = None
         self._rung_levels = None
 
-    def create_likelihood(self, rung_levels: List[int]):
+    def create_likelihood(self, rung_levels: list[int]):
         """
         Delayed creation of likelihood, needs to know rung levels of Hyperband
         scheduler.
@@ -297,13 +298,13 @@ class HyperTuneJointGPModel(GaussianProcessRegression, HyperTuneModelMixin):
         )
         self.reset_params()
 
-    def hypertune_ensemble_distribution(self) -> Optional[Dict[int, float]]:
+    def hypertune_ensemble_distribution(self) -> dict[int, float] | None:
         if self._likelihood is not None:
             return self._likelihood.ensemble_distribution
         else:
             return None
 
-    def fit(self, data: Dict[str, Any]):
+    def fit(self, data: dict[str, Any]):
         super().fit(data)
         resource_attr_range = self._likelihood_kwargs["resource_attr_range"]
         poster_state = GaussProcPosteriorStateAndRungLevels(

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/hypertune/likelihood.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/hypertune/likelihood.py
@@ -1,4 +1,4 @@
-from typing import Dict, Tuple, Any, Optional
+from typing import Any
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.likelihood import (
     GaussianProcessMarginalLikelihood,
@@ -39,10 +39,10 @@ class HyperTuneIndependentGPMarginalLikelihood(
     def __init__(
         self,
         kernel: KernelFunction,
-        mean: Dict[int, MeanFunction],
-        resource_attr_range: Tuple[int, int],
-        ensemble_distribution: Dict[int, float],
-        target_transform: Optional[ScalarTargetTransform] = None,
+        mean: dict[int, MeanFunction],
+        resource_attr_range: tuple[int, int],
+        ensemble_distribution: dict[int, float],
+        target_transform: ScalarTargetTransform | None = None,
         separate_noise_variances: bool = False,
         initial_noise_variance=None,
         initial_covariance_scale=None,
@@ -64,14 +64,14 @@ class HyperTuneIndependentGPMarginalLikelihood(
         self.set_ensemble_distribution(ensemble_distribution)
 
     @property
-    def ensemble_distribution(self) -> Dict[int, float]:
+    def ensemble_distribution(self) -> dict[int, float]:
         return self._ensemble_distribution
 
-    def set_ensemble_distribution(self, distribution: Dict[int, float]):
+    def set_ensemble_distribution(self, distribution: dict[int, float]):
         assert_ensemble_distribution(distribution, set(self.mean.keys()))
         self._ensemble_distribution = distribution.copy()
 
-    def get_posterior_state(self, data: Dict[str, Any]) -> PosteriorState:
+    def get_posterior_state(self, data: dict[str, Any]) -> PosteriorState:
         GaussianProcessMarginalLikelihood.assert_data_entries(data)
         targets = self.target_transform(data["targets"])
         return HyperTuneIndependentGPPosteriorState(
@@ -99,9 +99,9 @@ class HyperTuneJointGPMarginalLikelihood(GaussianProcessMarginalLikelihood):
         self,
         kernel: KernelFunction,
         mean: MeanFunction,
-        resource_attr_range: Tuple[int, int],
-        ensemble_distribution: Dict[int, float],
-        target_transform: Optional[ScalarTargetTransform] = None,
+        resource_attr_range: tuple[int, int],
+        ensemble_distribution: dict[int, float],
+        target_transform: ScalarTargetTransform | None = None,
         initial_noise_variance=None,
         encoding_type=None,
         **kwargs,
@@ -119,13 +119,13 @@ class HyperTuneJointGPMarginalLikelihood(GaussianProcessMarginalLikelihood):
         self.set_ensemble_distribution(ensemble_distribution)
 
     @property
-    def ensemble_distribution(self) -> Dict[int, float]:
+    def ensemble_distribution(self) -> dict[int, float]:
         return self._ensemble_distribution
 
-    def set_ensemble_distribution(self, distribution: Dict[int, float]):
+    def set_ensemble_distribution(self, distribution: dict[int, float]):
         self._ensemble_distribution = distribution.copy()
 
-    def get_posterior_state(self, data: Dict[str, Any]) -> PosteriorState:
+    def get_posterior_state(self, data: dict[str, Any]) -> PosteriorState:
         GaussianProcessMarginalLikelihood.assert_data_entries(data)
         targets = self.target_transform(data["targets"])
         return HyperTuneJointGPPosteriorState(

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/hypertune/posterior_state.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/hypertune/posterior_state.py
@@ -1,5 +1,5 @@
 import numpy as np
-from typing import Dict, Tuple, Optional, Callable, Set
+from collections.abc import Callable
 from numpy.random import RandomState
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.independent.posterior_state import (
@@ -27,7 +27,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.posterior_util
 
 
 def assert_ensemble_distribution(
-    distribution: Dict[int, float], all_resources: Set[int]
+    distribution: dict[int, float], all_resources: set[int]
 ):
     assert set(distribution.keys()).issubset(all_resources), (
         f"distribution.keys() = {set(distribution.keys())} must be subset "
@@ -39,10 +39,10 @@ def assert_ensemble_distribution(
 
 
 def _sample_hypertune_common(
-    ensemble_distribution: Dict[int, float],
+    ensemble_distribution: dict[int, float],
     sample_func: Callable[[int, int], np.ndarray],
     num_samples: int,
-    random_state: Optional[RandomState] = None,
+    random_state: RandomState | None = None,
 ) -> np.ndarray:
     if random_state is None:
         random_state = np.random
@@ -98,11 +98,11 @@ class HyperTuneIndependentGPPosteriorState(IndependentGPPerResourcePosteriorStat
         features: np.ndarray,
         targets: np.ndarray,
         kernel: KernelFunction,
-        mean: Dict[int, MeanFunction],
-        covariance_scale: Dict[int, np.ndarray],
+        mean: dict[int, MeanFunction],
+        covariance_scale: dict[int, np.ndarray],
         noise_variance: NoiseVariance,
-        resource_attr_range: Tuple[int, int],
-        ensemble_distribution: Dict[int, float],
+        resource_attr_range: tuple[int, int],
+        ensemble_distribution: dict[int, float],
         debug_log: bool = False,
     ):
         """
@@ -123,7 +123,7 @@ class HyperTuneIndependentGPPosteriorState(IndependentGPPerResourcePosteriorStat
         assert_ensemble_distribution(ensemble_distribution, set(mean.keys()))
         self.ensemble_distribution = ensemble_distribution
 
-    def predict(self, test_features: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def predict(self, test_features: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         means, variances = 0, 0
         for resource, theta in self.ensemble_distribution.items():
             _means, _variances = self._states[resource].predict(test_features)
@@ -135,7 +135,7 @@ class HyperTuneIndependentGPPosteriorState(IndependentGPPerResourcePosteriorStat
         self,
         sample_func: Callable[[int, int], np.ndarray],
         num_samples: int,
-        random_state: Optional[RandomState] = None,
+        random_state: RandomState | None = None,
     ) -> np.ndarray:
         return _sample_hypertune_common(
             ensemble_distribution=self.ensemble_distribution,
@@ -148,7 +148,7 @@ class HyperTuneIndependentGPPosteriorState(IndependentGPPerResourcePosteriorStat
         self,
         test_features: np.ndarray,
         num_samples: int = 1,
-        random_state: Optional[RandomState] = None,
+        random_state: RandomState | None = None,
     ) -> np.ndarray:
         """
         If ``test_features`` are non-extended features (no resource attribute),
@@ -181,7 +181,7 @@ class HyperTuneIndependentGPPosteriorState(IndependentGPPerResourcePosteriorStat
         self,
         test_features: np.ndarray,
         num_samples: int = 1,
-        random_state: Optional[RandomState] = None,
+        random_state: RandomState | None = None,
     ) -> np.ndarray:
         """
         If ``test_features`` are non-extended features (no resource attribute),
@@ -213,7 +213,7 @@ class HyperTuneIndependentGPPosteriorState(IndependentGPPerResourcePosteriorStat
     def backward_gradient(
         self,
         input: np.ndarray,
-        head_gradients: Dict[str, np.ndarray],
+        head_gradients: dict[str, np.ndarray],
         mean_data: float,
         std_data: float,
     ) -> np.ndarray:
@@ -259,8 +259,8 @@ class HyperTuneJointGPPosteriorState(GaussProcPosteriorState):
         mean: MeanFunction,
         kernel: KernelFunctionWithCovarianceScale,
         noise_variance: np.ndarray,
-        resource_attr_range: Tuple[int, int],
-        ensemble_distribution: Dict[int, float],
+        resource_attr_range: tuple[int, int],
+        ensemble_distribution: dict[int, float],
         debug_log: bool = False,
     ):
         """
@@ -287,7 +287,7 @@ class HyperTuneJointGPPosteriorState(GaussProcPosteriorState):
         )
         return helper.extend_features_by_resource(test_features)
 
-    def predict(self, test_features: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def predict(self, test_features: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         means, variances = 0, 0
         for resource, theta in self.ensemble_distribution.items():
             features_ext = self._extend_features_by_resource(test_features, resource)
@@ -300,7 +300,7 @@ class HyperTuneJointGPPosteriorState(GaussProcPosteriorState):
         self,
         sample_func: Callable[[int, int], np.ndarray],
         num_samples: int,
-        random_state: Optional[RandomState] = None,
+        random_state: RandomState | None = None,
     ) -> np.ndarray:
         return _sample_hypertune_common(
             ensemble_distribution=self.ensemble_distribution,
@@ -313,7 +313,7 @@ class HyperTuneJointGPPosteriorState(GaussProcPosteriorState):
         self,
         test_features: np.ndarray,
         num_samples: int = 1,
-        random_state: Optional[RandomState] = None,
+        random_state: RandomState | None = None,
     ) -> np.ndarray:
         """
         If ``test_features`` are non-extended features (no resource attribute),
@@ -347,7 +347,7 @@ class HyperTuneJointGPPosteriorState(GaussProcPosteriorState):
         self,
         test_features: np.ndarray,
         num_samples: int = 1,
-        random_state: Optional[RandomState] = None,
+        random_state: RandomState | None = None,
     ) -> np.ndarray:
         """
         If ``test_features`` are non-extended features (no resource attribute),
@@ -380,7 +380,7 @@ class HyperTuneJointGPPosteriorState(GaussProcPosteriorState):
     def backward_gradient(
         self,
         input: np.ndarray,
-        head_gradients: Dict[str, np.ndarray],
+        head_gradients: dict[str, np.ndarray],
         mean_data: float,
         std_data: float,
     ) -> np.ndarray:

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/hypertune/utils.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/hypertune/utils.py
@@ -264,8 +264,9 @@ class GaussProcPosteriorStateAndRungLevels(PosteriorStateWithSampleJoint):
         return self._rung_levels
 
 
-PerResourcePosteriorState = IndependentGPPerResourcePosteriorState | GaussProcPosteriorStateAndRungLevels
-
+PerResourcePosteriorState = (
+    IndependentGPPerResourcePosteriorState | GaussProcPosteriorStateAndRungLevels
+)
 
 
 def _posterior_state_for_rung_level(

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/hypertune/utils.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/hypertune/utils.py
@@ -1,7 +1,8 @@
 import numpy as np
 import autograd.numpy as anp
 from autograd.tracer import getval
-from typing import Optional, Tuple, List, Union, Dict, Callable, Any
+from typing import Any
+from collections.abc import Callable
 from numpy.random import RandomState
 
 from syne_tune.optimizer.schedulers.searchers.utils.hp_ranges_impl import (
@@ -28,7 +29,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.kernel.base im
 
 
 class ExtendFeaturesByResourceMixin:
-    def __init__(self, resource: int, resource_attr_range: Tuple[int, int]):
+    def __init__(self, resource: int, resource_attr_range: tuple[int, int]):
         hp_range = HyperparameterRangeInteger(
             name="resource",
             lower_bound=resource_attr_range[0],
@@ -60,7 +61,7 @@ class PosteriorStateClampedResource(
         self,
         poster_state_extended: PosteriorStateWithSampleJoint,
         resource: int,
-        resource_attr_range: Tuple[int, int],
+        resource_attr_range: tuple[int, int],
     ):
         ExtendFeaturesByResourceMixin.__init__(self, resource, resource_attr_range)
         self._poster_state_extended = poster_state_extended
@@ -80,7 +81,7 @@ class PosteriorStateClampedResource(
     def neg_log_likelihood(self) -> anp.ndarray:
         return self._poster_state_extended.neg_log_likelihood()
 
-    def predict(self, test_features: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def predict(self, test_features: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         return self._poster_state_extended.predict(
             self.extend_features_by_resource(test_features)
         )
@@ -89,7 +90,7 @@ class PosteriorStateClampedResource(
         self,
         test_features: np.ndarray,
         num_samples: int = 1,
-        random_state: Optional[RandomState] = None,
+        random_state: RandomState | None = None,
     ) -> np.ndarray:
         return self._poster_state_extended.sample_marginals(
             test_features=self.extend_features_by_resource(test_features),
@@ -101,7 +102,7 @@ class PosteriorStateClampedResource(
         self,
         test_features: np.ndarray,
         num_samples: int = 1,
-        random_state: Optional[RandomState] = None,
+        random_state: RandomState | None = None,
     ) -> np.ndarray:
         return self._poster_state_extended.sample_joint(
             test_features=self.extend_features_by_resource(test_features),
@@ -112,7 +113,7 @@ class PosteriorStateClampedResource(
     def backward_gradient(
         self,
         input: np.ndarray,
-        head_gradients: Dict[str, np.ndarray],
+        head_gradients: dict[str, np.ndarray],
         mean_data: float,
         std_data: float,
     ) -> np.ndarray:
@@ -133,7 +134,7 @@ class MeanFunctionClampedResource(MeanFunction, ExtendFeaturesByResourceMixin):
         self,
         mean_extended: MeanFunction,
         resource: int,
-        resource_attr_range: Tuple[int, int],
+        resource_attr_range: tuple[int, int],
         **kwargs,
     ):
         MeanFunction.__init__(self, **kwargs)
@@ -143,10 +144,10 @@ class MeanFunctionClampedResource(MeanFunction, ExtendFeaturesByResourceMixin):
     def param_encoding_pairs(self):
         return self._mean_extended.param_encoding_pairs()
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return self._mean_extended.get_params()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         self._mean_extended.set_params(param_dict)
 
     def forward(self, X):
@@ -158,7 +159,7 @@ class KernelFunctionClampedResource(KernelFunction, ExtendFeaturesByResourceMixi
         self,
         kernel_extended: KernelFunction,
         resource: int,
-        resource_attr_range: Tuple[int, int],
+        resource_attr_range: tuple[int, int],
         **kwargs,
     ):
         KernelFunction.__init__(self, dimension=kernel_extended.dimension - 1, **kwargs)
@@ -168,10 +169,10 @@ class KernelFunctionClampedResource(KernelFunction, ExtendFeaturesByResourceMixi
     def param_encoding_pairs(self):
         return self._kernel_extended.param_encoding_pairs()
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return self._kernel_extended.get_params()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         self._kernel_extended.set_params(param_dict)
 
     def diagonal(self, X):
@@ -193,7 +194,7 @@ class GaussProcPosteriorStateAndRungLevels(PosteriorStateWithSampleJoint):
     def __init__(
         self,
         poster_state: GaussProcPosteriorState,
-        rung_levels: List[int],
+        rung_levels: list[int],
     ):
         self._poster_state = poster_state
         self._rung_levels = rung_levels
@@ -217,14 +218,14 @@ class GaussProcPosteriorStateAndRungLevels(PosteriorStateWithSampleJoint):
     def neg_log_likelihood(self) -> anp.ndarray:
         return self._poster_state.neg_log_likelihood()
 
-    def predict(self, test_features: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def predict(self, test_features: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         return self._poster_state.predict(test_features)
 
     def sample_marginals(
         self,
         test_features: np.ndarray,
         num_samples: int = 1,
-        random_state: Optional[RandomState] = None,
+        random_state: RandomState | None = None,
     ) -> np.ndarray:
         return self._poster_state.sample_marginals(
             test_features=test_features,
@@ -236,7 +237,7 @@ class GaussProcPosteriorStateAndRungLevels(PosteriorStateWithSampleJoint):
         self,
         test_features: np.ndarray,
         num_samples: int = 1,
-        random_state: Optional[RandomState] = None,
+        random_state: RandomState | None = None,
     ) -> np.ndarray:
         return self._poster_state.sample_joint(
             test_features=test_features,
@@ -247,7 +248,7 @@ class GaussProcPosteriorStateAndRungLevels(PosteriorStateWithSampleJoint):
     def backward_gradient(
         self,
         input: np.ndarray,
-        head_gradients: Dict[str, np.ndarray],
+        head_gradients: dict[str, np.ndarray],
         mean_data: float,
         std_data: float,
     ) -> np.ndarray:
@@ -259,21 +260,19 @@ class GaussProcPosteriorStateAndRungLevels(PosteriorStateWithSampleJoint):
         )
 
     @property
-    def rung_levels(self) -> List[int]:
+    def rung_levels(self) -> list[int]:
         return self._rung_levels
 
 
-PerResourcePosteriorState = Union[
-    IndependentGPPerResourcePosteriorState,
-    GaussProcPosteriorStateAndRungLevels,
-]
+PerResourcePosteriorState = IndependentGPPerResourcePosteriorState | GaussProcPosteriorStateAndRungLevels
+
 
 
 def _posterior_state_for_rung_level(
     poster_state: PerResourcePosteriorState,
     resource: int,
-    resource_attr_range: Tuple[int, int],
-) -> Union[GaussProcPosteriorState, PosteriorStateClampedResource]:
+    resource_attr_range: tuple[int, int],
+) -> GaussProcPosteriorState | PosteriorStateClampedResource:
     if isinstance(poster_state, IndependentGPPerResourcePosteriorState):
         return poster_state.state(resource)
     else:
@@ -286,10 +285,10 @@ def _posterior_state_for_rung_level(
 
 def hypertune_ranking_losses(
     poster_state: PerResourcePosteriorState,
-    data: Dict[str, Any],
+    data: dict[str, Any],
     num_samples: int,
-    resource_attr_range: Tuple[int, int],
-    random_state: Optional[RandomState] = None,
+    resource_attr_range: tuple[int, int],
+    random_state: RandomState | None = None,
 ) -> np.ndarray:
     """
     Samples ranking loss values as defined in the Hyper-Tune paper. We return a
@@ -388,10 +387,10 @@ def hypertune_ranking_losses(
 
 
 def number_supported_levels_and_data_highest_level(
-    rung_levels: List[int],
-    data: Dict[str, Any],
-    resource_attr_range: Tuple[int, int],
-) -> Tuple[int, dict]:
+    rung_levels: list[int],
+    data: dict[str, Any],
+    resource_attr_range: tuple[int, int],
+) -> tuple[int, dict]:
     """
     Finds ``num_supp_levels`` as maximum such that
     rung levels up to there have ``>= 6`` labeled datapoints. The set
@@ -425,8 +424,8 @@ def number_supported_levels_and_data_highest_level(
 
 
 def _extract_data_at_resource(
-    data: Dict[str, Any], resource: int, resource_attr_range: Tuple[int, int]
-) -> Dict[str, Any]:
+    data: dict[str, Any], resource: int, resource_attr_range: tuple[int, int]
+) -> dict[str, Any]:
     features_ext = data["features"]
     targets = data["targets"]
     num_fantasies = targets.shape[1] if targets.ndim == 2 else 1
@@ -449,9 +448,9 @@ def _losses_for_maximum_rung_by_cross_validation(
     poster_state_for_fold: Callable[
         [np.ndarray, np.ndarray], PosteriorStateWithSampleJoint
     ],
-    data_max_resource: Dict[str, Any],
+    data_max_resource: dict[str, Any],
     num_samples: int,
-    random_state: Optional[RandomState],
+    random_state: RandomState | None,
 ) -> np.ndarray:
     """
     Estimates loss samples at highest rung by K-fold cross-validation, where
@@ -508,9 +507,9 @@ def _losses_for_maximum_rung_by_cross_validation(
 
 def _losses_for_rung(
     poster_state: PosteriorStateWithSampleJoint,
-    data_max_resource: Dict[str, Any],
+    data_max_resource: dict[str, Any],
     num_samples: int,
-    random_state: Optional[RandomState],
+    random_state: RandomState | None,
 ) -> np.ndarray:
     joint_sample = poster_state.sample_joint(
         test_features=data_max_resource["features"],

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/independent/gpind_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/independent/gpind_model.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable, List, Tuple, Optional
+from collections.abc import Callable
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.constants import (
     OptimizationConfig,
@@ -59,12 +59,12 @@ class IndependentGPPerResourceModel(GaussianProcessOptimizeModel):
         self,
         kernel: KernelFunction,
         mean_factory: Callable[[int], MeanFunction],
-        resource_attr_range: Tuple[int, int],
-        target_transform: Optional[ScalarTargetTransform] = None,
+        resource_attr_range: tuple[int, int],
+        target_transform: ScalarTargetTransform | None = None,
         separate_noise_variances: bool = False,
-        initial_noise_variance: Optional[float] = None,
-        initial_covariance_scale: Optional[float] = None,
-        optimization_config: Optional[OptimizationConfig] = None,
+        initial_noise_variance: float | None = None,
+        initial_covariance_scale: float | None = None,
+        optimization_config: OptimizationConfig | None = None,
         random_seed=None,
         fit_reset_params: bool = True,
     ):
@@ -85,7 +85,7 @@ class IndependentGPPerResourceModel(GaussianProcessOptimizeModel):
         }
         self._likelihood = None  # Delayed creation
 
-    def create_likelihood(self, rung_levels: List[int]):
+    def create_likelihood(self, rung_levels: list[int]):
         """
         Delayed creation of likelihood, needs to know rung levels of Hyperband
         scheduler.

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/independent/posterior_state.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/independent/posterior_state.py
@@ -1,4 +1,4 @@
-from typing import Dict, Tuple, Optional, Callable, Union
+from collections.abc import Callable
 import numpy as np
 import autograd.numpy as anp
 from numpy.random import RandomState
@@ -18,7 +18,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.mean import (
 )
 
 
-NoiseVariance = Union[np.ndarray, Dict[int, np.ndarray]]
+NoiseVariance = np.ndarray | dict[int, np.ndarray]
 
 
 class IndependentGPPerResourcePosteriorState(PosteriorStateWithSampleJoint):
@@ -39,10 +39,10 @@ class IndependentGPPerResourcePosteriorState(PosteriorStateWithSampleJoint):
         features: np.ndarray,
         targets: np.ndarray,
         kernel: KernelFunction,
-        mean: Dict[int, MeanFunction],
-        covariance_scale: Dict[int, np.ndarray],
+        mean: dict[int, MeanFunction],
+        covariance_scale: dict[int, np.ndarray],
         noise_variance: NoiseVariance,
-        resource_attr_range: Tuple[int, int],
+        resource_attr_range: tuple[int, int],
         debug_log: bool = False,
     ):
         """
@@ -92,10 +92,10 @@ class IndependentGPPerResourcePosteriorState(PosteriorStateWithSampleJoint):
         features: np.ndarray,
         targets: np.ndarray,
         kernel: KernelFunction,
-        mean: Dict[int, MeanFunction],
-        covariance_scale: Dict[int, np.ndarray],
-        noise_variance: Dict[int, np.ndarray],
-        resource_attr_range: Tuple[int, int],
+        mean: dict[int, MeanFunction],
+        covariance_scale: dict[int, np.ndarray],
+        noise_variance: dict[int, np.ndarray],
+        resource_attr_range: tuple[int, int],
         debug_log: bool = False,
     ):
         features, resources = decode_extended_features(features, resource_attr_range)
@@ -135,7 +135,7 @@ class IndependentGPPerResourcePosteriorState(PosteriorStateWithSampleJoint):
 
     # Different to ``sample_marginals``, ``sample_joint``, this method supports
     # ``autograd`` differentiation
-    def predict(self, test_features: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def predict(self, test_features: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         test_features, resources = decode_extended_features(
             test_features, self._resource_attr_range
         )
@@ -205,7 +205,7 @@ class IndependentGPPerResourcePosteriorState(PosteriorStateWithSampleJoint):
         self,
         test_features: np.ndarray,
         num_samples: int = 1,
-        random_state: Optional[RandomState] = None,
+        random_state: RandomState | None = None,
     ) -> np.ndarray:
         """
         Different to ``predict``, entries in ``test_features``
@@ -230,7 +230,7 @@ class IndependentGPPerResourcePosteriorState(PosteriorStateWithSampleJoint):
         self,
         test_features: np.ndarray,
         num_samples: int = 1,
-        random_state: Optional[RandomState] = None,
+        random_state: RandomState | None = None,
     ) -> np.ndarray:
         """
         Different to ``predict``, entries in ``test_features``
@@ -254,7 +254,7 @@ class IndependentGPPerResourcePosteriorState(PosteriorStateWithSampleJoint):
     def backward_gradient(
         self,
         input: np.ndarray,
-        head_gradients: Dict[str, np.ndarray],
+        head_gradients: dict[str, np.ndarray],
         mean_data: float,
         std_data: float,
     ) -> np.ndarray:

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/base.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/base.py
@@ -1,6 +1,6 @@
 import autograd.numpy as anp
 from autograd.tracer import getval
-from typing import Dict, Any
+from typing import Any
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.constants import (
     INITIAL_COVARIANCE_SCALE,
@@ -142,7 +142,7 @@ class SquaredDistance(Block):
 
         return anp.abs(D)
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         """
         Parameter keys are "inv_bw<k> "if ``dimension > 1``, and "inv_bw" if
         ``dimension == 1``.
@@ -156,7 +156,7 @@ class SquaredDistance(Block):
                 for k in range(inverse_bandwidths.size)
             }
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         dimension = self.encoding.dimension
         if dimension == 1:
             inverse_bandwidths = [param_dict["inv_bw"]]
@@ -272,13 +272,13 @@ class Matern52(KernelFunction):
         assert self.has_covariance_scale, "covariance_scale is fixed to 1"
         self.encoding.set(self.covariance_scale_internal, covariance_scale)
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         result = self.squared_distance.get_params()
         if self.has_covariance_scale:
             result["covariance_scale"] = self.get_covariance_scale()
         return result
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         self.squared_distance.set_params(param_dict)
         if self.has_covariance_scale:
             self.set_covariance_scale(param_dict["covariance_scale"])

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/cross_validation.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/cross_validation.py
@@ -1,6 +1,6 @@
 import autograd.numpy as anp
 from autograd.builtins import isinstance
-from typing import Dict, Any
+from typing import Any
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.kernel.base import (
     KernelFunction,
@@ -128,7 +128,7 @@ class CrossValidationKernelFunction(KernelFunction):
         cfg, _ = self._compute_terms(X)
         return self.mean_main(cfg)
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         result = dict()
         for pref, func in [
             ("kernelm_", self.kernel_main),
@@ -138,7 +138,7 @@ class CrossValidationKernelFunction(KernelFunction):
             result.update({(pref + k): v for k, v in func.get_params().items()})
         return result
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         for pref, func in [
             ("kernelm_", self.kernel_main),
             ("meanm_", self.mean_main),
@@ -163,8 +163,8 @@ class CrossValidationMeanFunction(MeanFunction):
     def param_encoding_pairs(self):
         return []
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return dict()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         pass

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/exponential_decay.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/exponential_decay.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any
+from typing import Any
 import autograd.numpy as anp
 from autograd.builtins import isinstance
 
@@ -60,7 +60,7 @@ class ExponentialDecayResourcesKernelFunction(KernelFunction):
         alpha_init: float = 1.0,
         mean_lam_init: float = 0.5,
         gamma_init: float = 0.5,
-        delta_fixed_value: Optional[float] = None,
+        delta_fixed_value: float | None = None,
         delta_init: float = 0.5,
         max_metric_value: float = 1.0,
         **kwargs
@@ -263,7 +263,7 @@ class ExponentialDecayResourcesKernelFunction(KernelFunction):
 
         return anp.add(mean, anp.multiply(kappa, kr_pref))
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         """
         Parameter keys are "alpha", "mean_lam", "gamma", "delta" (only if not
         fixed to ``delta_fixed_value``), as well as those of ``self.kernel_x`` (prefix
@@ -280,7 +280,7 @@ class ExponentialDecayResourcesKernelFunction(KernelFunction):
 
         return result
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         for pref, func in [("kernelx_", self.kernel_x), ("meanx_", self.mean_x)]:
             len_pref = len(pref)
             stripped_dict = {
@@ -306,8 +306,8 @@ class ExponentialDecayResourcesMeanFunction(MeanFunction):
     def param_encoding_pairs(self):
         return []
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return dict()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         pass

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/fabolas.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/fabolas.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 import autograd.numpy as anp
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.kernel.base import (
@@ -105,12 +105,12 @@ class FabolasKernelFunction(KernelFunction):
             (self.u3_internal, self.encoding_u3),
         ]
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         values = list(self._get_pars(None))
         keys = ["u1", "u2", "u3"]
         return {k: anp.reshape(v, (1,))[0] for k, v in zip(keys, values)}
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         self.encoding_u12.set(self.u1_internal, param_dict["u1"])
         self.encoding_u12.set(self.u2_internal, param_dict["u2"])
         self.encoding_u3.set(self.u3_internal, param_dict["u3"])

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/freeze_thaw.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/freeze_thaw.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 import autograd.numpy as anp
 from autograd.builtins import isinstance
 from autograd.tracer import getval
@@ -203,7 +203,7 @@ class FreezeThawKernelFunction(KernelFunction):
         cfg, res, kappa, mean = self._compute_terms(X, alpha, mean_lam, ret_mean=True)
         return anp.add(mean, anp.multiply(kappa, gamma))
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         """
         Parameter keys are alpha, mean_lam, gamma, delta (only if not fixed
         to delta_fixed_value), as well as those of self.kernel_x (prefix
@@ -216,7 +216,7 @@ class FreezeThawKernelFunction(KernelFunction):
             result.update({(pref + k): v for k, v in func.get_params().items()})
         return result
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         for pref, func in [("kernelx_", self.kernel_x), ("meanx_", self.mean_x)]:
             len_pref = len(pref)
             stripped_dict = {
@@ -240,8 +240,8 @@ class FreezeThawMeanFunction(MeanFunction):
     def param_encoding_pairs(self):
         return []
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return dict()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         pass

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/product_kernel.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/product_kernel.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.kernel.base import (
     KernelFunction,
 )
@@ -69,14 +69,14 @@ class ProductKernelFunction(KernelFunction):
         """
         return self.kernel1.param_encoding_pairs() + self.kernel2.param_encoding_pairs()
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         result = dict()
         prefs = [k + "_" for k in self.name_prefixes]
         for pref, kernel in zip(prefs, [self.kernel1, self.kernel2]):
             result.update({(pref + k): v for k, v in kernel.get_params().items()})
         return result
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         prefs = [k + "_" for k in self.name_prefixes]
         for pref, kernel in zip(prefs, [self.kernel1, self.kernel2]):
             len_pref = len(pref)

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/range_kernel.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/range_kernel.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.kernel.base import (
     KernelFunction,
 )
@@ -55,8 +55,8 @@ class RangeKernelFunction(KernelFunction):
         """
         return self.kernel.param_encoding_pairs()
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return self.kernel.get_params()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         self.kernel.set_params(param_dict)

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/freeze_thaw.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/freeze_thaw.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any
+from typing import Any
 
 import numpy as np
 import autograd.numpy as anp
@@ -52,10 +52,10 @@ class ZeroKernel(KernelFunction):
     def param_encoding_pairs(self):
         return []
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return dict()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         pass
 
 
@@ -69,10 +69,10 @@ class ZeroMean(MeanFunction):
     def param_encoding_pairs(self):
         return []
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return dict()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         pass
 
 
@@ -125,10 +125,10 @@ class ExponentialDecayBaseKernelFunction(KernelFunction):
     def param_encoding_pairs(self):
         return self.kernel.param_encoding_pairs()
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return self.kernel.get_params()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         self.kernel.set_params(param_dict)
 
     def mean_function(self, X):
@@ -137,7 +137,7 @@ class ExponentialDecayBaseKernelFunction(KernelFunction):
         return self.kernel.mean_function(X)
 
 
-def logdet_cholfact_cov_resource(likelihood: Dict) -> float:
+def logdet_cholfact_cov_resource(likelihood: dict) -> float:
     """
     Computes the additional log(det(Lbar)) term. This is
     sum_i log(det(Lbar_i)), where Lbar_i is upper left submatrix of
@@ -156,7 +156,7 @@ def logdet_cholfact_cov_resource(likelihood: Dict) -> float:
     return _inner_product(log_diag[:dim], weights)
 
 
-def resource_kernel_likelihood_precomputations(targets: List[np.ndarray]) -> Dict:
+def resource_kernel_likelihood_precomputations(targets: list[np.ndarray]) -> dict:
     """
     Precomputations required by ``resource_kernel_likelihood_computations``.
 
@@ -200,11 +200,11 @@ def resource_kernel_likelihood_precomputations(targets: List[np.ndarray]) -> Dic
 # TODO: This code is complex. If it does not run faster than
 # ``resource_kernel_likelihood_slow_computations``, remove it.
 def resource_kernel_likelihood_computations(
-    precomputed: Dict,
+    precomputed: dict,
     res_kernel: ExponentialDecayBaseKernelFunction,
     noise_variance,
     skip_c_d: bool = False,
-) -> Dict:
+) -> dict:
     """
     Given ``precomputed`` from ``resource_kernel_likelihood_precomputations`` and
     resource kernel function ``res_kernel``, compute quantities required for
@@ -312,11 +312,11 @@ def resource_kernel_likelihood_computations(
 # TODO: It is not clear whether this code is slower, and it is certainly
 # simpler.
 def resource_kernel_likelihood_slow_computations(
-    targets: List[np.ndarray],
+    targets: list[np.ndarray],
     res_kernel: ExponentialDecayBaseKernelFunction,
     noise_variance,
     skip_c_d: bool = False,
-) -> Dict:
+) -> dict:
     """
     Naive implementation of ``resource_kernel_likelihood_computations``, which
     does not require precomputations, but is somewhat slower. Here, results are
@@ -372,11 +372,11 @@ def resource_kernel_likelihood_slow_computations(
 
 
 def predict_posterior_marginals_extended(
-    poster_state: Dict,
+    poster_state: dict,
     mean,
     kernel,
     test_features,
-    resources: List[int],
+    resources: list[int],
     res_kernel: ExponentialDecayBaseKernelFunction,
 ):
     """
@@ -413,7 +413,7 @@ def predict_posterior_marginals_extended(
 
 
 def sample_posterior_joint(
-    poster_state: Dict,
+    poster_state: dict,
     mean,
     kernel,
     feature,
@@ -424,7 +424,7 @@ def sample_posterior_joint(
     means_all,
     random_state: RandomState,
     num_samples: int = 1,
-) -> Dict:
+) -> dict:
     """
     Given ``poster_state`` for some data plus one additional configuration
     with data (``feature``, ``targets``), draw joint samples of unobserved

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/gpiss_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/gpiss_model.py
@@ -1,4 +1,3 @@
-from typing import Optional
 import logging
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.learncurve.likelihood import (
@@ -68,9 +67,9 @@ class GaussianProcessLearningCurveModel(GaussianProcessOptimizeModel):
         self,
         kernel: KernelFunction,
         res_model: LCModel,
-        mean: Optional[MeanFunction] = None,
-        initial_noise_variance: Optional[float] = None,
-        optimization_config: Optional[OptimizationConfig] = None,
+        mean: MeanFunction | None = None,
+        initial_noise_variance: float | None = None,
+        optimization_config: OptimizationConfig | None = None,
         random_seed=None,
         fit_reset_params: bool = True,
     ):

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/issm.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/issm.py
@@ -1,5 +1,3 @@
-from typing import List, Dict, Tuple
-
 import numpy as np
 import scipy.linalg as spl
 import autograd.numpy as anp
@@ -33,13 +31,13 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.config_ext impo
 
 def _prepare_data_internal(
     state: TuningJobState,
-    data_lst: List[Tuple[Configuration, List, str]],
+    data_lst: list[tuple[Configuration, list, str]],
     config_space_ext: ExtendedConfiguration,
     active_metric: str,
     do_fantasizing: bool,
     mean: float,
     std: float,
-) -> (List[Configuration], List[np.ndarray], List[str]):
+) -> (list[Configuration], list[np.ndarray], list[str]):
     r_min, r_max = config_space_ext.resource_attr_range
     configs = [x[0] for x in data_lst]
     trial_ids = [x[2] for x in data_lst]
@@ -119,7 +117,7 @@ def _prepare_data_internal(
     return configs, targets, trial_ids
 
 
-def _create_tuple(ev: TrialEvaluations, active_metric: str, config_for_trial: Dict):
+def _create_tuple(ev: TrialEvaluations, active_metric: str, config_for_trial: dict):
     metric_vals = ev.metrics[active_metric]
     assert isinstance(metric_vals, dict)
     observed = list(
@@ -136,7 +134,7 @@ def prepare_data(
     active_metric: str,
     normalize_targets: bool = False,
     do_fantasizing: bool = False,
-) -> Dict:
+) -> dict:
     """
     Prepares data in ``state`` for further processing. The entries
     ``configs``, ``targets`` of the result dict are lists of one entry per trial,
@@ -212,7 +210,7 @@ def prepare_data_with_pending(
     config_space_ext: ExtendedConfiguration,
     active_metric: str,
     normalize_targets: bool = False,
-) -> (Dict, Dict):
+) -> (dict, dict):
     """
     Similar to ``prepare_data`` with ``do_fantasizing=False``, but two dicts are
     returned, the first for trials without pending evaluations, the second
@@ -311,7 +309,7 @@ def prepare_data_with_pending(
     return results
 
 
-def issm_likelihood_precomputations(targets: List[np.ndarray], r_min: int) -> Dict:
+def issm_likelihood_precomputations(targets: list[np.ndarray], r_min: int) -> dict:
     """
     Precomputations required by ``issm_likelihood_computations``.
 
@@ -386,12 +384,12 @@ def _flatvec(a, _np=anp):
 
 
 def issm_likelihood_computations(
-    precomputed: Dict,
-    issm_params: Dict,
+    precomputed: dict,
+    issm_params: dict,
     r_min: int,
     r_max: int,
     skip_c_d: bool = False,
-) -> Dict:
+) -> dict:
     """
     Given ``precomputed`` from ``issm_likelihood_precomputations`` and ISSM
     parameters ``issm_params``, compute quantities required for inference and
@@ -526,8 +524,8 @@ def issm_likelihood_computations(
 
 
 def posterior_computations(
-    features, mean, kernel, issm_likelihood: Dict, noise_variance
-) -> Dict:
+    features, mean, kernel, issm_likelihood: dict, noise_variance
+) -> dict:
     """
     Computes posterior state (required for predictions) and negative log
     marginal likelihood (returned in ``criterion``), The latter is computed only
@@ -593,7 +591,7 @@ def posterior_computations(
     return result
 
 
-def predict_posterior_marginals(poster_state: Dict, mean, kernel, test_features):
+def predict_posterior_marginals(poster_state: dict, mean, kernel, test_features):
     """
     These are posterior marginals on the h variable, whereas the full model is
     for f_r = h + g_r (additive).
@@ -624,7 +622,7 @@ def predict_posterior_marginals(poster_state: Dict, mean, kernel, test_features)
 
 
 def sample_posterior_marginals(
-    poster_state: Dict,
+    poster_state: dict,
     mean,
     kernel,
     test_features,
@@ -648,12 +646,12 @@ def sample_posterior_marginals(
 
 
 def predict_posterior_marginals_extended(
-    poster_state: Dict,
+    poster_state: dict,
     mean,
     kernel,
     test_features,
-    resources: List[int],
-    issm_params: Dict,
+    resources: list[int],
+    issm_params: dict,
     r_min: int,
     r_max: int,
 ):
@@ -724,17 +722,17 @@ def predict_posterior_marginals_extended(
 
 
 def sample_posterior_joint(
-    poster_state: Dict,
+    poster_state: dict,
     mean,
     kernel,
     feature,
     targets: np.ndarray,
-    issm_params: Dict,
+    issm_params: dict,
     r_min: int,
     r_max: int,
     random_state: RandomState,
     num_samples: int = 1,
-) -> Dict:
+) -> dict:
     """
     Given ``poster_state`` for some data plus one additional configuration
     with data (``feature``, ``targets``, ``issm_params``), draw joint samples
@@ -866,12 +864,12 @@ def sample_posterior_joint(
 
 
 def issm_likelihood_slow_computations(
-    targets: List[np.ndarray],
-    issm_params: Dict,
+    targets: list[np.ndarray],
+    issm_params: dict,
     r_min: int,
     r_max: int,
     skip_c_d: bool = False,
-) -> Dict:
+) -> dict:
     """
     Naive implementation of ``issm_likelihood_computations``, which does not
     require precomputations, but is much slower. Here, results are computed
@@ -962,8 +960,8 @@ def issm_likelihood_slow_computations(
 
 
 def _update_posterior_internal(
-    poster_state: Dict, kernel, feature, d_new, s_new, r2_new
-) -> Dict:
+    poster_state: dict, kernel, feature, d_new, s_new, r2_new
+) -> dict:
     assert "r2vec" in poster_state and "r4vec" in poster_state
     features = poster_state["features"]
     r2vec = poster_state["r2vec"]
@@ -1003,8 +1001,8 @@ def _update_posterior_internal(
 
 
 def update_posterior_state(
-    poster_state: Dict, kernel, feature, d_new, s_new, r2_new
-) -> Dict:
+    poster_state: dict, kernel, feature, d_new, s_new, r2_new
+) -> dict:
     """
     Incremental update of posterior state, given data for one additional
     configuration. The new datapoint gives rise to a new row/column of the
@@ -1069,7 +1067,7 @@ def update_posterior_state(
 
 
 def update_posterior_pvec(
-    poster_state: Dict, kernel, feature, d_new, s_new, r2_new
+    poster_state: dict, kernel, feature, d_new, s_new, r2_new
 ) -> np.ndarray:
     """
     Part of ``update_posterior_state``, just returns the new p vector.

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/likelihood.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/likelihood.py
@@ -1,4 +1,4 @@
-from typing import Union, Optional, List, Dict, Any
+from typing import Any
 import autograd.numpy as anp
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.likelihood import (
@@ -40,7 +40,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.mean import (
 )
 
 
-LCModel = Union[ISSModelParameters, ExponentialDecayBaseKernelFunction]
+LCModel = ISSModelParameters | ExponentialDecayBaseKernelFunction
 
 
 class GaussAdditiveMarginalLikelihood(MarginalLikelihood):
@@ -63,7 +63,7 @@ class GaussAdditiveMarginalLikelihood(MarginalLikelihood):
         self,
         kernel: KernelFunction,
         res_model: LCModel,
-        mean: Optional[MeanFunction] = None,
+        mean: MeanFunction | None = None,
         initial_noise_variance=None,
         encoding_type=None,
         **kwargs
@@ -115,21 +115,21 @@ class GaussAdditiveMarginalLikelihood(MarginalLikelihood):
                 self.params, "noise_variance", self.encoding
             )
 
-    def get_posterior_state(self, data: Dict[str, Any]) -> PosteriorState:
+    def get_posterior_state(self, data: dict[str, Any]) -> PosteriorState:
         return self._type(
             data,
             **self._posterstate_kwargs,
             noise_variance=self.get_noise_variance(),
         )
 
-    def forward(self, data: Dict[str, Any]):
+    def forward(self, data: dict[str, Any]):
         assert not data["do_fantasizing"], (
             "data must not be for fantasizing. Call prepare_data with "
             + "do_fantasizing=False"
         )
         return super().forward(data)
 
-    def param_encoding_pairs(self) -> List[tuple]:
+    def param_encoding_pairs(self) -> list[tuple]:
         own_param_encoding_pairs = [(self.noise_variance_internal, self.encoding)]
         return (
             own_param_encoding_pairs
@@ -147,13 +147,13 @@ class GaussAdditiveMarginalLikelihood(MarginalLikelihood):
     def _set_noise_variance(self, val):
         self.encoding.set(self.noise_variance_internal, val)
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         result = {"noise_variance": self.get_noise_variance()}
         for pref, func in self._components:
             result.update({(pref + k): v for k, v in func.get_params().items()})
         return result
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         for pref, func in self._components:
             len_pref = len(pref)
             stripped_dict = {
@@ -162,11 +162,11 @@ class GaussAdditiveMarginalLikelihood(MarginalLikelihood):
             func.set_params(stripped_dict)
         self._set_noise_variance(param_dict["noise_variance"])
 
-    def data_precomputations(self, data: Dict[str, Any], overwrite: bool = False):
+    def data_precomputations(self, data: dict[str, Any], overwrite: bool = False):
         if overwrite or not self._type.has_precomputations(data):
             self._type.data_precomputations(data)
 
-    def on_fit_start(self, data: Dict[str, Any]):
+    def on_fit_start(self, data: dict[str, Any]):
         assert not data["do_fantasizing"], (
             "data must not be for fantasizing. Call prepare_data with "
             + "do_fantasizing=False"

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/model_params.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/model_params.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 import autograd.numpy as anp
 from autograd.tracer import getval
 
@@ -64,7 +64,7 @@ class ISSModelParameters(MeanFunction):
             gamma = encode_unwrap_parameter(self.gamma_internal, self.gamma_encoding)
             return anp.reshape(gamma, (1,))[0]
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         if self.gamma_is_one:
             return dict()
         else:
@@ -74,11 +74,11 @@ class ISSModelParameters(MeanFunction):
         assert not self.gamma_is_one, "Cannot set gamma (fixed to 1)"
         self.gamma_encoding.set(self.gamma_internal, val)
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         if not self.gamma_is_one:
             self.set_gamma(param_dict["gamma"])
 
-    def get_issm_params(self, features) -> Dict[str, Any]:
+    def get_issm_params(self, features) -> dict[str, Any]:
         """
         Given feature matrix X, returns ISSM parameters which configure the
         likelihood: alpha, beta vectors (size n), gamma scalar.
@@ -132,7 +132,7 @@ class IndependentISSModelParameters(ISSModelParameters):
         beta = encode_unwrap_parameter(self.beta_internal, self.beta_encoding)
         return anp.reshape(beta, (1,))[0]
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         _params = super().get_params()
         return dict(_params, alpha=self.get_alpha(), beta=self.get_beta())
 
@@ -142,12 +142,12 @@ class IndependentISSModelParameters(ISSModelParameters):
     def set_beta(self, val):
         self.beta_encoding.set(self.beta_internal, val)
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         super().set_params(param_dict)
         self.set_alpha(param_dict["alpha"])
         self.set_beta(param_dict["beta"])
 
-    def get_issm_params(self, features) -> Dict[str, Any]:
+    def get_issm_params(self, features) -> dict[str, Any]:
         n = getval(features.shape[0])
         one_vec = anp.ones((n,))
         return {

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/posterior_state.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/posterior_state.py
@@ -1,7 +1,7 @@
 import numpy as np
 import autograd.numpy as anp
 from autograd import grad
-from typing import Tuple, Dict, List, Optional, Any
+from typing import Any
 from numpy.random import RandomState
 import logging
 
@@ -74,7 +74,7 @@ class GaussProcAdditivePosteriorState(PosteriorState):
 
     def __init__(
         self,
-        data: Optional[dict],
+        data: dict | None,
         mean: MeanFunction,
         kernel: KernelFunction,
         noise_variance,
@@ -117,7 +117,7 @@ class GaussProcAdditivePosteriorState(PosteriorState):
     def num_fantasies(self):
         return self.poster_state["pmat"].shape[1]
 
-    def _compute_posterior_state(self, data: Dict[str, Any], noise_variance, **kwargs):
+    def _compute_posterior_state(self, data: dict[str, Any], noise_variance, **kwargs):
         raise NotImplementedError()
 
     def neg_log_likelihood(self) -> anp.ndarray:
@@ -126,7 +126,7 @@ class GaussProcAdditivePosteriorState(PosteriorState):
         ), "neg_log_likelihood not defined for fantasizing posterior state"
         return self.poster_state["criterion"]
 
-    def predict(self, test_features: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def predict(self, test_features: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         """
         We compute marginals over f(x, r), where ``test_features`` are extended
         features.
@@ -143,7 +143,7 @@ class GaussProcAdditivePosteriorState(PosteriorState):
         self,
         test_features: np.ndarray,
         num_samples: int = 1,
-        random_state: Optional[RandomState] = None,
+        random_state: RandomState | None = None,
     ) -> np.ndarray:
         """
         See comments of ``predict``.
@@ -167,7 +167,7 @@ class GaussProcAdditivePosteriorState(PosteriorState):
     def backward_gradient(
         self,
         input: np.ndarray,
-        head_gradients: Dict[str, np.ndarray],
+        head_gradients: dict[str, np.ndarray],
         mean_data: float,
         std_data: float,
     ) -> np.ndarray:
@@ -201,19 +201,19 @@ class GaussProcAdditivePosteriorState(PosteriorState):
 
     def _sample_curves_internal(
         self,
-        data: Dict[str, Any],
-        poster_state: Dict[str, Any],
+        data: dict[str, Any],
+        poster_state: dict[str, Any],
         num_samples: int = 1,
-        random_state: Optional[RandomState] = None,
-    ) -> List[dict]:
+        random_state: RandomState | None = None,
+    ) -> list[dict]:
         raise NotImplementedError()
 
     def sample_curves(
         self,
-        data: Dict[str, Any],
+        data: dict[str, Any],
         num_samples: int = 1,
-        random_state: Optional[RandomState] = None,
-    ) -> List[dict]:
+        random_state: RandomState | None = None,
+    ) -> list[dict]:
         """
         Given data from one or more configurations (as returned by
         ``issm.prepare_data``), for each config, sample a curve from the
@@ -244,7 +244,7 @@ class GaussProcAdditivePosteriorState(PosteriorState):
         )
 
     @staticmethod
-    def has_precomputations(data: Dict[str, Any]) -> bool:
+    def has_precomputations(data: dict[str, Any]) -> bool:
         raise NotImplementedError()
 
 
@@ -259,7 +259,7 @@ class IncrementalUpdateGPAdditivePosteriorState(GaussProcAdditivePosteriorState)
 
     def __init__(
         self,
-        data: Optional[dict],
+        data: dict | None,
         mean: MeanFunction,
         kernel: KernelFunction,
         noise_variance,
@@ -269,7 +269,7 @@ class IncrementalUpdateGPAdditivePosteriorState(GaussProcAdditivePosteriorState)
 
     def _prepare_update(
         self, feature: np.ndarray, targets: np.ndarray
-    ) -> Tuple[float, float, float]:
+    ) -> tuple[float, float, float]:
         """
         Helper method for ``update``. Returns new entries for d, s, r2 vectors.
 
@@ -281,7 +281,7 @@ class IncrementalUpdateGPAdditivePosteriorState(GaussProcAdditivePosteriorState)
 
     def _update_internal(
         self, feature: np.ndarray, targets: np.ndarray
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Update posterior state, given a single new datapoint. ``feature``,
         ``targets`` are like one entry of ``data``. The method returns a new
@@ -330,7 +330,7 @@ class IncrementalUpdateGPAdditivePosteriorState(GaussProcAdditivePosteriorState)
 
     def _sample_posterior_joint_for_config(
         self,
-        poster_state: Dict[str, Any],
+        poster_state: dict[str, Any],
         config: Configuration,
         feature: np.ndarray,
         targets: np.ndarray,
@@ -344,10 +344,10 @@ class IncrementalUpdateGPAdditivePosteriorState(GaussProcAdditivePosteriorState)
 
     def sample_and_update_for_pending(
         self,
-        data_pending: Dict[str, Any],
+        data_pending: dict[str, Any],
         sample_all_nonobserved: bool = False,
-        random_state: Optional[RandomState] = None,
-    ) -> (List[np.ndarray], "IncrementalUpdateGPAdditivePosteriorState"):
+        random_state: RandomState | None = None,
+    ) -> (list[np.ndarray], "IncrementalUpdateGPAdditivePosteriorState"):
         """
         This function is needed for sampling fantasy targets, and also to
         support simulation-based scoring.
@@ -415,7 +415,7 @@ class GaussProcISSMPosteriorState(IncrementalUpdateGPAdditivePosteriorState):
 
     def __init__(
         self,
-        data: Optional[dict],
+        data: dict | None,
         mean: MeanFunction,
         kernel: KernelFunction,
         iss_model: ISSModelParameters,
@@ -436,10 +436,10 @@ class GaussProcISSMPosteriorState(IncrementalUpdateGPAdditivePosteriorState):
         super().__init__(data, mean, kernel, noise_variance=noise_variance, **kwargs)
 
     @staticmethod
-    def has_precomputations(data: Dict[str, Any]) -> bool:
+    def has_precomputations(data: dict[str, Any]) -> bool:
         return all(k in data for k in ("ydims", "num_configs", "deltay", "logr"))
 
-    def _compute_posterior_state(self, data: Dict[str, Any], noise_variance, **kwargs):
+    def _compute_posterior_state(self, data: dict[str, Any], noise_variance, **kwargs):
         # Compute posterior state
         issm_params = self.iss_model.get_issm_params(data["features"])
         if self.has_precomputations(data):
@@ -464,7 +464,7 @@ class GaussProcISSMPosteriorState(IncrementalUpdateGPAdditivePosteriorState):
             noise_variance=noise_variance,
         )
 
-    def predict(self, test_features: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def predict(self, test_features: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         resource_attr_range = (self.r_min, self.r_max)
         features, resources = decode_extended_features(
             test_features, resource_attr_range=resource_attr_range
@@ -482,7 +482,7 @@ class GaussProcISSMPosteriorState(IncrementalUpdateGPAdditivePosteriorState):
         )
 
     @staticmethod
-    def data_precomputations(data: Dict[str, Any]):
+    def data_precomputations(data: dict[str, Any]):
         logger.info("Enhancing data dictionary by precomputed variables")
         data.update(
             issm_likelihood_precomputations(
@@ -492,11 +492,11 @@ class GaussProcISSMPosteriorState(IncrementalUpdateGPAdditivePosteriorState):
 
     def _sample_curves_internal(
         self,
-        data: Dict[str, Any],
-        poster_state: Dict[str, Any],
+        data: dict[str, Any],
+        poster_state: dict[str, Any],
         num_samples: int = 1,
-        random_state: Optional[RandomState] = None,
-    ) -> List[dict]:
+        random_state: RandomState | None = None,
+    ) -> list[dict]:
         if random_state is None:
             random_state = np.random
         results = []
@@ -522,7 +522,7 @@ class GaussProcISSMPosteriorState(IncrementalUpdateGPAdditivePosteriorState):
 
     def _prepare_update(
         self, feature: np.ndarray, targets: np.ndarray
-    ) -> Tuple[float, float, float]:
+    ) -> tuple[float, float, float]:
         issm_params = self.iss_model.get_issm_params(feature.reshape((1, -1)))
         issm_likelihood = issm_likelihood_slow_computations(
             targets=[_colvec(targets, _np=np)],
@@ -561,7 +561,7 @@ class GaussProcExpDecayPosteriorState(IncrementalUpdateGPAdditivePosteriorState)
 
     def __init__(
         self,
-        data: Optional[dict],
+        data: dict | None,
         mean: MeanFunction,
         kernel: KernelFunction,
         res_kernel: ExponentialDecayBaseKernelFunction,
@@ -587,10 +587,10 @@ class GaussProcExpDecayPosteriorState(IncrementalUpdateGPAdditivePosteriorState)
         )
 
     @staticmethod
-    def has_precomputations(data: Dict[str, Any]) -> bool:
+    def has_precomputations(data: dict[str, Any]) -> bool:
         return all(k in data for k in ("ydims", "num_configs", "yflat"))
 
-    def _compute_posterior_state(self, data: Dict[str, Any], noise_variance, **kwargs):
+    def _compute_posterior_state(self, data: dict[str, Any], noise_variance, **kwargs):
         # Compute posterior state
         if self.has_precomputations(data):
             issm_likelihood = resource_kernel_likelihood_computations(
@@ -620,7 +620,7 @@ class GaussProcExpDecayPosteriorState(IncrementalUpdateGPAdditivePosteriorState)
         self.poster_state["means_all"] = issm_likelihood["means_all"]
         self.poster_state["noise_variance"] = noise_variance
 
-    def predict(self, test_features: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def predict(self, test_features: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         resource_attr_range = (self.r_min, self.r_max)
         features, resources = decode_extended_features(
             test_features, resource_attr_range=resource_attr_range
@@ -635,16 +635,16 @@ class GaussProcExpDecayPosteriorState(IncrementalUpdateGPAdditivePosteriorState)
         )
 
     @staticmethod
-    def data_precomputations(data: Dict[str, Any]):
+    def data_precomputations(data: dict[str, Any]):
         data.update(resource_kernel_likelihood_precomputations(targets=data["targets"]))
 
     def _sample_curves_internal(
         self,
-        data: Dict[str, Any],
-        poster_state: Dict[str, Any],
+        data: dict[str, Any],
+        poster_state: dict[str, Any],
         num_samples: int = 1,
-        random_state: Optional[RandomState] = None,
-    ) -> List[dict]:
+        random_state: RandomState | None = None,
+    ) -> list[dict]:
         assert "lfact_all" in poster_state
         if random_state is None:
             random_state = np.random
@@ -672,7 +672,7 @@ class GaussProcExpDecayPosteriorState(IncrementalUpdateGPAdditivePosteriorState)
 
     def _prepare_update(
         self, feature: np.ndarray, targets: np.ndarray
-    ) -> Tuple[float, float, float]:
+    ) -> tuple[float, float, float]:
         issm_likelihood = resource_kernel_likelihood_slow_computations(
             targets=[_colvec(targets, _np=np)],
             res_kernel=self.res_kernel,

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/likelihood.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/likelihood.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Tuple, Any
+from typing import Any
 import numpy as np
 import autograd.numpy as anp
 from numpy.random import RandomState
@@ -40,20 +40,20 @@ class MarginalLikelihood(Block):
     Interface for marginal likelihood of Gaussian-linear model.
     """
 
-    def get_posterior_state(self, data: Dict[str, Any]) -> PosteriorState:
+    def get_posterior_state(self, data: dict[str, Any]) -> PosteriorState:
         raise NotImplementedError
 
-    def forward(self, data: Dict[str, Any]):
+    def forward(self, data: dict[str, Any]):
         return self.get_posterior_state(data).neg_log_likelihood()
 
-    def param_encoding_pairs(self) -> List[tuple]:
+    def param_encoding_pairs(self) -> list[tuple]:
         """
         Return a list of tuples with the Gluon parameters of the likelihood
         and their respective encodings
         """
         raise NotImplementedError
 
-    def box_constraints_internal(self) -> Dict[str, Tuple[float, float]]:
+    def box_constraints_internal(self) -> dict[str, tuple[float, float]]:
         """
         :return: Box constraints for all the underlying parameters
         """
@@ -68,10 +68,10 @@ class MarginalLikelihood(Block):
     def get_noise_variance(self, as_ndarray=False):
         raise NotImplementedError
 
-    def get_params(self) -> Dict[str, np.ndarray]:
+    def get_params(self) -> dict[str, np.ndarray]:
         raise NotImplementedError
 
-    def set_params(self, param_dict: Dict[str, np.ndarray]):
+    def set_params(self, param_dict: dict[str, np.ndarray]):
         raise NotImplementedError
 
     def reset_params(self, random_state: RandomState):
@@ -85,7 +85,7 @@ class MarginalLikelihood(Block):
         # defaults to ``np.random.uniform``, whose seed we do not control).
         self.initialize(init=random_state.uniform, force_reinit=True)
 
-    def data_precomputations(self, data: Dict[str, Any], overwrite: bool = False):
+    def data_precomputations(self, data: dict[str, Any], overwrite: bool = False):
         """
         Some models require precomputations based on ``data``. Precomputed
         variables are appended to ``data``. This is done only if not already
@@ -96,7 +96,7 @@ class MarginalLikelihood(Block):
         """
         pass
 
-    def on_fit_start(self, data: Dict[str, Any]):
+    def on_fit_start(self, data: dict[str, Any]):
         """
         Called at the beginning of ``fit``.
 
@@ -123,8 +123,8 @@ class GaussianProcessMarginalLikelihood(MarginalLikelihood):
     def __init__(
         self,
         kernel: KernelFunction,
-        mean: Optional[MeanFunction] = None,
-        target_transform: Optional[ScalarTargetTransform] = None,
+        mean: MeanFunction | None = None,
+        target_transform: ScalarTargetTransform | None = None,
         initial_noise_variance=None,
         encoding_type=None,
         **kwargs,
@@ -160,7 +160,7 @@ class GaussianProcessMarginalLikelihood(MarginalLikelihood):
         )
 
     @staticmethod
-    def assert_data_entries(data: Dict[str, Any]):
+    def assert_data_entries(data: dict[str, Any]):
         features = data.get("features")
         targets = data.get("targets")
         assert (
@@ -175,7 +175,7 @@ class GaussianProcessMarginalLikelihood(MarginalLikelihood):
             + f"(received {features.shape[0]} and {targets.shape[0]})"
         )
 
-    def get_posterior_state(self, data: Dict[str, Any]) -> PosteriorState:
+    def get_posterior_state(self, data: dict[str, Any]) -> PosteriorState:
         self.assert_data_entries(data)
         targets = self.target_transform(data["targets"])
         return GaussProcPosteriorState(
@@ -186,21 +186,21 @@ class GaussianProcessMarginalLikelihood(MarginalLikelihood):
             noise_variance=self._noise_variance(),
         )
 
-    def forward(self, data: Dict[str, Any]):
+    def forward(self, data: dict[str, Any]):
         return self.get_posterior_state(
             data
         ).neg_log_likelihood() + self.target_transform.negative_log_jacobian(
             data["targets"]
         )
 
-    def _components(self) -> List[Tuple[str, MeanFunction]]:
+    def _components(self) -> list[tuple[str, MeanFunction]]:
         return [
             ("kernel_", self.kernel),
             ("mean_", self.mean),
             ("ytrans_", self.target_transform),
         ]
 
-    def param_encoding_pairs(self) -> List[tuple]:
+    def param_encoding_pairs(self) -> list[tuple]:
         _param_encoding_pairs = [(self.noise_variance_internal, self.encoding_noise)]
         for _, component in self._components():
             _param_encoding_pairs.extend(component.param_encoding_pairs())
@@ -213,13 +213,13 @@ class GaussianProcessMarginalLikelihood(MarginalLikelihood):
     def _set_noise_variance(self, val: float):
         self.encoding_noise.set(self.noise_variance_internal, val)
 
-    def get_params(self) -> Dict[str, np.ndarray]:
+    def get_params(self) -> dict[str, np.ndarray]:
         result = {"noise_variance": self.get_noise_variance()}
         for pref, func in self._components():
             result.update({(pref + k): v for k, v in func.get_params().items()})
         return result
 
-    def set_params(self, param_dict: Dict[str, np.ndarray]):
+    def set_params(self, param_dict: dict[str, np.ndarray]):
         for pref, func in self._components():
             len_pref = len(pref)
             stripped_dict = {
@@ -228,7 +228,7 @@ class GaussianProcessMarginalLikelihood(MarginalLikelihood):
             func.set_params(stripped_dict)
         self._set_noise_variance(param_dict["noise_variance"])
 
-    def on_fit_start(self, data: Dict[str, Any]):
+    def on_fit_start(self, data: dict[str, Any]):
         self.assert_data_entries(data)
         targets = data["targets"]
         assert (

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/mean.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/mean.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 import autograd.numpy as anp
 from autograd.tracer import getval
 
@@ -38,13 +38,13 @@ class MeanFunction(Block):
         """
         raise NotImplementedError
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         """
         :return: Dictionary with hyperparameter values
         """
         raise NotImplementedError
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         """
         :param param_dict: Dictionary with new hyperparameter values
         :return:
@@ -97,10 +97,10 @@ class ScalarMeanFunction(MeanFunction):
     def set_mean_value(self, mean_value):
         self.encoding.set(self.mean_value_internal, mean_value)
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return {"mean_value": self.get_mean_value()}
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         self.set_mean_value(param_dict["mean_value"])
 
 
@@ -114,8 +114,8 @@ class ZeroMeanFunction(MeanFunction):
     def param_encoding_pairs(self):
         return []
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return dict()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         pass

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/optimization_utils.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/optimization_utils.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 import numpy as np
 from scipy import optimize
 from autograd import value_and_grad
@@ -31,7 +31,7 @@ STARTING_POINT_RANDOMIZATION_STD = 1.0
 
 
 class ParamVecDictConverter:
-    def __init__(self, param_dict: Dict[str, Any]):
+    def __init__(self, param_dict: dict[str, Any]):
         self.param_dict = param_dict
         self.names = sorted(
             [name for name, value in param_dict.items() if value is not None]

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/posterior_state.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/posterior_state.py
@@ -2,7 +2,8 @@ import numpy as np
 import autograd.numpy as anp
 from autograd import grad
 from autograd.tracer import getval
-from typing import Tuple, Optional, Dict, Callable, Any
+from typing import Any
+from collections.abc import Callable
 from numpy.random import RandomState
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.kernel import (
@@ -46,7 +47,7 @@ class PosteriorState:
         """
         raise NotImplementedError
 
-    def predict(self, test_features: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def predict(self, test_features: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         """
         Computes marginal statistics (means, variances) for a number of test
         features.
@@ -60,7 +61,7 @@ class PosteriorState:
         self,
         test_features: np.ndarray,
         num_samples: int = 1,
-        random_state: Optional[RandomState] = None,
+        random_state: RandomState | None = None,
     ) -> np.ndarray:
         """
         See comments of ``predict``.
@@ -75,7 +76,7 @@ class PosteriorState:
     def backward_gradient(
         self,
         input: np.ndarray,
-        head_gradients: Dict[str, np.ndarray],
+        head_gradients: dict[str, np.ndarray],
         mean_data: float,
         std_data: float,
     ) -> np.ndarray:
@@ -98,7 +99,7 @@ class PosteriorStateWithSampleJoint(PosteriorState):
         self,
         test_features: np.ndarray,
         num_samples: int = 1,
-        random_state: Optional[RandomState] = None,
+        random_state: RandomState | None = None,
     ) -> np.ndarray:
         """
         See comments of ``predict``.
@@ -121,7 +122,7 @@ class GaussProcPosteriorState(PosteriorStateWithSampleJoint):
     def __init__(
         self,
         features: np.ndarray,
-        targets: Optional[np.ndarray],
+        targets: np.ndarray | None,
         mean: MeanFunction,
         kernel: KernelFunctionWithCovarianceScale,
         noise_variance: np.ndarray,
@@ -188,7 +189,7 @@ class GaussProcPosteriorState(PosteriorStateWithSampleJoint):
     def num_fantasies(self):
         return self.pred_mat.shape[1]
 
-    def _state_kwargs(self) -> Dict[str, Any]:
+    def _state_kwargs(self) -> dict[str, Any]:
         return {
             "features": self.features,
             "mean": self.mean,
@@ -204,7 +205,7 @@ class GaussProcPosteriorState(PosteriorStateWithSampleJoint):
         critval = negative_log_marginal_likelihood(self.chol_fact, self.pred_mat)
         return critval
 
-    def predict(self, test_features: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def predict(self, test_features: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         return predict_posterior_marginals(
             **self._state_kwargs(), test_features=test_features
         )
@@ -213,7 +214,7 @@ class GaussProcPosteriorState(PosteriorStateWithSampleJoint):
         self,
         test_features: np.ndarray,
         num_samples: int = 1,
-        random_state: Optional[RandomState] = None,
+        random_state: RandomState | None = None,
     ) -> np.ndarray:
         if random_state is None:
             random_state = np.random
@@ -227,7 +228,7 @@ class GaussProcPosteriorState(PosteriorStateWithSampleJoint):
     def backward_gradient(
         self,
         input: np.ndarray,
-        head_gradients: Dict[str, np.ndarray],
+        head_gradients: dict[str, np.ndarray],
         mean_data: float,
         std_data: float,
     ) -> np.ndarray:
@@ -262,7 +263,7 @@ class GaussProcPosteriorState(PosteriorStateWithSampleJoint):
         self,
         test_features: np.ndarray,
         num_samples: int = 1,
-        random_state: Optional[RandomState] = None,
+        random_state: RandomState | None = None,
     ) -> np.ndarray:
         if random_state is None:
             random_state = np.random
@@ -275,9 +276,9 @@ class GaussProcPosteriorState(PosteriorStateWithSampleJoint):
 
 
 def backward_gradient_given_predict(
-    predict_func: Callable[[np.ndarray], Tuple[np.ndarray, np.ndarray]],
+    predict_func: Callable[[np.ndarray], tuple[np.ndarray, np.ndarray]],
     input: np.ndarray,
-    head_gradients: Dict[str, np.ndarray],
+    head_gradients: dict[str, np.ndarray],
     mean_data: float,
     std_data: float,
 ) -> np.ndarray:
@@ -333,7 +334,7 @@ class IncrementalUpdateGPPosteriorState(GaussProcPosteriorState):
     def __init__(
         self,
         features: np.ndarray,
-        targets: Optional[np.ndarray],
+        targets: np.ndarray | None,
         mean: MeanFunction,
         kernel: KernelFunctionWithCovarianceScale,
         noise_variance: np.ndarray,
@@ -385,7 +386,7 @@ class IncrementalUpdateGPPosteriorState(GaussProcPosteriorState):
         self,
         feature: np.ndarray,
         mean_impute_mask=None,
-        random_state: Optional[RandomState] = None,
+        random_state: RandomState | None = None,
     ) -> (np.ndarray, "IncrementalUpdateGPPosteriorState"):
         """
         Draw target(s), shape (1, m), from current posterior state, then update

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/posterior_utils.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/posterior_utils.py
@@ -1,4 +1,3 @@
-from typing import Tuple, Union
 import autograd.numpy as anp
 import autograd.scipy.linalg as aspl
 import numpy as np
@@ -24,9 +23,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.kernel import 
 )
 
 
-KernelFunctionWithCovarianceScale = Union[
-    KernelFunction, Tuple[KernelFunction, np.ndarray]
-]
+KernelFunctionWithCovarianceScale = KernelFunction | tuple[KernelFunction, np.ndarray]
 
 
 def _extract_kernel_and_scale(kernel: KernelFunctionWithCovarianceScale):

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/slice.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/slice.py
@@ -1,4 +1,4 @@
-from typing import Callable, Tuple, List
+from collections.abc import Callable
 import numpy as np
 from numpy.random import RandomState
 
@@ -40,7 +40,7 @@ class SliceSampler:
 
     def sample(
         self, init_sample: np.ndarray, num_samples: int, burn: int, thin: int
-    ) -> List[np.ndarray]:
+    ) -> list[np.ndarray]:
         samples = []
         next_sample = init_sample
         for _ in range(num_samples):
@@ -60,7 +60,7 @@ def slice_sampler_step_out(
     scale: float,
     sliced_log_density: Callable[[float], float],
     random_state: RandomState,
-) -> Tuple[float, float]:
+) -> tuple[float, float]:
     r = random_state.rand()
     lower_bound = -r * scale
     upper_bound = lower_bound + scale

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/target_transform.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/target_transform.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 import autograd.numpy as anp
 from autograd.tracer import getval
 
@@ -70,10 +70,10 @@ class IdentityTargetTransform(ScalarTargetTransform):
     def param_encoding_pairs(self):
         return []
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return dict()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         pass
 
 
@@ -179,10 +179,10 @@ class BoxCoxTargetTransform(ScalarTargetTransform):
     def set_boxcox_lambda(self, boxcox_lambda):
         self.encoding.set(self.boxcox_lambda_internal, boxcox_lambda)
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return {BOXCOX_LAMBDA_NAME: self.get_boxcox_lambda()}
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         if not self._boxcox_lambda_fixed:
             self.set_boxcox_lambda(param_dict[BOXCOX_LAMBDA_NAME])
 

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/warping.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/warping.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, List, Dict, Any
+from typing import Any
 import autograd.numpy as anp
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.constants import (
@@ -58,7 +58,7 @@ class Warping(MeanFunction):
     def __init__(
         self,
         dimension: int,
-        coordinate_range: Optional[Tuple[int, int]] = None,
+        coordinate_range: tuple[int, int] | None = None,
         encoding_type: str = DEFAULT_ENCODING,
         **kwargs,
     ):
@@ -143,7 +143,7 @@ class Warping(MeanFunction):
         else:
             return f"power_{kind}_{index}"
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         size = self.upper - self.lower
         just_one = size == 1
         param_dict = dict()
@@ -157,7 +157,7 @@ class Warping(MeanFunction):
             )
         return param_dict
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         size = self.upper - self.lower
         just_one = size == 1
         for kind in ("a", "b"):
@@ -171,7 +171,7 @@ class Warping(MeanFunction):
             self.encoding.set(warping_int, warping)
 
 
-def warpings_for_hyperparameters(hp_ranges: HyperparameterRanges) -> List[Warping]:
+def warpings_for_hyperparameters(hp_ranges: HyperparameterRanges) -> list[Warping]:
     """
     It is custom to warp hyperparameters which are not categorical. This
     function creates warpings based on your configuration space.
@@ -245,7 +245,7 @@ class WarpedKernel(KernelFunction):
         checked.
     """
 
-    def __init__(self, kernel: KernelFunction, warpings: List[Warping], **kwargs):
+    def __init__(self, kernel: KernelFunction, warpings: list[Warping], **kwargs):
         super().__init__(kernel.dimension, **kwargs)
         num_warpings = len(warpings)
         assert num_warpings > 0
@@ -291,14 +291,14 @@ class WarpedKernel(KernelFunction):
             x for warping in self.warpings for x in warping.param_encoding_pairs()
         ]
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         result = dict()
         blocks = [self.kernel] + self.warpings
         for pref, block in zip(self._prefixes, blocks):
             result.update({(pref + k): v for k, v in block.get_params().items()})
         return result
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         blocks = [self.kernel] + self.warpings
         for pref, block in zip(self._prefixes, blocks):
             len_pref = len(pref)

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost/cost_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost/cost_model.py
@@ -1,4 +1,3 @@
-from typing import List
 from dataclasses import dataclass
 
 from syne_tune.optimizer.schedulers.searchers.utils.common import Configuration
@@ -80,7 +79,7 @@ class CostModel:
         """
         pass
 
-    def sample_joint(self, candidates: List[Configuration]) -> List[CostValue]:
+    def sample_joint(self, candidates: list[Configuration]) -> list[CostValue]:
         """
         Draws cost values :math:`(c_0(x), c_1(x))` for candidates (non-extended).
 
@@ -120,11 +119,11 @@ class CostModel:
 
     def predict_times(
         self,
-        candidates: List[Configuration],
-        resources: List[int],
-        cost_values: List[CostValue],
+        candidates: list[Configuration],
+        resources: list[int],
+        cost_values: list[CostValue],
         start_time: float = 0,
-    ) -> List[float]:
+    ) -> list[float]:
         """
         Given configs :math:`x`, resource values :math:`r` and cost values returned
         by :meth:`sample_joint`, compute time predictions for when each config

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost/linear_cost_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost/linear_cost_model.py
@@ -1,4 +1,4 @@
-from typing import List, Callable, Optional, Dict, Tuple
+from collections.abc import Callable
 import numpy as np
 from sklearn.linear_model import RidgeCV
 from enum import IntEnum
@@ -50,7 +50,7 @@ class LinearCostModel(CostModel):
         return INTERNAL_COST_NAME
 
     def feature_matrices(
-        self, candidates: List[Configuration]
+        self, candidates: list[Configuration]
     ) -> (np.ndarray, np.ndarray):
         """
         Has to be supplied by subclasses
@@ -107,7 +107,7 @@ class LinearCostModel(CostModel):
         self.weights1 = predictor.coef_[dim0:].reshape((-1, 1))
         self.alpha = predictor.alpha_
 
-    def sample_joint(self, candidates: List[Configuration]) -> List[CostValue]:
+    def sample_joint(self, candidates: list[Configuration]) -> list[CostValue]:
         assert self.weights0 is not None, "Must call 'update' before 'sample_joint'"
         features0, features1 = self.feature_matrices(candidates)
         c0_vals = np.matmul(features0, self.weights0).reshape((-1,))
@@ -124,7 +124,7 @@ class BiasOnlyLinearCostModel(LinearCostModel):
         super().__init__()
 
     def feature_matrices(
-        self, candidates: List[Configuration]
+        self, candidates: list[Configuration]
     ) -> (np.ndarray, np.ndarray):
         one_feats = np.ones((len(candidates), 1))
         return one_feats, one_feats
@@ -170,10 +170,10 @@ class MLPLinearCostModel(LinearCostModel):
         num_hidden_layers: Callable[[dict], int],
         hidden_layer_width: Callable[[dict, int], int],
         batch_size: Callable[[dict], int],
-        bs_exponent: Optional[float] = None,
+        bs_exponent: float | None = None,
         extra_mlp: bool = False,
         c0_mlp_feature: bool = False,
-        expected_hidden_layer_width: Optional[Callable[[int], float]] = None,
+        expected_hidden_layer_width: Callable[[int], float] | None = None,
     ):
         super().__init__()
         self.num_inputs = num_inputs
@@ -190,7 +190,7 @@ class MLPLinearCostModel(LinearCostModel):
         self.expected_hidden_layer_width = expected_hidden_layer_width
 
     def feature_matrices(
-        self, candidates: List[Configuration]
+        self, candidates: list[Configuration]
     ) -> (np.ndarray, np.ndarray):
         features1_1 = []
         features1_2 = []
@@ -251,11 +251,11 @@ class FixedLayersMLPCostModel(MLPLinearCostModel):
         self,
         num_inputs: int,
         num_outputs: int,
-        num_units_keys: List[str] = None,
-        bs_exponent: Optional[float] = None,
+        num_units_keys: list[str] = None,
+        bs_exponent: float | None = None,
         extra_mlp: bool = False,
         c0_mlp_feature: bool = False,
-        expected_hidden_layer_width: Optional[Callable[[int], float]] = None,
+        expected_hidden_layer_width: Callable[[int], float] | None = None,
     ):
         if num_units_keys is None:
             num_units_keys = ["n_units_1", "n_units_2"]
@@ -277,7 +277,7 @@ class FixedLayersMLPCostModel(MLPLinearCostModel):
         )
 
     @staticmethod
-    def get_expected_hidden_layer_width(config_space: Dict, num_units_keys: List[str]):
+    def get_expected_hidden_layer_width(config_space: dict, num_units_keys: list[str]):
         """
         Constructs expected_hidden_layer_width function from the training
         evaluation function.
@@ -330,8 +330,8 @@ class NASBench201LinearCostModel(LinearCostModel):
 
     def __init__(
         self,
-        config_keys: Tuple[str, ...],
-        map_config_values: Dict[str, int],
+        config_keys: tuple[str, ...],
+        map_config_values: dict[str, int],
         conv_separate_features: bool,
         count_sum: bool,
     ):
@@ -341,11 +341,11 @@ class NASBench201LinearCostModel(LinearCostModel):
         self.conv_separate_features = conv_separate_features
         self.count_sum = count_sum
 
-    def _translate(self, config: Configuration) -> List[int]:
+    def _translate(self, config: Configuration) -> list[int]:
         return [self._map_config_values[config[name]] for name in self._config_keys]
 
     def feature_matrices(
-        self, candidates: List[Configuration]
+        self, candidates: list[Configuration]
     ) -> (np.ndarray, np.ndarray):
         features1_1 = []
         features1_2 = []

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost/sklearn_cost_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost/sklearn_cost_model.py
@@ -1,4 +1,5 @@
-from typing import List, Tuple, Callable, Optional, Dict, Any
+from typing import Any
+from collections.abc import Callable
 import numpy as np
 
 try:
@@ -46,8 +47,8 @@ class NonLinearCostModel(CostModel):
         return INTERNAL_COST_NAME
 
     def transform_dataset(
-        self, dataset: List[Tuple[Configuration, float]], num_data0: int, res_min: int
-    ) -> Dict[str, Any]:
+        self, dataset: list[tuple[Configuration, float]], num_data0: int, res_min: int
+    ) -> dict[str, Any]:
         """
         Transforms dataset (see :meth:`_data_for_c1_regression`) into a dataset
         representation (dict), which is used as ``kwargs`` in :meth:`fit_regressor`.
@@ -72,7 +73,7 @@ class NonLinearCostModel(CostModel):
         """
         raise NotImplementedError
 
-    def predict_c1_values(self, candidates: List[Configuration]):
+    def predict_c1_values(self, candidates: list[Configuration]):
         """
         :param candidates: Test configs
         :return: Corresponding ``c1`` values
@@ -120,7 +121,7 @@ class NonLinearCostModel(CostModel):
                     pass
         _, self.b0, self.regr_model = best[0]
 
-    def sample_joint(self, candidates: List[Configuration]) -> List[CostValue]:
+    def sample_joint(self, candidates: list[Configuration]) -> list[CostValue]:
         assert self.b0 is not None, "Must call 'update' before 'sample_joint'"
         c1_vals = self.predict_c1_values(candidates)
         c0_vals = np.full(len(c1_vals), self.b0)
@@ -175,7 +176,7 @@ class ScikitLearnCostModel(NonLinearCostModel):
     :param model_type: Regression model for ``c1(x)``
     """
 
-    def __init__(self, model_type: Optional[str] = None):
+    def __init__(self, model_type: str | None = None):
         if model_type is None:
             model_type = "random_forest"
         else:
@@ -188,8 +189,8 @@ class ScikitLearnCostModel(NonLinearCostModel):
         self.model_type = model_type
 
     def transform_dataset(
-        self, dataset: List[Tuple[Configuration, float]], num_data0: int, res_min: int
-    ) -> Dict[str, Any]:
+        self, dataset: list[tuple[Configuration, float]], num_data0: int, res_min: int
+    ) -> dict[str, Any]:
         num_hps = len(self.hp_ranges)
         num_data = len(dataset)
         features = np.zeros((num_data, num_hps))
@@ -225,7 +226,7 @@ class ScikitLearnCostModel(NonLinearCostModel):
         crit_val = (np.sum(resvec) + b0 * num_data0 / res_min) / res_min
         return crit_val, model
 
-    def predict_c1_values(self, candidates: List[Configuration]):
+    def predict_c1_values(self, candidates: list[Configuration]):
         features1 = self.hp_ranges.to_ndarray_matrix(candidates, categ_onehot=False)
         c1_vals = self.regr_model.predict(features1).reshape((-1,))
         return c1_vals
@@ -248,7 +249,7 @@ class UnivariateSplineCostModel(NonLinearCostModel):
     def __init__(
         self,
         scalar_attribute: Callable[[Configuration], float],
-        input_range: Tuple[float, float],
+        input_range: tuple[float, float],
         spline_degree: int = 3,
     ):
         """
@@ -268,8 +269,8 @@ class UnivariateSplineCostModel(NonLinearCostModel):
         self.spline_degree = spline_degree
 
     def transform_dataset(
-        self, dataset: List[Tuple[Configuration, float]], num_data0: int, res_min: int
-    ) -> Dict[str, Any]:
+        self, dataset: list[tuple[Configuration, float]], num_data0: int, res_min: int
+    ) -> dict[str, Any]:
         # We combine duplicates in the second part of the dataset
         config_lst, target_lst = zip(*dataset[:num_data0])
         config_lst = list(config_lst)
@@ -348,7 +349,7 @@ class UnivariateSplineCostModel(NonLinearCostModel):
         crit_val = (np.sum(resvec) + b0 * num_data0 / res_min) / res_min
         return crit_val, model
 
-    def predict_c1_values(self, candidates: List[Configuration]):
+    def predict_c1_values(self, candidates: list[Configuration]):
         features1 = np.array([self.scalar_attribute(config) for config in candidates])
         c1_vals = self.regr_model(features1).reshape((-1,))
         return c1_vals

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost_fifo_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost_fifo_model.py
@@ -1,4 +1,3 @@
-from typing import Dict, List, Set
 import numpy as np
 import logging
 
@@ -55,10 +54,10 @@ class CostFixedResourcePredictor(BasePredictor):
         self._num_samples = num_samples
 
     @staticmethod
-    def keys_predict() -> Set[str]:
+    def keys_predict() -> set[str]:
         return {"mean"}
 
-    def predict(self, inputs: np.ndarray) -> List[Dict[str, np.ndarray]]:
+    def predict(self, inputs: np.ndarray) -> list[dict[str, np.ndarray]]:
         # Inputs are encoded. For cost models, need to decode them back
         # to candidates (not necessarily differentiable)
         # Note: Both ``inputs`` and ``hp_ranges`` may correspond to extended
@@ -84,20 +83,20 @@ class CostFixedResourcePredictor(BasePredictor):
         return [{"mean": np.mean(prediction_list, axis=0)}]
 
     def backward_gradient(
-        self, input: np.ndarray, head_gradients: List[Dict[str, np.ndarray]]
-    ) -> List[np.ndarray]:
+        self, input: np.ndarray, head_gradients: list[dict[str, np.ndarray]]
+    ) -> list[np.ndarray]:
         """
         The gradient contribution through the cost model is blocked.
 
         """
         return [np.zeros_like(input)]
 
-    def predict_mean_current_candidates(self) -> List[np.ndarray]:
+    def predict_mean_current_candidates(self) -> list[np.ndarray]:
         raise NotImplementedError()
 
     # We currently do not support cost models for the primary metric to be
     # optimized
-    def current_best(self) -> List[np.ndarray]:
+    def current_best(self) -> list[np.ndarray]:
         raise NotImplementedError()
 
 

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/estimator.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/estimator.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, Any, Optional, Union
+from typing import Any
 
 import numpy as np
 
@@ -31,13 +31,13 @@ class Estimator:
     can be accessed with :meth:`get_params`, :meth:`set_params`.
     """
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         """
         :return: Current tunable model parameters
         """
         raise NotImplementedError()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         """
         :param param_dict: New model parameters
         """
@@ -69,7 +69,7 @@ class Estimator:
         raise NotImplementedError()
 
     @property
-    def debug_log(self) -> Optional[DebugLogPrinter]:
+    def debug_log(self) -> DebugLogPrinter | None:
         return None
 
     def configure_scheduler(self, scheduler):
@@ -87,7 +87,7 @@ class Estimator:
 # that work both in the standard case of a single output model and in the
 # multi-output case
 
-OutputEstimator = Union[Estimator, Dict[str, Estimator]]
+OutputEstimator = Estimator | dict[str, Estimator]
 
 
 @dataclass
@@ -100,7 +100,7 @@ class TransformedData:
 
 def transform_state_to_data(
     state: TuningJobState,
-    active_metric: Optional[str] = None,
+    active_metric: str | None = None,
     normalize_targets: bool = True,
     num_fantasy_samples: int = 1,
 ) -> TransformedData:

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/gp_mcmc_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/gp_mcmc_model.py
@@ -1,4 +1,3 @@
-from typing import Optional
 import logging
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.gpr_mcmc import (
@@ -41,9 +40,9 @@ class GaussProcMCMCEstimator(GaussProcEstimator):
         gpmodel: GPRegressionMCMC,
         active_metric: str = INTERNAL_METRIC_NAME,
         normalize_targets: bool = True,
-        debug_log: Optional[DebugLogPrinter] = None,
-        filter_observed_data: Optional[ConfigurationFilter] = None,
-        hp_ranges_for_prediction: Optional[HyperparameterRanges] = None,
+        debug_log: DebugLogPrinter | None = None,
+        filter_observed_data: ConfigurationFilter | None = None,
+        hp_ranges_for_prediction: HyperparameterRanges | None = None,
     ):
         super().__init__(
             gpmodel=gpmodel,

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/gp_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/gp_model.py
@@ -45,8 +45,13 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.debug_log import (
 logger = logging.getLogger(__name__)
 
 
-GPModel = GaussianProcessRegression | GPRegressionMCMC | IndependentGPPerResourceModel | HyperTuneIndependentGPModel | HyperTuneJointGPModel
-
+GPModel = (
+    GaussianProcessRegression
+    | GPRegressionMCMC
+    | IndependentGPPerResourceModel
+    | HyperTuneIndependentGPModel
+    | HyperTuneJointGPModel
+)
 
 
 class GaussProcPredictor(BasePredictor):

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/gp_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/gp_model.py
@@ -1,4 +1,3 @@
-from typing import Dict, List, Optional, Union
 import numpy as np
 import logging
 
@@ -46,13 +45,8 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.debug_log import (
 logger = logging.getLogger(__name__)
 
 
-GPModel = Union[
-    GaussianProcessRegression,
-    GPRegressionMCMC,
-    IndependentGPPerResourceModel,
-    HyperTuneIndependentGPModel,
-    HyperTuneJointGPModel,
-]
+GPModel = GaussianProcessRegression | GPRegressionMCMC | IndependentGPPerResourceModel | HyperTuneIndependentGPModel | HyperTuneJointGPModel
+
 
 
 class GaussProcPredictor(BasePredictor):
@@ -85,12 +79,12 @@ class GaussProcPredictor(BasePredictor):
         self,
         state: TuningJobState,
         gpmodel: GPModel,
-        fantasy_samples: List[FantasizedPendingEvaluation],
+        fantasy_samples: list[FantasizedPendingEvaluation],
         active_metric: str = None,
         normalize_mean: float = 0.0,
         normalize_std: float = 1.0,
-        filter_observed_data: Optional[ConfigurationFilter] = None,
-        hp_ranges_for_prediction: Optional[HyperparameterRanges] = None,
+        filter_observed_data: ConfigurationFilter | None = None,
+        hp_ranges_for_prediction: HyperparameterRanges | None = None,
     ):
         super().__init__(state, active_metric, filter_observed_data)
         self._gpmodel = gpmodel
@@ -105,7 +99,7 @@ class GaussProcPredictor(BasePredictor):
         else:
             return super().hp_ranges_for_prediction()
 
-    def predict(self, inputs: np.ndarray) -> List[Dict[str, np.ndarray]]:
+    def predict(self, inputs: np.ndarray) -> list[dict[str, np.ndarray]]:
         predictions_list = []
         for post_mean, post_variance in self._gpmodel.predict(inputs):
             assert post_mean.shape[0] == inputs.shape[0], (
@@ -123,8 +117,8 @@ class GaussProcPredictor(BasePredictor):
         return predictions_list
 
     def backward_gradient(
-        self, input: np.ndarray, head_gradients: List[Dict[str, np.ndarray]]
-    ) -> List[np.ndarray]:
+        self, input: np.ndarray, head_gradients: list[dict[str, np.ndarray]]
+    ) -> list[np.ndarray]:
         poster_states = self.posterior_states
         assert (
             poster_states is not None
@@ -148,7 +142,7 @@ class GaussProcPredictor(BasePredictor):
         return isinstance(self._gpmodel, GPRegressionMCMC)
 
     @property
-    def posterior_states(self) -> Optional[List[PosteriorState]]:
+    def posterior_states(self) -> list[PosteriorState] | None:
         return self._gpmodel.states
 
     def _current_best_filter_candidates(self, candidates):
@@ -187,10 +181,10 @@ class GaussProcEstimator(Estimator):
         gpmodel: GPModel,
         active_metric: str,
         normalize_targets: bool = True,
-        debug_log: Optional[DebugLogPrinter] = None,
-        filter_observed_data: Optional[ConfigurationFilter] = None,
+        debug_log: DebugLogPrinter | None = None,
+        filter_observed_data: ConfigurationFilter | None = None,
         no_fantasizing: bool = False,
-        hp_ranges_for_prediction: Optional[HyperparameterRanges] = None,
+        hp_ranges_for_prediction: HyperparameterRanges | None = None,
     ):
         self._gpmodel = gpmodel
         self.active_metric = active_metric
@@ -203,7 +197,7 @@ class GaussProcEstimator(Estimator):
         self._std = None
 
     @property
-    def debug_log(self) -> Optional[DebugLogPrinter]:
+    def debug_log(self) -> DebugLogPrinter | None:
         return self._debug_log
 
     @property
@@ -398,10 +392,10 @@ class GaussProcEmpiricalBayesEstimator(GaussProcEstimator):
         num_fantasy_samples: int,
         active_metric: str = INTERNAL_METRIC_NAME,
         normalize_targets: bool = True,
-        debug_log: Optional[DebugLogPrinter] = None,
-        filter_observed_data: Optional[ConfigurationFilter] = None,
+        debug_log: DebugLogPrinter | None = None,
+        filter_observed_data: ConfigurationFilter | None = None,
         no_fantasizing: bool = False,
-        hp_ranges_for_prediction: Optional[HyperparameterRanges] = None,
+        hp_ranges_for_prediction: HyperparameterRanges | None = None,
     ):
         assert num_fantasy_samples > 0
         super().__init__(

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/gpiss_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/gpiss_model.py
@@ -1,4 +1,3 @@
-from typing import Dict, List, Optional
 import numpy as np
 import logging
 
@@ -63,9 +62,9 @@ class GaussProcAdditivePredictor(BasePredictor):
         self,
         state: TuningJobState,
         gpmodel: GaussianProcessLearningCurveModel,
-        fantasy_samples: List[FantasizedPendingEvaluation],
+        fantasy_samples: list[FantasizedPendingEvaluation],
         active_metric: str,
-        filter_observed_data: Optional[ConfigurationFilter] = None,
+        filter_observed_data: ConfigurationFilter | None = None,
         normalize_mean: float = 0.0,
         normalize_std: float = 1.0,
     ):
@@ -75,7 +74,7 @@ class GaussProcAdditivePredictor(BasePredictor):
         self.std = normalize_std
         self.fantasy_samples = fantasy_samples
 
-    def predict(self, inputs: np.ndarray) -> List[Dict[str, np.ndarray]]:
+    def predict(self, inputs: np.ndarray) -> list[dict[str, np.ndarray]]:
         """
         Input features ``inputs`` are w.r.t. extended configs ``(x, r)``.
 
@@ -99,8 +98,8 @@ class GaussProcAdditivePredictor(BasePredictor):
         return predictions_list
 
     def backward_gradient(
-        self, input: np.ndarray, head_gradients: List[Dict[str, np.ndarray]]
-    ) -> List[np.ndarray]:
+        self, input: np.ndarray, head_gradients: list[dict[str, np.ndarray]]
+    ) -> list[np.ndarray]:
         poster_states = self.posterior_states
         assert (
             poster_states is not None
@@ -124,7 +123,7 @@ class GaussProcAdditivePredictor(BasePredictor):
         return False
 
     @property
-    def posterior_states(self) -> Optional[List[GaussProcAdditivePosteriorState]]:
+    def posterior_states(self) -> list[GaussProcAdditivePosteriorState] | None:
         return self._gpmodel.states
 
 
@@ -152,8 +151,8 @@ class GaussProcAdditiveEstimator(Estimator):
         active_metric: str,
         config_space_ext: ExtendedConfiguration,
         normalize_targets: bool = False,
-        debug_log: Optional[DebugLogPrinter] = None,
-        filter_observed_data: Optional[ConfigurationFilter] = None,
+        debug_log: DebugLogPrinter | None = None,
+        filter_observed_data: ConfigurationFilter | None = None,
     ):
         self._gpmodel = gpmodel
         self.active_metric = active_metric
@@ -171,7 +170,7 @@ class GaussProcAdditiveEstimator(Estimator):
         self.normalize_targets = normalize_targets
 
     @property
-    def debug_log(self) -> Optional[DebugLogPrinter]:
+    def debug_log(self) -> DebugLogPrinter | None:
         return self._debug_log
 
     def get_params(self):
@@ -243,7 +242,7 @@ class GaussProcAdditiveEstimator(Estimator):
         )
 
     def predictor_for_fantasy_samples(
-        self, state: TuningJobState, fantasy_samples: List[FantasizedPendingEvaluation]
+        self, state: TuningJobState, fantasy_samples: list[FantasizedPendingEvaluation]
     ) -> Predictor:
         """
         Same as ``model`` with ``fit_params=False``, but ``fantasy_samples`` are

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/meanstd_acqfunc_impl.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/meanstd_acqfunc_impl.py
@@ -1,4 +1,3 @@
-from typing import Dict, Optional, Set, List, Tuple
 import logging
 import itertools
 
@@ -90,7 +89,7 @@ class EIAcquisitionFunction(MeanStdAcquisitionFunction):
     def _compute_head(
         self,
         output_to_predictions: SamplePredictionsPerOutput,
-        current_best: Optional[np.ndarray],
+        current_best: np.ndarray | None,
     ) -> np.ndarray:
         assert current_best is not None
         means, stds = self._extract_mean_and_std(output_to_predictions)
@@ -102,7 +101,7 @@ class EIAcquisitionFunction(MeanStdAcquisitionFunction):
     def _compute_head_and_gradient(
         self,
         output_to_predictions: SamplePredictionsPerOutput,
-        current_best: Optional[np.ndarray],
+        current_best: np.ndarray | None,
     ) -> HeadWithGradient:
         assert current_best is not None
         mean, std = self._extract_mean_and_std(output_to_predictions)
@@ -168,7 +167,7 @@ class LCBAcquisitionFunction(MeanStdAcquisitionFunction):
     def _compute_head(
         self,
         output_to_predictions: SamplePredictionsPerOutput,
-        current_best: Optional[np.ndarray],
+        current_best: np.ndarray | None,
     ) -> np.ndarray:
         means, stds = self._extract_mean_and_std(output_to_predictions)
         return np.mean(means - stds * self.kappa, axis=1)
@@ -176,7 +175,7 @@ class LCBAcquisitionFunction(MeanStdAcquisitionFunction):
     def _compute_head_and_gradient(
         self,
         output_to_predictions: SamplePredictionsPerOutput,
-        current_best: Optional[np.ndarray],
+        current_best: np.ndarray | None,
     ) -> HeadWithGradient:
         mean, std = self._extract_mean_and_std(output_to_predictions)
         nf_mean = mean.size
@@ -224,7 +223,7 @@ class EIpuAcquisitionFunction(MeanStdAcquisitionFunction):
     def __init__(
         self,
         predictor: OutputPredictor,
-        active_metric: Optional[str] = None,
+        active_metric: str | None = None,
         exponent_cost: float = 1.0,
         jitter: float = 0.01,
     ):
@@ -241,7 +240,7 @@ class EIpuAcquisitionFunction(MeanStdAcquisitionFunction):
     def _head_needs_current_best(self) -> bool:
         return True
 
-    def _output_to_keys_predict(self) -> Dict[str, Set[str]]:
+    def _output_to_keys_predict(self) -> dict[str, set[str]]:
         """
         The cost model may be deterministic, as the acquisition function
         only needs the mean.
@@ -254,7 +253,7 @@ class EIpuAcquisitionFunction(MeanStdAcquisitionFunction):
     def _compute_head(
         self,
         output_to_predictions: SamplePredictionsPerOutput,
-        current_best: Optional[np.ndarray],
+        current_best: np.ndarray | None,
     ) -> np.ndarray:
         """
         Returns minus the cost-aware expected improvement.
@@ -271,7 +270,7 @@ class EIpuAcquisitionFunction(MeanStdAcquisitionFunction):
     def _compute_head_and_gradient(
         self,
         output_to_predictions: SamplePredictionsPerOutput,
-        current_best: Optional[np.ndarray],
+        current_best: np.ndarray | None,
     ) -> HeadWithGradient:
         """
         Returns minus cost-aware expected improvement and, for each output
@@ -321,7 +320,7 @@ class ConstraintCurrentBestProvider(CurrentBestProvider):
     Here, ``current_best`` depends on two predictors, for active and constraint metric.
     """
 
-    def __init__(self, current_best_list: List[np.ndarray], num_samples_active: int):
+    def __init__(self, current_best_list: list[np.ndarray], num_samples_active: int):
         list_size = len(current_best_list)
         assert list_size > 0 and list_size % num_samples_active == 0
         self._active_and_constraint_current_best = [
@@ -329,7 +328,7 @@ class ConstraintCurrentBestProvider(CurrentBestProvider):
         ]
         self._num_samples_active = num_samples_active
 
-    def __call__(self, positions: Tuple[int, ...]) -> Optional[np.ndarray]:
+    def __call__(self, positions: tuple[int, ...]) -> np.ndarray | None:
         flat_pos = positions[1] * self._num_samples_active + positions[0]
         return self._active_and_constraint_current_best[flat_pos]
 
@@ -372,7 +371,7 @@ class CEIAcquisitionFunction(MeanStdAcquisitionFunction):
     def __init__(
         self,
         predictor: OutputPredictor,
-        active_metric: Optional[str] = None,
+        active_metric: str | None = None,
         jitter: float = 0.01,
     ):
         super().__init__(predictor, active_metric)
@@ -391,7 +390,7 @@ class CEIAcquisitionFunction(MeanStdAcquisitionFunction):
     def _compute_head(
         self,
         output_to_predictions: SamplePredictionsPerOutput,
-        current_best: Optional[np.ndarray],
+        current_best: np.ndarray | None,
     ) -> np.ndarray:
         """
         Returns minus the legacy_constrained expected improvement (- CEI).
@@ -418,7 +417,7 @@ class CEIAcquisitionFunction(MeanStdAcquisitionFunction):
     def _compute_head_and_gradient(
         self,
         output_to_predictions: SamplePredictionsPerOutput,
-        current_best: Optional[np.ndarray],
+        current_best: np.ndarray | None,
     ) -> HeadWithGradient:
         """
         Returns minus cost-aware expected improvement (- CEI) and, for each output predictor, the gradients

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/model_base.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/model_base.py
@@ -1,4 +1,3 @@
-from typing import List, Optional
 import numpy as np
 import logging
 
@@ -23,24 +22,24 @@ class BasePredictor(Predictor):
     def __init__(
         self,
         state: TuningJobState,
-        active_metric: Optional[str] = None,
-        filter_observed_data: Optional[ConfigurationFilter] = None,
+        active_metric: str | None = None,
+        filter_observed_data: ConfigurationFilter | None = None,
     ):
         super().__init__(state, active_metric)
         self._current_best = None
         self._filter_observed_data = filter_observed_data
 
     @property
-    def filter_observed_data(self) -> Optional[ConfigurationFilter]:
+    def filter_observed_data(self) -> ConfigurationFilter | None:
         return self._filter_observed_data
 
     def set_filter_observed_data(
-        self, filter_observed_data: Optional[ConfigurationFilter]
+        self, filter_observed_data: ConfigurationFilter | None
     ):
         self._filter_observed_data = filter_observed_data
         self._current_best = None
 
-    def predict_mean_current_candidates(self) -> List[np.ndarray]:
+    def predict_mean_current_candidates(self) -> list[np.ndarray]:
         """
         Returns the predictive mean (signal with key 'mean') at all current candidates
         in the state (observed, pending).
@@ -68,7 +67,7 @@ class BasePredictor(Predictor):
             all_means.append(means)
         return all_means
 
-    def current_best(self) -> List[np.ndarray]:
+    def current_best(self) -> list[np.ndarray]:
         if self._current_best is None:
             all_means = self.predict_mean_current_candidates()
             result = [np.min(means, axis=0) for means in all_means]

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/model_skipopt.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/model_skipopt.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.tuning_job_state import (
     TuningJobState,
@@ -130,7 +130,7 @@ class SkipNoMaxResourcePredicate(SkipOptimizationPredicate):
         self.lastrec_max_resource_cases = None
 
     def _num_max_resource_cases(self, state: TuningJobState):
-        def is_max_resource(metrics: Dict[str, Any]) -> int:
+        def is_max_resource(metrics: dict[str, Any]) -> int:
             return int(self.max_resource in metrics[self.metric_name])
 
         return sum(is_max_resource(ev.metrics) for ev in state.trials_evaluations)

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/model_transformer.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/model_transformer.py
@@ -39,8 +39,9 @@ def _assert_same_keys(dict1, dict2):
 # that work both in the standard case of a single output model and in the
 # multi-output case
 
-SkipOptimizationOutputPredicate = SkipOptimizationPredicate | dict[str, SkipOptimizationPredicate]
-
+SkipOptimizationOutputPredicate = (
+    SkipOptimizationPredicate | dict[str, SkipOptimizationPredicate]
+)
 
 
 class StateForModelConverter:
@@ -273,9 +274,7 @@ class ModelStateTransformer:
             )
             del metric_vals[key]
 
-    def label_trial(
-        self, data: TrialEvaluations, config: Configuration | None = None
-    ):
+    def label_trial(self, data: TrialEvaluations, config: Configuration | None = None):
         """
         Adds observed data for a trial. If it has observations in the state
         already, ``data.metrics`` are appended. Otherwise, a new entry is

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/model_transformer.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/model_transformer.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Callable, Union
+from collections.abc import Callable
 import logging
 import copy
 
@@ -39,9 +39,8 @@ def _assert_same_keys(dict1, dict2):
 # that work both in the standard case of a single output model and in the
 # multi-output case
 
-SkipOptimizationOutputPredicate = Union[
-    SkipOptimizationPredicate, Dict[str, SkipOptimizationPredicate]
-]
+SkipOptimizationOutputPredicate = SkipOptimizationPredicate | dict[str, SkipOptimizationPredicate]
+
 
 
 class StateForModelConverter:
@@ -108,8 +107,8 @@ class ModelStateTransformer:
         self,
         estimator: OutputEstimator,
         init_state: TuningJobState,
-        skip_optimization: Optional[SkipOptimizationOutputPredicate] = None,
-        state_converter: Optional[StateForModelConverter] = None,
+        skip_optimization: SkipOptimizationOutputPredicate | None = None,
+        state_converter: StateForModelConverter | None = None,
     ):
         self._use_single_model = False
         if isinstance(estimator, Estimator):
@@ -118,7 +117,7 @@ class ModelStateTransformer:
             assert isinstance(estimator, dict), (
                 f"{estimator} is not an instance of Estimator. "
                 f"It is assumed that we are in the multi-output case and that it "
-                f"must be a Dict. No other types are supported. "
+                f"must be a dict. No other types are supported. "
             )
             # Default: Always refit model parameters for each output model
             if skip_optimization is None:
@@ -127,8 +126,8 @@ class ModelStateTransformer:
                     for output_name in estimator.keys()
                 }
             else:
-                assert isinstance(skip_optimization, Dict), (
-                    f"{skip_optimization} must be a Dict, consistently "
+                assert isinstance(skip_optimization, dict), (
+                    f"{skip_optimization} must be a dict, consistently "
                     f"with {estimator}."
                 )
                 _assert_same_keys(estimator, skip_optimization)
@@ -155,7 +154,7 @@ class ModelStateTransformer:
         self._state_converter = state_converter
         self._state = copy.copy(init_state)
         # OutputPredictor computed on demand
-        self._predictor: Optional[OutputPredictor] = None
+        self._predictor: OutputPredictor | None = None
         # Observed data for which model parameters were re-fit most
         # recently, separately for each model
         self._num_evaluations = {output_name: 0 for output_name in estimator.keys()}
@@ -214,8 +213,8 @@ class ModelStateTransformer:
     def append_trial(
         self,
         trial_id: str,
-        config: Optional[Configuration] = None,
-        resource: Optional[int] = None,
+        config: Configuration | None = None,
+        resource: int | None = None,
     ):
         """
         Appends new pending evaluation to the state.
@@ -230,7 +229,7 @@ class ModelStateTransformer:
         self._state.append_pending(trial_id, config=config, resource=resource)
 
     def drop_pending_evaluation(
-        self, trial_id: str, resource: Optional[int] = None
+        self, trial_id: str, resource: int | None = None
     ) -> bool:
         """
         Drop pending evaluation from state. If it is not listed as pending,
@@ -247,7 +246,7 @@ class ModelStateTransformer:
         self,
         trial_id: str,
         metric_name: str = INTERNAL_METRIC_NAME,
-        key: Optional[str] = None,
+        key: str | None = None,
     ):
         """
         Removes specific observation from the state.
@@ -275,7 +274,7 @@ class ModelStateTransformer:
             del metric_vals[key]
 
     def label_trial(
-        self, data: TrialEvaluations, config: Optional[Configuration] = None
+        self, data: TrialEvaluations, config: Configuration | None = None
     ):
         """
         Adds observed data for a trial. If it has observations in the state

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/sklearn_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/sklearn_model.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional, List
+from typing import Any
 
 import numpy as np
 
@@ -31,18 +31,18 @@ class SKLearnPredictorWrapper(BasePredictor):
         self,
         sklearn_predictor: SKLearnPredictor,
         state: TuningJobState,
-        active_metric: Optional[str] = None,
+        active_metric: str | None = None,
     ):
         super().__init__(state, active_metric)
         self.sklearn_predictor = sklearn_predictor
 
-    def predict(self, inputs: np.ndarray) -> List[Dict[str, np.ndarray]]:
+    def predict(self, inputs: np.ndarray) -> list[dict[str, np.ndarray]]:
         means, stddevs = self.sklearn_predictor.predict(X=inputs)
         return [{"mean": means, "std": stddevs}]
 
     def backward_gradient(
-        self, input: np.ndarray, head_gradients: List[Dict[str, np.ndarray]]
-    ) -> List[np.ndarray]:
+        self, input: np.ndarray, head_gradients: list[dict[str, np.ndarray]]
+    ) -> list[np.ndarray]:
         r"""
         Computes the gradient :math:`\nabla f(x)` for an acquisition
         function :math:`f(x)`, where :math:`x` is a single input point. This
@@ -81,10 +81,10 @@ class SKLearnEstimatorWrapper(Estimator):
         self.sklearn_estimator = sklearn_estimator
         self.target_metric = active_metric
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         return self.sklearn_estimator.get_params()
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         self.sklearn_estimator.set_params(param_dict)
 
     def fit_from_state(self, state: TuningJobState, update_params: bool) -> Predictor:

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/subsample_state_multi_fidelity.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/subsample_state_multi_fidelity.py
@@ -1,4 +1,3 @@
-from typing import Optional, List, Tuple
 import copy
 from numpy.random import RandomState
 from operator import itemgetter
@@ -19,11 +18,11 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.models.model_transformer 
 from syne_tune.util import is_positive_integer
 
 
-ObservedData = List[Tuple[int, int, float]]
+ObservedData = list[tuple[int, int, float]]
 
 
 def _extract_observations(
-    trials_evaluations: List[TrialEvaluations],
+    trials_evaluations: list[TrialEvaluations],
 ) -> ObservedData:
     """
     Maps ``trials_evaluations`` to list of tuples :math:`(i, r, y_{i r})`, where
@@ -45,7 +44,7 @@ def _extract_observations(
     return all_data
 
 
-def _create_trials_evaluations(data: ObservedData) -> List[TrialEvaluations]:
+def _create_trials_evaluations(data: ObservedData) -> list[TrialEvaluations]:
     """Inverse of :func:`_extract_observations`
 
     :param data: List of tuples
@@ -67,7 +66,7 @@ def _create_trials_evaluations(data: ObservedData) -> List[TrialEvaluations]:
 def cap_size_tuning_job_state(
     state: TuningJobState,
     max_size: int,
-    random_state: Optional[RandomState] = None,
+    random_state: RandomState | None = None,
 ) -> TuningJobState:
     """
     Returns state which is identical to ``state``, except that the
@@ -148,7 +147,7 @@ class SubsampleMultiFidelityStateConverter(StateForModelConverter):
     few trials. Use :class:`SubsampleMFDenseDataStateConverter` in such a case.
     """
 
-    def __init__(self, max_size: int, random_state: Optional[RandomState] = None):
+    def __init__(self, max_size: int, random_state: RandomState | None = None):
         self.max_size = int(max_size)
         assert self.max_size >= 1
         self._random_state = random_state
@@ -166,7 +165,7 @@ class SubsampleMultiFidelityStateConverter(StateForModelConverter):
 
 
 def _sparsify_at_most_one_per_trial_and_group(
-    data: ObservedData, max_size: int, rung_levels: List[int]
+    data: ObservedData, max_size: int, rung_levels: list[int]
 ) -> ObservedData:
     r"""
     Define groups :math:`G_j = \{r_j + 1,\dots, r_j\}`, where math:`[r_j]` is
@@ -277,9 +276,9 @@ class SubsampleMFDenseDataStateConverter(SubsampleMultiFidelityStateConverter):
     def __init__(
         self,
         max_size: int,
-        grace_period: Optional[int] = None,
-        reduction_factor: Optional[float] = None,
-        random_state: Optional[RandomState] = None,
+        grace_period: int | None = None,
+        reduction_factor: float | None = None,
+        random_state: RandomState | None = None,
     ):
         super().__init__(max_size, random_state)
         if grace_period is None:

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/subsample_state_single_fidelity.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/subsample_state_single_fidelity.py
@@ -1,4 +1,3 @@
-from typing import Optional, List, Tuple
 import copy
 from numpy.random import RandomState
 from operator import itemgetter
@@ -15,11 +14,11 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.models.model_transformer 
 )
 
 
-ObservedData = List[Tuple[int, float]]
+ObservedData = list[tuple[int, float]]
 
 
 def _extract_observations(
-    trials_evaluations: List[TrialEvaluations],
+    trials_evaluations: list[TrialEvaluations],
 ) -> ObservedData:
     """
     Maps ``trials_evaluations`` to list of tuples :math:`(i, y_i)`, where
@@ -34,7 +33,7 @@ def _extract_observations(
     ]
 
 
-def _create_trials_evaluations(data: ObservedData) -> List[TrialEvaluations]:
+def _create_trials_evaluations(data: ObservedData) -> list[TrialEvaluations]:
     """Inverse of :func:`_extract_observations`
 
     :param data: List of tuples
@@ -53,7 +52,7 @@ def cap_size_tuning_job_state(
     max_size: int,
     mode: str,
     top_fraction: float,
-    random_state: Optional[RandomState] = None,
+    random_state: RandomState | None = None,
 ) -> TuningJobState:
     """
     Returns state which is identical to ``state``, except that the
@@ -113,7 +112,7 @@ class SubsampleSingleFidelityStateConverter(StateForModelConverter):
         max_size: int,
         mode: str,
         top_fraction: float,
-        random_state: Optional[RandomState] = None,
+        random_state: RandomState | None = None,
     ):
         support_mode = ["min", "max"]
         assert (

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/sklearn/estimator.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/sklearn/estimator.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 import numpy as np
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.sklearn.predictor import (
@@ -28,13 +28,13 @@ class SKLearnEstimator:
         """
         raise NotImplementedError
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> dict[str, Any]:
         """
         :return: Current model hyperparameters
         """
         return dict()  # Default (estimator has no hyperparameters)
 
-    def set_params(self, param_dict: Dict[str, Any]):
+    def set_params(self, param_dict: dict[str, Any]):
         """
         :param param_dict: New model hyperparameters
         """

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/sklearn/predictor.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/sklearn/predictor.py
@@ -1,5 +1,3 @@
-from typing import Tuple, Dict
-
 import numpy as np
 
 
@@ -11,7 +9,7 @@ class SKLearnPredictor:
     This is only for predictors who return means and stddevs in :meth:`predict`.
     """
 
-    def predict(self, X: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def predict(self, X: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         """
         Returns signals which are statistics of the predictive distribution at
         input points ``inputs``.
@@ -23,7 +21,7 @@ class SKLearnPredictor:
         raise NotImplementedError
 
     def backward_gradient(
-        self, input: np.ndarray, head_gradients: Dict[str, np.ndarray]
+        self, input: np.ndarray, head_gradients: dict[str, np.ndarray]
     ) -> np.ndarray:
         r"""
         Needs to be implemented only if gradient-based local optimization of

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/base_classes.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/base_classes.py
@@ -1,15 +1,5 @@
-from typing import (
-    List,
-    Iterable,
-    Tuple,
-    Optional,
-    Set,
-    Dict,
-    Union,
-    Iterator,
-    Callable,
-    Any,
-)
+from typing import Any
+from collections.abc import Iterable,Iterator, Callable
 import numpy as np
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common import (
@@ -49,7 +39,7 @@ def assign_active_metric(predictor, active_metric):
 
 
 class NextCandidatesAlgorithm:
-    def next_candidates(self) -> List[Configuration]:
+    def next_candidates(self) -> list[Configuration]:
         raise NotImplementedError
 
 
@@ -66,13 +56,13 @@ class Predictor:
     :param active_metric: Name of internal objective
     """
 
-    def __init__(self, state: TuningJobState, active_metric: Optional[str] = None):
+    def __init__(self, state: TuningJobState, active_metric: str | None = None):
         self.state = state
         if active_metric is None:
             active_metric = INTERNAL_METRIC_NAME
         self.active_metric = active_metric
 
-    def keys_predict(self) -> Set[str]:
+    def keys_predict(self) -> set[str]:
         """Keys of signals returned by :meth:`predict`.
 
         Note: In order to work with :class:`AcquisitionFunction` implementations,
@@ -85,7 +75,7 @@ class Predictor:
         """
         return {"mean", "std"}
 
-    def predict(self, inputs: np.ndarray) -> List[Dict[str, np.ndarray]]:
+    def predict(self, inputs: np.ndarray) -> list[dict[str, np.ndarray]]:
         """
         Returns signals which are statistics of the predictive distribution at
         input points ``inputs``. By default:
@@ -114,7 +104,7 @@ class Predictor:
 
     def predict_candidates(
         self, candidates: Iterable[Configuration]
-    ) -> List[Dict[str, np.ndarray]]:
+    ) -> list[dict[str, np.ndarray]]:
         """Convenience variant of :meth:`predict`
 
         :param candidates: List of configurations
@@ -124,7 +114,7 @@ class Predictor:
             self.hp_ranges_for_prediction().to_ndarray_matrix(candidates)
         )
 
-    def current_best(self) -> List[np.ndarray]:
+    def current_best(self) -> list[np.ndarray]:
         """
         Returns the so-called incumbent, to be used in acquisition functions
         such as expected improvement. This is the minimum of predictive means
@@ -144,8 +134,8 @@ class Predictor:
         raise NotImplementedError
 
     def backward_gradient(
-        self, input: np.ndarray, head_gradients: List[Dict[str, np.ndarray]]
-    ) -> List[np.ndarray]:
+        self, input: np.ndarray, head_gradients: list[dict[str, np.ndarray]]
+    ) -> list[np.ndarray]:
         r"""
         Computes the gradient :math:`\nabla_x f(x)` for an acquisition
         function :math:`f(x)`, where :math:`x` is a single input point. This
@@ -169,7 +159,7 @@ class Predictor:
 # This is needed for multi-output BO methods such as legacy_constrained BO, where each output
 # is associated to a predictor. This type includes the Union with the standard
 # Predictor type for backward compatibility.
-OutputPredictor = Union[Predictor, Dict[str, Predictor]]
+OutputPredictor = Predictor | dict[str, Predictor]
 
 
 class ScoringFunction:
@@ -179,7 +169,7 @@ class ScoringFunction:
     """
 
     def __init__(
-        self, predictor: OutputPredictor = None, active_metric: Optional[str] = None
+        self, predictor: OutputPredictor = None, active_metric: str | None = None
     ):
         self.predictor = predictor
         if active_metric is None:
@@ -189,8 +179,8 @@ class ScoringFunction:
     def score(
         self,
         candidates: Iterable[Configuration],
-        predictor: Optional[OutputPredictor] = None,
-    ) -> List[float]:
+        predictor: OutputPredictor | None = None,
+    ) -> list[float]:
         """
         :param candidates: Configurations for which scores are to be computed
         :param predictor: Overrides default  predictor
@@ -208,7 +198,7 @@ class AcquisitionFunction(ScoringFunction):
     """
 
     def compute_acq(
-        self, inputs: np.ndarray, predictor: Optional[OutputPredictor] = None
+        self, inputs: np.ndarray, predictor: OutputPredictor | None = None
     ) -> np.ndarray:
         """
         Note: If inputs has shape ``(d,)``, it is taken to be ``(1, d)``
@@ -220,8 +210,8 @@ class AcquisitionFunction(ScoringFunction):
         raise NotImplementedError
 
     def compute_acq_with_gradient(
-        self, input: np.ndarray, predictor: Optional[OutputPredictor] = None
-    ) -> Tuple[float, np.ndarray]:
+        self, input: np.ndarray, predictor: OutputPredictor | None = None
+    ) -> tuple[float, np.ndarray]:
         r"""
         For a single input point :math:`x`, compute acquisition function value
         :math:`f(x)` and gradient :math:`\nabla_x f(x)`.
@@ -235,8 +225,8 @@ class AcquisitionFunction(ScoringFunction):
     def score(
         self,
         candidates: Iterable[Configuration],
-        predictor: Optional[OutputPredictor] = None,
-    ) -> List[float]:
+        predictor: OutputPredictor | None = None,
+    ) -> list[float]:
         if predictor is None:
             predictor = self.predictor
         if isinstance(predictor, dict):
@@ -276,7 +266,7 @@ class LocalOptimizer:
         hp_ranges: HyperparameterRanges,
         predictor: OutputPredictor,
         acquisition_class: AcquisitionFunctionConstructor,
-        active_metric: Optional[str] = None,
+        active_metric: str | None = None,
     ):
         self.hp_ranges = hp_ranges
         self.predictor = predictor
@@ -289,7 +279,7 @@ class LocalOptimizer:
         self.acquisition_class = acquisition_class
 
     def optimize(
-        self, candidate: Configuration, predictor: Optional[OutputPredictor] = None
+        self, candidate: Configuration, predictor: OutputPredictor | None = None
     ) -> Configuration:
         """Run local optimization, starting from ``candidate``
 
@@ -311,8 +301,8 @@ class CandidateGenerator:
         raise NotImplementedError
 
     def generate_candidates_en_bulk(
-        self, num_cands: int, exclusion_list: Optional[ExclusionList] = None
-    ) -> List[Configuration]:
+        self, num_cands: int, exclusion_list: ExclusionList | None = None
+    ) -> list[Configuration]:
         """
         :param num_cands: Number of candidates to generate
         :param exclusion_list: If given, these candidates must not be returned

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/base_classes.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/base_classes.py
@@ -1,5 +1,5 @@
 from typing import Any
-from collections.abc import Iterable,Iterator, Callable
+from collections.abc import Iterable, Iterator, Callable
 import numpy as np
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common import (

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/bo_algorithm.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/bo_algorithm.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Iterator, Optional
+from collections.abc import Iterator
 import logging
 from dataclasses import dataclass
 import numpy as np
@@ -88,21 +88,21 @@ class BayesianOptimizationAlgorithm(NextCandidatesAlgorithm):
     initial_candidates_scorer: ScoringFunction
     num_initial_candidates: int
     local_optimizer: LocalOptimizer
-    pending_candidate_state_transformer: Optional[ModelStateTransformer]
+    pending_candidate_state_transformer: ModelStateTransformer | None
     exclusion_candidates: ExclusionList
     num_requested_candidates: int
     greedy_batch_selection: bool
     duplicate_detector: DuplicateDetector
-    num_initial_candidates_for_batch: Optional[int] = None
+    num_initial_candidates_for_batch: int | None = None
     sample_unique_candidates: bool = False
-    debug_log: Optional[DebugLogPrinter] = None
+    debug_log: DebugLogPrinter | None = None
 
     # Note: For greedy batch selection (num_outer_iterations > 1), the
     # underlying ``Predictor`` changes with each new pending candidate. The
     # model changes are managed by ``pending_candidate_state_transformer``. The
     # model has to be passed to both ``initial_candidates_scorer`` and
     # ``local_optimizer``.
-    def next_candidates(self) -> List[Configuration]:
+    def next_candidates(self) -> list[Configuration]:
         if self.greedy_batch_selection:
             # Select batch greedily, one candidate at a time, updating the
             # model in between
@@ -193,8 +193,8 @@ class BayesianOptimizationAlgorithm(NextCandidatesAlgorithm):
     def _get_next_candidates(
         self,
         num_candidates: int,
-        predictor: Optional[Predictor],
-        num_initial_candidates: Optional[int] = None,
+        predictor: Predictor | None,
+        num_initial_candidates: int | None = None,
     ):
         if num_initial_candidates is None:
             num_initial_candidates = self.num_initial_candidates
@@ -265,9 +265,9 @@ class BayesianOptimizationAlgorithm(NextCandidatesAlgorithm):
 
 
 def _order_candidates(
-    candidates: List[Configuration],
+    candidates: list[Configuration],
     scoring_function: ScoringFunction,
-    predictor: Optional[Predictor],
+    predictor: Predictor | None,
     with_scores: bool = False,
 ):
     if len(candidates) == 0:
@@ -282,11 +282,11 @@ def _order_candidates(
 
 
 def _lazily_locally_optimize(
-    candidates: List[Configuration],
+    candidates: list[Configuration],
     local_optimizer: LocalOptimizer,
     hp_ranges: HyperparameterRanges,
-    predictor: Optional[Predictor],
-) -> Iterator[Tuple[Configuration, Configuration]]:
+    predictor: Predictor | None,
+) -> Iterator[tuple[Configuration, Configuration]]:
     """
     Due to local deduplication we do not know in advance how many candidates
     we have to locally optimize, hence this helper to create a lazy generator
@@ -305,11 +305,11 @@ def _lazily_locally_optimize(
 # principle arise if ``sample_unique_candidates == False``. This does not work
 # if ``duplicate_detector`` is of type :class:`DuplicateDetectorNoDetection`.
 def _pick_from_locally_optimized(
-    candidates_with_optimization: Iterator[Tuple[Configuration, Configuration]],
+    candidates_with_optimization: Iterator[tuple[Configuration, Configuration]],
     exclusion_candidates: ExclusionList,
     num_candidates: int,
     duplicate_detector: DuplicateDetector,
-) -> List[Configuration]:
+) -> list[Configuration]:
     updated_excludelist = exclusion_candidates.copy()
     result = []
     for original_candidate, optimized_candidate in candidates_with_optimization:

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/bo_algorithm_components.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/bo_algorithm_components.py
@@ -1,4 +1,4 @@
-from typing import Iterable, List, Optional, Iterator
+from collections.abc import Iterable, Iterator
 import numpy as np
 from scipy.optimize import fmin_l_bfgs_b
 import logging
@@ -36,8 +36,8 @@ class IndependentThompsonSampling(ScoringFunction):
     def __init__(
         self,
         predictor: OutputPredictor = None,
-        active_metric: Optional[str] = None,
-        random_state: Optional[RandomState] = None,
+        active_metric: str | None = None,
+        random_state: RandomState | None = None,
     ):
         super().__init__(predictor, active_metric)
         if random_state is None:
@@ -47,8 +47,8 @@ class IndependentThompsonSampling(ScoringFunction):
     def score(
         self,
         candidates: Iterable[Configuration],
-        predictor: Optional[Predictor] = None,
-    ) -> List[float]:
+        predictor: Predictor | None = None,
+    ) -> list[float]:
         if predictor is None:
             predictor = self.predictor
         predictions_list = predictor.predict_candidates(candidates)
@@ -80,7 +80,7 @@ class LBFGSOptimizeAcquisition(LocalOptimizer):
         self.num_evaluations = None
 
     def optimize(
-        self, candidate: Configuration, predictor: Optional[OutputPredictor] = None
+        self, candidate: Configuration, predictor: OutputPredictor | None = None
     ) -> Configuration:
         # Before local minimization, the model for this state_id should have been fitted.
         if predictor is None:
@@ -129,7 +129,7 @@ class NoOptimization(LocalOptimizer):
         pass
 
     def optimize(
-        self, candidate: Configuration, predictor: Optional[Predictor] = None
+        self, candidate: Configuration, predictor: Predictor | None = None
     ) -> Configuration:
         return candidate
 
@@ -159,7 +159,7 @@ class RandomStatefulCandidateGenerator(CandidateGenerator):
 
     def generate_candidates_en_bulk(
         self, num_cands: int, exclusion_list=None
-    ) -> List[Configuration]:
+    ) -> list[Configuration]:
         if exclusion_list is None:
             return self.hp_ranges.random_configs(self.random_state, num_cands)
         else:
@@ -198,7 +198,7 @@ def generate_unique_candidates(
     candidates_generator: CandidateGenerator,
     num_candidates: int,
     exclusion_candidates: ExclusionList,
-) -> List[Configuration]:
+) -> list[Configuration]:
     exclusion_candidates = exclusion_candidates.copy()  # Copy
     result = []
     num_results = 0
@@ -249,9 +249,9 @@ class RandomFromSetCandidateGenerator(CandidateGenerator):
 
     def __init__(
         self,
-        base_set: List[Configuration],
+        base_set: list[Configuration],
         random_state: np.random.RandomState,
-        ext_config: Optional[Configuration] = None,
+        ext_config: Configuration | None = None,
     ):
         self.random_state = random_state
         self.base_set = base_set
@@ -267,7 +267,7 @@ class RandomFromSetCandidateGenerator(CandidateGenerator):
             config = self._extend_configs([self.base_set[pos]])[0]
             yield config
 
-    def _extend_configs(self, configs: List[Configuration]) -> List[Configuration]:
+    def _extend_configs(self, configs: list[Configuration]) -> list[Configuration]:
         if self._ext_config is None:
             return configs
         else:
@@ -275,7 +275,7 @@ class RandomFromSetCandidateGenerator(CandidateGenerator):
 
     def generate_candidates_en_bulk(
         self, num_cands: int, exclusion_list=None
-    ) -> List[Configuration]:
+    ) -> list[Configuration]:
         if num_cands >= self.num_base:
             if exclusion_list is None:
                 configs = self.base_set.copy()

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/utils/comparison_gpy.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/utils/comparison_gpy.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any
+from typing import Any
 import numpy as np
 import copy
 
@@ -98,7 +98,7 @@ def evaluate_blackbox(bb_func, inputs: np.ndarray) -> np.ndarray:
 # blackbox are done. This avoids silly errors.
 def sample_data(
     bb_cls, num_train: int, num_grid: int, expand_datadct: bool = True
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     bb_func = bb_cls()
     ss_limits = bb_func.search_space
     num_dims = len(ss_limits)
@@ -126,7 +126,7 @@ def sample_data(
     return data
 
 
-def expand_data(data: Dict[str, Any]) -> Dict[str, Any]:
+def expand_data(data: dict[str, Any]) -> dict[str, Any]:
     """
     Appends derived entries to data dict, which have non-elementary types.
     """
@@ -147,7 +147,7 @@ def expand_data(data: Dict[str, Any]) -> Dict[str, Any]:
 
 # Recall that inputs in data are encoded, so we have to decode them to their
 # native ranges for ``trials_evaluations``
-def data_to_state(data: Dict[str, Any]) -> TuningJobState:
+def data_to_state(data: dict[str, Any]) -> TuningJobState:
     configs, cs = decode_inputs(data["train_inputs"], data["ss_limits"])
     config_for_trial = {
         str(trial_id): config for trial_id, config in enumerate(configs)
@@ -163,7 +163,7 @@ def data_to_state(data: Dict[str, Any]) -> TuningJobState:
     )
 
 
-def decode_inputs(inputs: np.ndarray, ss_limits) -> (List[Configuration], Dict):
+def decode_inputs(inputs: np.ndarray, ss_limits) -> (list[Configuration], dict):
     cs_names = [f"x{i}" for i in range(len(ss_limits))]
     cs = {
         name: uniform(lower=lims["min"], upper=lims["max"])

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/utils/debug_log.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/utils/debug_log.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any
+from typing import Any
 import logging
 import numpy as np
 
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 __all__ = ["DebugLogPrinter"]
 
 
-def _param_dict_to_str(params: Dict[str, Any]) -> str:
+def _param_dict_to_str(params: dict[str, Any]) -> str:
     parts = []
     for name, param in params.items():
         if isinstance(param, float):
@@ -62,7 +62,7 @@ class DebugLogPrinter:
         msg = "\n".join(entries)
         self.block_info["final_config"] = msg
 
-    def _observed_trial_ids(self, state: TuningJobState) -> List[str]:
+    def _observed_trial_ids(self, state: TuningJobState) -> list[str]:
         trial_ids = []
         for ev in state.trials_evaluations:
             trial_id = ev.trial_id
@@ -75,7 +75,7 @@ class DebugLogPrinter:
                     trial_ids.append(trial_id)
         return trial_ids
 
-    def _pending_trial_ids(self, state: TuningJobState) -> List[str]:
+    def _pending_trial_ids(self, state: TuningJobState) -> list[str]:
         trial_ids = []
         for ev in state.pending_evaluations:
             trial_id = ev.trial_id
@@ -100,7 +100,7 @@ class DebugLogPrinter:
         msg = "Targets: " + str(targets.reshape((-1,)))
         self.block_info["targets"] = msg
 
-    def set_model_params(self, params: Dict[str, Any]):
+    def set_model_params(self, params: dict[str, Any]):
         assert self.get_config_type == "BO", "Need to be in 'BO' block"
         msg = "Model params: " + _param_dict_to_str(params)
         self.block_info["params"] = msg

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/utils/test_objects.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/utils/test_objects.py
@@ -4,7 +4,7 @@
 Object definitions that are used for testing.
 """
 
-from typing import Iterator, Tuple, Dict, List, Optional, Union
+from collections.abc import Iterator
 import numpy as np
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common import (
@@ -134,8 +134,8 @@ class Quadratic3d:
 
 
 def tuples_to_configs(
-    config_tpls: List[Tuple[Hyperparameter, ...]], hp_ranges: HyperparameterRanges
-) -> List[Configuration]:
+    config_tpls: list[tuple[Hyperparameter, ...]], hp_ranges: HyperparameterRanges
+) -> list[Configuration]:
     """
     Many unit tests write configs as tuples.
 
@@ -155,15 +155,15 @@ def create_exclusion_set(
     return ExclusionList(hp_ranges=hp_ranges, configurations=candidates_tpl)
 
 
-TupleOrDict = Union[tuple, dict]
+TupleOrDict = tuple | dict
 
 
 def create_tuning_job_state(
     hp_ranges: HyperparameterRanges,
-    cand_tuples: List[TupleOrDict],
-    metrics: List[Dict],
-    pending_tuples: Optional[List[TupleOrDict]] = None,
-    failed_tuples: Optional[List[TupleOrDict]] = None,
+    cand_tuples: list[TupleOrDict],
+    metrics: list[dict],
+    pending_tuples: list[TupleOrDict] | None = None,
+    failed_tuples: list[TupleOrDict] | None = None,
 ) -> TuningJobState:
     """
     Builds ``TuningJobState`` from basics, where configs are given as tuples or

--- a/syne_tune/optimizer/schedulers/searchers/bore/bore.py
+++ b/syne_tune/optimizer/schedulers/searchers/bore/bore.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any
+from typing import Any
 import time
 import xgboost
 import logging
@@ -58,17 +58,17 @@ class Bore(SingleObjectiveBaseSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        points_to_evaluate: Optional[List[Dict[str, Any]]] = None,
+        config_space: dict[str, Any],
+        points_to_evaluate: list[dict[str, Any]] | None = None,
         random_seed: int = None,
-        gamma: Optional[float] = 0.25,
-        calibrate: Optional[bool] = False,
-        classifier: Optional[str] = "xgboost",
-        acq_optimizer: Optional[str] = "rs",
-        feval_acq: Optional[int] = 500,
-        random_prob: Optional[float] = 0.0,
-        init_random: Optional[int] = 6,
-        classifier_kwargs: Optional[dict] = None,
+        gamma: float | None = 0.25,
+        calibrate: bool | None = False,
+        classifier: str | None = "xgboost",
+        acq_optimizer: str | None = "rs",
+        feval_acq: int | None = 500,
+        random_prob: float | None = 0.0,
+        init_random: int | None = 6,
+        classifier_kwargs: dict | None = None,
     ):
         super().__init__(
             config_space=config_space,
@@ -244,7 +244,7 @@ class Bore(SingleObjectiveBaseSearcher):
     def on_trial_complete(
         self,
         trial_id: int,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         metric: float,
         resource_level: int = None,
     ):

--- a/syne_tune/optimizer/schedulers/searchers/bore/legacy_bore.py
+++ b/syne_tune/optimizer/schedulers/searchers/bore/legacy_bore.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any
+from typing import Any
 import time
 import xgboost
 import logging
@@ -54,20 +54,20 @@ class LegacyBore(StochasticAndFilterDuplicatesSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        points_to_evaluate: Optional[List[dict]] = None,
-        allow_duplicates: Optional[bool] = None,
-        restrict_configurations: Optional[List[Dict[str, Any]]] = None,
-        mode: Optional[str] = None,
-        gamma: Optional[float] = None,
-        calibrate: Optional[bool] = None,
-        classifier: Optional[str] = None,
-        acq_optimizer: Optional[str] = None,
-        feval_acq: Optional[int] = None,
-        random_prob: Optional[float] = None,
-        init_random: Optional[int] = None,
-        classifier_kwargs: Optional[dict] = None,
+        points_to_evaluate: list[dict] | None = None,
+        allow_duplicates: bool | None = None,
+        restrict_configurations: list[dict[str, Any]] | None = None,
+        mode: str | None = None,
+        gamma: float | None = None,
+        calibrate: bool | None = None,
+        classifier: str | None = None,
+        acq_optimizer: str | None = None,
+        feval_acq: int | None = None,
+        random_prob: float | None = None,
+        init_random: int | None = None,
+        classifier_kwargs: dict | None = None,
         **kwargs,
     ):
         super().__init__(
@@ -262,9 +262,9 @@ class LegacyBore(StochasticAndFilterDuplicatesSearcher):
         )
         return True
 
-    def _update(self, trial_id: str, config: Dict[str, Any], result: Dict[str, Any]):
+    def _update(self, trial_id: str, config: dict[str, Any], result: dict[str, Any]):
         self.inputs.append(self._hp_ranges.to_ndarray(config))
         self.targets.append(result[self._metric])
 
-    def clone_from_state(self, state: Dict[str, Any]):
+    def clone_from_state(self, state: dict[str, Any]):
         raise NotImplementedError

--- a/syne_tune/optimizer/schedulers/searchers/bore/legacy_multi_fidelity_bore.py
+++ b/syne_tune/optimizer/schedulers/searchers/bore/legacy_multi_fidelity_bore.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any
+from typing import Any
 import logging
 import numpy as np
 
@@ -34,19 +34,19 @@ class LegacyMultiFidelityBore(LegacyBore):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        points_to_evaluate: Optional[List[dict]] = None,
-        allow_duplicates: Optional[bool] = None,
-        mode: Optional[str] = None,
-        gamma: Optional[float] = None,
-        calibrate: Optional[bool] = None,
-        classifier: Optional[str] = None,
-        acq_optimizer: Optional[str] = None,
-        feval_acq: Optional[int] = None,
-        random_prob: Optional[float] = None,
-        init_random: Optional[int] = None,
-        classifier_kwargs: Optional[dict] = None,
+        points_to_evaluate: list[dict] | None = None,
+        allow_duplicates: bool | None = None,
+        mode: str | None = None,
+        gamma: float | None = None,
+        calibrate: bool | None = None,
+        classifier: str | None = None,
+        acq_optimizer: str | None = None,
+        feval_acq: int | None = None,
+        random_prob: float | None = None,
+        init_random: int | None = None,
+        classifier_kwargs: dict | None = None,
         resource_attr: str = "epoch",
         **kwargs,
     ):
@@ -102,7 +102,7 @@ class LegacyMultiFidelityBore(LegacyBore):
 
         return super()._train_model(train_data, train_targets)
 
-    def _update(self, trial_id: str, config: Dict[str, Any], result: Dict[str, Any]):
+    def _update(self, trial_id: str, config: dict[str, Any], result: dict[str, Any]):
         super()._update(trial_id=trial_id, config=config, result=result)
         resource_level = int(result[self.resource_attr])
         self.resource_levels.append(resource_level)

--- a/syne_tune/optimizer/schedulers/searchers/botorch/botorch_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/botorch/botorch_searcher.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any
+from typing import Any
 import logging
 
 import numpy as np
@@ -58,11 +58,11 @@ class BoTorchSearcher(SingleObjectiveBaseSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        points_to_evaluate: Optional[List[dict]] = None,
+        config_space: dict[str, Any],
+        points_to_evaluate: list[dict] | None = None,
         num_init_random: int = 3,
         no_fantasizing: bool = False,
-        max_num_observations: Optional[int] = 200,
+        max_num_observations: int | None = 200,
         input_warping: bool = True,
         random_seed: int = None,
     ):
@@ -87,7 +87,7 @@ class BoTorchSearcher(SingleObjectiveBaseSearcher):
     def on_trial_complete(
         self,
         trial_id: int,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         metric: float,
     ):
         trial_id = int(trial_id)
@@ -104,7 +104,7 @@ class BoTorchSearcher(SingleObjectiveBaseSearcher):
             for k, v in self.config_space.items()
         }
 
-    def suggest(self) -> Optional[dict]:
+    def suggest(self) -> dict | None:
 
         config_suggested = self._next_points_to_evaluate()
 
@@ -141,7 +141,7 @@ class BoTorchSearcher(SingleObjectiveBaseSearcher):
     def _config_from_ndarray(self, candidate) -> dict:
         return self._hp_ranges.from_ndarray(candidate)
 
-    def _sample_next_candidate(self) -> Optional[dict]:
+    def _sample_next_candidate(self) -> dict | None:
         """
         :return: A next candidate to evaluate, if possible it is obtained by
             fitting a GP on past data and maximizing EI. If this fails because
@@ -222,7 +222,7 @@ class BoTorchSearcher(SingleObjectiveBaseSearcher):
             warp_tf = None
         return SingleTaskGP(X_tensor, Y_tensor, input_transform=warp_tf)
 
-    def _config_to_feature_matrix(self, configs: List[dict]) -> Tensor:
+    def _config_to_feature_matrix(self, configs: list[dict]) -> Tensor:
         bounds = Tensor(self._hp_ranges.get_ndarray_bounds()).T
         X = Tensor(self._hp_ranges.to_ndarray_matrix(configs))
         return normalize(X, bounds)
@@ -230,14 +230,14 @@ class BoTorchSearcher(SingleObjectiveBaseSearcher):
     def objectives(self):
         return np.array(list(self.trial_observations.values()))
 
-    def _configs_with_results(self) -> List[dict]:
+    def _configs_with_results(self) -> list[dict]:
         return [
             config
             for trial, config in self.trial_configs.items()
             if not trial in self.pending_trials
         ]
 
-    def _configs_pending(self) -> List[dict]:
+    def _configs_pending(self) -> list[dict]:
         return [
             config
             for trial, config in self.trial_configs.items()

--- a/syne_tune/optimizer/schedulers/searchers/conformal/conformal_quantile_regression_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/conformal/conformal_quantile_regression_searcher.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-from typing import Dict, Optional, List, Any
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -25,9 +25,9 @@ logger = logging.getLogger(__name__)
 class ConformalQuantileRegression(SingleObjectiveBaseSearcher):
     def __init__(
         self,
-        config_space: Dict,
-        random_seed: Optional[int] = None,
-        points_to_evaluate: Optional[List[Dict]] = None,
+        config_space: dict,
+        random_seed: int | None = None,
+        points_to_evaluate: list[dict] | None = None,
         num_init_random_draws: int = 5,
         update_frequency: int = 1,
         max_fit_samples: int = None,
@@ -71,7 +71,7 @@ class ConformalQuantileRegression(SingleObjectiveBaseSearcher):
         self.surrogate_cls = surrogate_cls
         self.random_state = np.random.RandomState(self.random_seed)
 
-    def suggest(self, **kwargs) -> Optional[Dict[str, Any]]:
+    def suggest(self, **kwargs) -> dict[str, Any] | None:
         config = self._next_points_to_evaluate()
 
         if config is None:
@@ -129,18 +129,18 @@ class ConformalQuantileRegression(SingleObjectiveBaseSearcher):
     def on_trial_complete(
         self,
         trial_id: int,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         metric: float,
         resource_level: int = None,
     ):
         self.trial_configs[trial_id] = config
         self.trial_results[trial_id].append(metric)
 
-    def sample_random(self) -> Dict:
+    def sample_random(self) -> dict:
         return {
             k: v.sample(random_state=self.random_state) if isinstance(v, Domain) else v
             for k, v in self.config_space.items()
         }
 
-    def configs_to_df(self, configs: List[Dict]) -> pd.DataFrame:
+    def configs_to_df(self, configs: list[dict]) -> pd.DataFrame:
         return pd.DataFrame(configs)

--- a/syne_tune/optimizer/schedulers/searchers/conformal/legacy_surrogate_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/conformal/legacy_surrogate_searcher.py
@@ -1,6 +1,5 @@
 import logging
 from collections import defaultdict
-from typing import Dict, Optional, List
 
 import numpy as np
 import pandas as pd
@@ -23,14 +22,14 @@ logger = logging.getLogger(__name__)
 class LegacySurrogateSearcher(StochasticSearcher):
     def __init__(
         self,
-        config_space: Dict,
+        config_space: dict,
         metric: str,
         mode: str = "min",
         num_init_random_draws: int = 5,
         update_frequency: int = 1,
-        points_to_evaluate: Optional[List[Dict]] = None,
+        points_to_evaluate: list[dict] | None = None,
         max_fit_samples: int = None,
-        random_seed: Optional[int] = None,
+        random_seed: int | None = None,
         **surrogate_kwargs,
     ):
         """
@@ -72,7 +71,7 @@ class LegacySurrogateSearcher(StochasticSearcher):
         self.sampler = None
         self.max_fit_samples = max_fit_samples
 
-    def get_config(self, trial_id: str, **kwargs) -> Optional[TrialSuggestion]:
+    def get_config(self, trial_id: str, **kwargs) -> TrialSuggestion | None:
         trial_id = int(trial_id)
         logger.debug(f"get_config trial {trial_id}, {self.num_results()} results")
         if self._points_to_evaluate:
@@ -132,22 +131,22 @@ class LegacySurrogateSearcher(StochasticSearcher):
         self.surrogate_model.fit(df_features=X, y=z)
 
     def on_trial_result(
-        self, trial_id: str, config: Dict, result: Dict, update: bool = True
+        self, trial_id: str, config: dict, result: dict, update: bool = True
     ):
         trial_id = int(trial_id)
         y = result[self.metric]
         self.trial_results[trial_id].append(y)
 
-    def sample_random(self) -> Dict:
+    def sample_random(self) -> dict:
         return {
             k: v.sample(random_state=self.random_state) if isinstance(v, Domain) else v
             for k, v in self.config_space.items()
         }
 
-    def configs_to_df(self, configs: List[Dict]) -> pd.DataFrame:
+    def configs_to_df(self, configs: list[dict]) -> pd.DataFrame:
         return pd.DataFrame(configs)
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return [self.metric]
 
     def metric_mode(self) -> str:

--- a/syne_tune/optimizer/schedulers/searchers/conformal/surrogate/conformalized_quantile_regression_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/conformal/surrogate/conformalized_quantile_regression_model.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Union, List, Dict
 
 import numpy as np
 import pandas as pd
@@ -32,11 +31,11 @@ class ConformalQuantileCorrection:
 
 
 class ConformalizedGradientBoostingQuantileRegressor(GradientBoostingQuantileRegressor):
-    conformal_correction: Dict[float, ConformalQuantileCorrection] = None
+    conformal_correction: dict[float, ConformalQuantileCorrection] = None
 
     def __init__(
         self,
-        quantiles: Union[int, List[float]] = 9,
+        quantiles: int | list[float] = 9,
         valid_fraction: float = 0.10,
         verbose: bool = False,
         **kwargs

--- a/syne_tune/optimizer/schedulers/searchers/conformal/surrogate/quantile_regression_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/conformal/surrogate/quantile_regression_model.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Dict, Union, List
 
 import numpy as np
 import pandas as pd
@@ -10,7 +9,7 @@ from tqdm import tqdm
 
 @dataclass
 class QuantileRegressorPredictions:
-    quantiles: List[float]
+    quantiles: list[float]
     results_stacked: np.ndarray
 
     def results(self, quantile: float) -> np.ndarray:
@@ -25,7 +24,7 @@ class QuantileRegressorPredictions:
 
     @classmethod
     def from_quantile_results(
-        cls, quantiles: List[float], results: Dict[float, np.ndarray]
+        cls, quantiles: list[float], results: dict[float, np.ndarray]
     ):
         listres = [results[item] for item in quantiles]
         results_stacked = np.stack(listres, axis=1)
@@ -43,7 +42,7 @@ class QuantileRegressorPredictions:
 
 
 class QuantileRegressor:
-    quantiles: List[float]
+    quantiles: list[float]
 
     def predict(self, df_test: pd.DataFrame) -> QuantileRegressorPredictions:
         raise NotImplementedError()
@@ -52,7 +51,7 @@ class QuantileRegressor:
 class GradientBoostingQuantileRegressor(QuantileRegressor, GradientBoostingRegressor):
     def __init__(
         self,
-        quantiles: Union[int, List[float]] = 5,
+        quantiles: int | list[float] = 5,
         verbose: bool = False,
         valid_fraction: float = 0.0,
         **kwargs,

--- a/syne_tune/optimizer/schedulers/searchers/conformal/surrogate/quantile_regression_surrogate.py
+++ b/syne_tune/optimizer/schedulers/searchers/conformal/surrogate/quantile_regression_surrogate.py
@@ -1,5 +1,4 @@
 from functools import partial
-from typing import Dict, Optional
 
 import numpy as np
 import pandas as pd
@@ -23,10 +22,10 @@ from syne_tune.optimizer.schedulers.transfer_learning.quantile_based.quantile_ba
 class QuantileRegressionSurrogateModel(SurrogateModel):
     def __init__(
         self,
-        config_space: Dict,
+        config_space: dict,
         mode: str,
-        random_state: Optional[np.random.RandomState] = None,
-        max_fit_samples: Optional[int] = None,
+        random_state: np.random.RandomState | None = None,
+        max_fit_samples: int | None = None,
         quantiles: int = 5,
         valid_fraction: float = 0.0,
         min_samples_to_conformalize: int = None,

--- a/syne_tune/optimizer/schedulers/searchers/conformal/surrogate/surrogate_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/conformal/surrogate/surrogate_model.py
@@ -2,7 +2,6 @@ import logging
 
 import pandas as pd
 import numpy as np
-from typing import Dict, Optional, Tuple, List, Union
 
 from syne_tune.config_space import Domain
 
@@ -10,10 +9,10 @@ from syne_tune.config_space import Domain
 class SurrogateModel:
     def __init__(
         self,
-        config_space: Dict,
+        config_space: dict,
         mode: str,
-        max_fit_samples: Optional[int] = None,
-        random_state: Optional[np.random.RandomState] = None,
+        max_fit_samples: int | None = None,
+        random_state: np.random.RandomState | None = None,
     ):
         self.random_state = random_state if random_state else np.random
         self.config_space = config_space
@@ -39,7 +38,7 @@ class SurrogateModel:
         self,
         df_features: pd.DataFrame,
         y: np.array,
-        ncandidates: Union[int, pd.DataFrame] = 2000,
+        ncandidates: int | pd.DataFrame = 2000,
     ):
         self._fit(df_features=df_features, y=y)
 
@@ -71,7 +70,7 @@ class SurrogateModel:
         z_pred = self._sampler()
         return z_pred
 
-    def predict(self, df_features: pd.DataFrame) -> Tuple[np.array, np.array]:
+    def predict(self, df_features: pd.DataFrame) -> tuple[np.array, np.array]:
         """
         :param df_features: input features to make predictions with shape (n, d)
         :return: predictions in the shape of (n,)
@@ -115,13 +114,13 @@ class SurrogateModel:
         self.df_candidates = self._configs_to_df(self.config_candidates)
         self._sampler = self._get_sampler(self.df_candidates)
 
-    def _sample_random(self) -> Dict:
+    def _sample_random(self) -> dict:
         return {
             k: v.sample(random_state=self.random_state) if isinstance(v, Domain) else v
             for k, v in self.config_space.items()
         }
 
-    def _configs_to_df(self, configs: List[Dict]) -> pd.DataFrame:
+    def _configs_to_df(self, configs: list[dict]) -> pd.DataFrame:
         return pd.DataFrame(configs)
 
     def _config_already_seen(self, config) -> bool:

--- a/syne_tune/optimizer/schedulers/searchers/kde/kde_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/kde/kde_searcher.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any, Tuple
+from typing import Any
 import logging
 import numpy as np
 import statsmodels.api as sm
@@ -62,15 +62,15 @@ class KernelDensityEstimator(SingleObjectiveBaseSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        points_to_evaluate: Optional[List[dict]] = None,
-        num_min_data_points: Optional[int] = None,
+        config_space: dict[str, Any],
+        points_to_evaluate: list[dict] | None = None,
+        num_min_data_points: int | None = None,
         top_n_percent: int = 15,
         min_bandwidth: float = 1e-3,
         num_candidates: int = 64,
         bandwidth_factor: int = 3,
         random_fraction: float = 0.33,
-        random_seed: Optional[int] = None,
+        random_seed: int | None = None,
     ):
         super().__init__(
             config_space=config_space,
@@ -195,7 +195,7 @@ class KernelDensityEstimator(SingleObjectiveBaseSearcher):
     def on_trial_complete(
         self,
         trial_id: int,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         metric: float,
     ):
         self.X.append(self._to_feature(config=config))
@@ -207,7 +207,7 @@ class KernelDensityEstimator(SingleObjectiveBaseSearcher):
             for k, v in self.config_space.items()
         }
 
-    def suggest(self, **kwargs) -> Optional[Dict[str, Any]]:
+    def suggest(self, **kwargs) -> dict[str, Any] | None:
         suggestion = self._next_points_to_evaluate()
         if suggestion is None:
             if self.y:
@@ -291,8 +291,8 @@ class KernelDensityEstimator(SingleObjectiveBaseSearcher):
         return suggestion
 
     def _check_data_shape_and_good_size(
-        self, data_shape: Tuple[int, int]
-    ) -> Optional[int]:
+        self, data_shape: list[int, int]
+    ) -> int | None:
         """
         Determine size of data for "good" model (the rest of the data is for the
         "bad" model). Both sizes must be larger than the number of features,
@@ -313,7 +313,7 @@ class KernelDensityEstimator(SingleObjectiveBaseSearcher):
 
     def _train_kde(
         self, train_data: np.ndarray, train_targets: np.ndarray
-    ) -> Optional[Tuple[Any, Any]]:
+    ) -> list[Any, Any] | None:
         train_data = train_data.reshape((train_targets.size, -1))
         n_good = self._check_data_shape_and_good_size(train_data.shape)
         if n_good is None:

--- a/syne_tune/optimizer/schedulers/searchers/kde/kde_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/kde/kde_searcher.py
@@ -290,9 +290,7 @@ class KernelDensityEstimator(SingleObjectiveBaseSearcher):
 
         return suggestion
 
-    def _check_data_shape_and_good_size(
-        self, data_shape: list[int, int]
-    ) -> int | None:
+    def _check_data_shape_and_good_size(self, data_shape: list[int, int]) -> int | None:
         """
         Determine size of data for "good" model (the rest of the data is for the
         "bad" model). Both sizes must be larger than the number of features,

--- a/syne_tune/optimizer/schedulers/searchers/last_value_multi_fidelity_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/last_value_multi_fidelity_searcher.py
@@ -1,7 +1,7 @@
 import sys
 import logging
 from collections import defaultdict
-from typing import Dict, Optional, List, Any, Union
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -21,13 +21,13 @@ logger = logging.getLogger(__name__)
 class LastValueMultiFidelitySearcher(SingleObjectiveBaseSearcher):
     def __init__(
         self,
-        config_space: Dict,
-        random_seed: Optional[int] = None,
-        points_to_evaluate: Optional[List[Dict]] = None,
+        config_space: dict,
+        random_seed: int | None = None,
+        points_to_evaluate: list[dict] | None = None,
         num_init_random_draws: int = 5,
         update_frequency: int = 1,
         max_fit_samples: int = None,
-        searcher: Optional[Union[str, SingleObjectiveBaseSearcher]] = "kde",
+        searcher: str | SingleObjectiveBaseSearcher | None = "kde",
         searcher_kwargs: dict[str, Any] = None,
     ):
         """
@@ -76,7 +76,7 @@ class LastValueMultiFidelitySearcher(SingleObjectiveBaseSearcher):
             self.searcher_cls = searcher
         self.searcher = None
 
-    def suggest(self, **kwargs) -> Optional[Dict[str, Any]]:
+    def suggest(self, **kwargs) -> dict[str, Any] | None:
         config = self._next_points_to_evaluate()
 
         if config is None:
@@ -139,7 +139,7 @@ class LastValueMultiFidelitySearcher(SingleObjectiveBaseSearcher):
     def on_trial_complete(
         self,
         trial_id: int,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         metric: float,
         resource_level: int = None,
     ):
@@ -149,18 +149,18 @@ class LastValueMultiFidelitySearcher(SingleObjectiveBaseSearcher):
     def on_trial_result(
         self,
         trial_id: int,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         metric: float,
         resource_level: int = None,
     ):
         self.trial_configs[trial_id] = config
         self.trial_results[trial_id].append(metric)
 
-    def sample_random(self) -> Dict:
+    def sample_random(self) -> dict:
         return {
             k: v.sample(random_state=self.random_state) if isinstance(v, Domain) else v
             for k, v in self.config_space.items()
         }
 
-    def configs_to_df(self, configs: List[Dict]) -> pd.DataFrame:
+    def configs_to_df(self, configs: list[dict]) -> pd.DataFrame:
         return pd.DataFrame(configs)

--- a/syne_tune/optimizer/schedulers/searchers/multi_fidelity_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/multi_fidelity_searcher.py
@@ -1,7 +1,7 @@
 import logging
 from collections import defaultdict
 
-from typing import Dict, Any, Optional, List, Union
+from typing import Any
 
 from syne_tune.optimizer.schedulers.searchers.searcher import BaseSearcher
 from syne_tune.optimizer.schedulers.searchers.single_objective_searcher import (
@@ -30,10 +30,10 @@ class IndependentMultiFidelitySearcher(BaseSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        searcher: Optional[Union[str, SingleObjectiveBaseSearcher]] = "kde",
-        points_to_evaluate: Optional[List[dict]] = None,
-        random_seed: Optional[int] = None,
+        config_space: dict[str, Any],
+        searcher: str | SingleObjectiveBaseSearcher  | None = "kde",
+        points_to_evaluate: list[dict] | None = None,
+        random_seed: int | None = None,
         searcher_kwargs: dict[str, Any] = None,
     ):
         super().__init__(
@@ -61,7 +61,7 @@ class IndependentMultiFidelitySearcher(BaseSearcher):
             )
         )
 
-    def suggest(self, **kwargs) -> Optional[Dict[str, Any]]:
+    def suggest(self, **kwargs) -> dict[str, Any] | None:
         """Suggest a new configuration.
 
         Note: Query :meth:`_next_points_to_evaluate` for initial configs to return
@@ -92,7 +92,7 @@ class IndependentMultiFidelitySearcher(BaseSearcher):
     def on_trial_result(
         self,
         trial_id: int,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         metric: float,
         resource_level: int,
     ):
@@ -111,7 +111,7 @@ class IndependentMultiFidelitySearcher(BaseSearcher):
     def on_trial_complete(
         self,
         trial_id: int,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         metric: float,
         resource_level: int,
     ):

--- a/syne_tune/optimizer/schedulers/searchers/multi_fidelity_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/multi_fidelity_searcher.py
@@ -31,7 +31,7 @@ class IndependentMultiFidelitySearcher(BaseSearcher):
     def __init__(
         self,
         config_space: dict[str, Any],
-        searcher: str | SingleObjectiveBaseSearcher  | None = "kde",
+        searcher: str | SingleObjectiveBaseSearcher | None = "kde",
         points_to_evaluate: list[dict] | None = None,
         random_seed: int | None = None,
         searcher_kwargs: dict[str, Any] = None,

--- a/syne_tune/optimizer/schedulers/searchers/random_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/random_searcher.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, List, Dict, Any
+from typing import Any
 
 from syne_tune.optimizer.schedulers.searchers.searcher import BaseSearcher
 from syne_tune.optimizer.schedulers.searchers.single_objective_searcher import (
@@ -26,15 +26,15 @@ class RandomSearcher(SingleObjectiveBaseSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        points_to_evaluate: Optional[List[dict]] = None,
+        config_space: dict[str, Any],
+        points_to_evaluate: list[dict] | None = None,
         random_seed: int = None,
     ):
         super().__init__(
             config_space, points_to_evaluate=points_to_evaluate, random_seed=random_seed
         )
 
-    def suggest(self) -> Optional[dict]:
+    def suggest(self) -> dict | None:
         """Sample a new configuration at random
 
         If ``allow_duplicates == False``, this is done without replacement, so
@@ -55,15 +55,15 @@ class MultiObjectiveRandomSearcher(BaseSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        points_to_evaluate: Optional[List[dict]] = None,
+        config_space: dict[str, Any],
+        points_to_evaluate: list[dict] | None = None,
         random_seed: int = None,
     ):
         super().__init__(
             config_space, points_to_evaluate=points_to_evaluate, random_seed=random_seed
         )
 
-    def suggest(self) -> Optional[dict]:
+    def suggest(self) -> dict | None:
         """Sample a new configuration at random
 
         If ``allow_duplicates == False``, this is done without replacement, so

--- a/syne_tune/optimizer/schedulers/searchers/regularized_evolution.py
+++ b/syne_tune/optimizer/schedulers/searchers/regularized_evolution.py
@@ -4,7 +4,7 @@ import logging
 import numpy as np
 
 from collections import deque
-from typing import Optional, List, Dict, Any
+from typing import Any
 from dataclasses import dataclass
 
 from syne_tune.config_space import config_space_size, non_constant_hyperparameter_keys
@@ -19,16 +19,16 @@ logger = logging.getLogger(__name__)
 @dataclass
 class PopulationElement:
     score: float = 0
-    config: Dict[str, Any] = None
-    results: List[float] = None
+    config: dict[str, Any] = None
+    results: list[float] = None
 
 
 def mutate_config(
-    config: Dict[str, Any],
-    config_space: Dict[str, Any],
+    config: dict[str, Any],
+    config_space: dict[str, Any],
     rng: np.random.RandomState,
     num_try: int = 1000,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
 
     child_config = copy.deepcopy(config)
     hp_name = rng.choice(non_constant_hyperparameter_keys(config_space))
@@ -44,8 +44,8 @@ def mutate_config(
 
 
 def sample_random_config(
-    config_space: Dict[str, Any], rng: np.random.RandomState
-) -> Dict[str, Any]:
+    config_space: dict[str, Any], rng: np.random.RandomState
+) -> dict[str, Any]:
     return {
         k: v.sample() if hasattr(v, "sample") else v for k, v in config_space.items()
     }
@@ -76,7 +76,7 @@ class RegularizedEvolution(SingleObjectiveBaseSearcher):
     def __init__(
         self,
         config_space,
-        points_to_evaluate: Optional[List[dict]] = None,
+        points_to_evaluate: list[dict] | None = None,
         population_size: int = 100,
         sample_size: int = 10,
         random_seed: int = None,
@@ -94,7 +94,7 @@ class RegularizedEvolution(SingleObjectiveBaseSearcher):
         self.population = deque()
         self.random_state = np.random.RandomState(self.random_seed)
 
-    def suggest(self, **kwargs) -> Optional[dict]:
+    def suggest(self, **kwargs) -> dict | None:
         initial_config = self._next_points_to_evaluate()
         if initial_config is not None:
             return initial_config
@@ -118,7 +118,7 @@ class RegularizedEvolution(SingleObjectiveBaseSearcher):
     def on_trial_complete(
         self,
         trial_id: int,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         metric: float,
     ):
         # Add element to the population

--- a/syne_tune/optimizer/schedulers/searchers/searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/searcher.py
@@ -2,7 +2,7 @@ import logging
 import numpy as np
 
 from copy import deepcopy
-from typing import Optional, List, Dict, Any
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -19,8 +19,8 @@ class BaseSearcher:
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        points_to_evaluate: Optional[List[Dict[str, Any]]] = None,
+        config_space: dict[str, Any],
+        points_to_evaluate: list[dict[str, Any]] | None = None,
         random_seed: int = None,
     ):
         self.config_space = config_space
@@ -34,7 +34,7 @@ class BaseSearcher:
         else:
             self.random_seed = random_seed
 
-    def _next_points_to_evaluate(self) -> Optional[Dict[str, Any]]:
+    def _next_points_to_evaluate(self) -> dict[str, Any] | None:
         """
         :return: Next entry from remaining ``points_to_evaluate`` (popped
             from front), or None
@@ -44,7 +44,7 @@ class BaseSearcher:
         else:
             return None  # No more initial configs
 
-    def suggest(self, **kwargs) -> Optional[Dict[str, Any]]:
+    def suggest(self, **kwargs) -> dict[str, Any] | None:
         """Suggest a new configuration.
 
         Note: Query :meth:`_next_points_to_evaluate` for initial configs to return
@@ -63,8 +63,8 @@ class BaseSearcher:
     def on_trial_result(
         self,
         trial_id: int,
-        config: Dict[str, Any],
-        metrics: List[float],
+        config: dict[str, Any],
+        metrics: list[float],
     ):
         """Inform searcher about result
 
@@ -95,8 +95,8 @@ class BaseSearcher:
     def on_trial_complete(
         self,
         trial_id: int,
-        config: Dict[str, Any],
-        metrics: List[float],
+        config: dict[str, Any],
+        metrics: list[float],
     ):
         """Inform searcher about result
 

--- a/syne_tune/optimizer/schedulers/searchers/searcher_factory.py
+++ b/syne_tune/optimizer/schedulers/searchers/searcher_factory.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 
 from syne_tune.optimizer.schedulers.searchers.bore import Bore
 from syne_tune.optimizer.schedulers.searchers.botorch.botorch_searcher import (
@@ -25,7 +25,7 @@ searcher_dict = {
 
 
 def searcher_factory(
-    searcher_name: str, config_space: Dict[str, Any], **searcher_kwargs
+    searcher_name: str, config_space: dict[str, Any], **searcher_kwargs
 ) -> BaseSearcher:
     assert (
         searcher_name in searcher_dict

--- a/syne_tune/optimizer/schedulers/searchers/single_objective_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/single_objective_searcher.py
@@ -1,6 +1,6 @@
 import logging
 
-from typing import Dict, Any
+from typing import Any
 
 from syne_tune.optimizer.schedulers.searchers.searcher import BaseSearcher
 
@@ -15,7 +15,7 @@ class SingleObjectiveBaseSearcher(BaseSearcher):
     def on_trial_result(
         self,
         trial_id: int,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         metric: float,
     ):
         """Inform searcher about result
@@ -37,7 +37,7 @@ class SingleObjectiveBaseSearcher(BaseSearcher):
     def on_trial_complete(
         self,
         trial_id: int,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         metric: float,
     ):
         """Inform searcher about result

--- a/syne_tune/optimizer/schedulers/searchers/utils/common.py
+++ b/syne_tune/optimizer/schedulers/searchers/utils/common.py
@@ -1,9 +1,9 @@
-from typing import Union, Dict, Callable
+from collections.abc import Callable
 
 
-Hyperparameter = Union[str, int, float]
+Hyperparameter = str | int | float
 
-Configuration = Dict[str, Hyperparameter]
+Configuration = dict[str, Hyperparameter]
 
 # Type of ``filter_observed_data``, which is (optionally) used to filter the
 # observed data in ``TuningJobState.trials_evaluations`` when determining

--- a/syne_tune/optimizer/schedulers/searchers/utils/default_arguments.py
+++ b/syne_tune/optimizer/schedulers/searchers/utils/default_arguments.py
@@ -1,4 +1,4 @@
-from typing import Set, Tuple, Dict, Optional, Any
+from typing import Any
 import logging
 import numbers
 
@@ -66,7 +66,7 @@ class IntegerOrNone(Integer):
 
 
 class Categorical(CheckType):
-    def __init__(self, choices: Tuple[str, ...]):
+    def __init__(self, choices: tuple[str, ...]):
         self.choices = set(choices)
 
     def assert_valid(self, key: str, value):
@@ -95,12 +95,12 @@ class Dictionary(CheckType):
 
 
 def check_and_merge_defaults(
-    options: Dict[str, Any],
-    mandatory: Set[str],
-    default_options: Dict[str, Any],
-    constraints: Optional[Dict[str, CheckType]] = None,
-    dict_name: Optional[str] = None,
-) -> Dict[str, Any]:
+    options: dict[str, Any],
+    mandatory: set[str],
+    default_options: dict[str, Any],
+    constraints: dict[str, CheckType] | None = None,
+    dict_name: str | None = None,
+) -> dict[str, Any]:
     """
     First, check that all keys in mandatory appear in options. Second, create
     result_options by merging ``options`` and ``default_options``, where entries in
@@ -154,7 +154,7 @@ def check_and_merge_defaults(
     return result_options
 
 
-def filter_by_key(options: Dict[str, Any], remove_keys: Set[str]) -> Dict[str, Any]:
+def filter_by_key(options: dict[str, Any], remove_keys: set[str]) -> dict[str, Any]:
     """
     Filter options by removing entries whose keys are in ``remove_keys``.
     Used to filter kwargs passed to a constructor, before passing it to
@@ -167,6 +167,6 @@ def filter_by_key(options: Dict[str, Any], remove_keys: Set[str]) -> Dict[str, A
     return {k: v for k, v in options.items() if k not in remove_keys}
 
 
-def assert_no_invalid_options(options: Dict[str, Any], all_keys: Set[str], name: str):
+def assert_no_invalid_options(options: dict[str, Any], all_keys: set[str], name: str):
     for k in options:
         assert k in all_keys, "{}: Invalid argument '{}'".format(name, k)

--- a/syne_tune/optimizer/schedulers/searchers/utils/exclusion_list.py
+++ b/syne_tune/optimizer/schedulers/searchers/utils/exclusion_list.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any, List, Union, Set
+from typing import Any
 
 from syne_tune.config_space import config_space_size
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.tuning_job_state import (
@@ -27,7 +27,7 @@ class ExclusionList:
     def __init__(
         self,
         hp_ranges: HyperparameterRanges,
-        configurations: Optional[Union[List[Configuration], Set[str]]] = None,
+        configurations: list[Configuration] | set[str] | None = None,
     ):
         self.hp_ranges = hp_ranges
         keys = self.hp_ranges.internal_keys
@@ -71,13 +71,13 @@ class ExclusionList:
             self.excl_set
         ) >= self.configspace_size
 
-    def get_state(self) -> Dict[str, Any]:
+    def get_state(self) -> dict[str, Any]:
         return {
             "excl_set": list(self.excl_set),
             "keys": self.keys,
         }
 
-    def clone_from_state(self, state: Dict[str, Any]):
+    def clone_from_state(self, state: dict[str, Any]):
         self.keys = state["keys"]
         self.excl_set = set(state["excl_set"])
 
@@ -86,7 +86,7 @@ class ExclusionListFromState(ExclusionList):
     def __init__(
         self,
         state: TuningJobState,
-        filter_observed_data: Optional[ConfigurationFilter] = None,
+        filter_observed_data: ConfigurationFilter | None = None,
     ):
         super().__init__(
             hp_ranges=state.hp_ranges,

--- a/syne_tune/optimizer/schedulers/searchers/utils/hp_ranges.py
+++ b/syne_tune/optimizer/schedulers/searchers/utils/hp_ranges.py
@@ -1,4 +1,5 @@
-from typing import Tuple, List, Iterable, Dict, Optional, Any
+from typing import Any
+from collections.abc import Iterable
 import numpy as np
 from numpy.random import RandomState
 
@@ -14,7 +15,7 @@ from syne_tune.optimizer.schedulers.searchers.utils.common import (
 )
 
 
-def _filter_constant_hyperparameters(config_space: Dict[str, Any]) -> Dict[str, Any]:
+def _filter_constant_hyperparameters(config_space: dict[str, Any]) -> dict[str, Any]:
     nonconst_keys = set(non_constant_hyperparameter_keys(config_space))
     return {k: v for k, v in config_space.items() if k in nonconst_keys}
 
@@ -65,11 +66,11 @@ class HyperparameterRanges:
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        name_last_pos: Optional[str] = None,
+        config_space: dict[str, Any],
+        name_last_pos: str | None = None,
         value_for_last_pos=None,
-        active_config_space: Optional[dict] = None,
-        prefix_keys: Optional[List[str]] = None,
+        active_config_space: dict | None = None,
+        prefix_keys: list[str] | None = None,
     ):
         self.config_space = _filter_constant_hyperparameters(config_space)
         self.name_last_pos = name_last_pos
@@ -77,7 +78,7 @@ class HyperparameterRanges:
         self._set_internal_keys(prefix_keys)
         self._set_active_config_space(active_config_space)
 
-    def _set_internal_keys(self, prefix_keys: Optional[List[str]]):
+    def _set_internal_keys(self, prefix_keys: list[str] | None):
         keys = sorted(self.config_space.keys())
         if prefix_keys is not None:
             pk_set = set(prefix_keys)
@@ -94,7 +95,7 @@ class HyperparameterRanges:
             keys = keys[:pos] + keys[(pos + 1) :] + [self.name_last_pos]
         self._internal_keys = keys
 
-    def _set_active_config_space(self, active_config_space: Dict[str, Any]):
+    def _set_active_config_space(self, active_config_space: dict[str, Any]):
         if active_config_space is None:
             self.active_config_space = dict()
             self._config_space_for_sampling = self.config_space
@@ -105,7 +106,7 @@ class HyperparameterRanges:
                 self.config_space, **active_config_space
             )
 
-    def _assert_sub_config_space(self, active_config_space: Dict[str, Any]):
+    def _assert_sub_config_space(self, active_config_space: dict[str, Any]):
         for k, v in active_config_space.items():
             assert (
                 k in self.config_space
@@ -121,11 +122,11 @@ class HyperparameterRanges:
                 assert check, f"active_config_space[{k}] has different {name}"
 
     @property
-    def internal_keys(self) -> List[str]:
+    def internal_keys(self) -> list[str]:
         return self._internal_keys
 
     @property
-    def config_space_for_sampling(self) -> Dict[str, Any]:
+    def config_space_for_sampling(self) -> dict[str, Any]:
         return self._config_space_for_sampling
 
     def to_ndarray(self, config: Configuration) -> np.ndarray:
@@ -164,7 +165,7 @@ class HyperparameterRanges:
         raise NotImplementedError
 
     @property
-    def encoded_ranges(self) -> Dict[str, Tuple[int, int]]:
+    def encoded_ranges(self) -> dict[str, tuple[int, int]]:
         """
         Encoded ranges are ``[0, 1]`` or closed subintervals thereof, in case
         ``active_config_space`` is used.
@@ -205,10 +206,10 @@ class HyperparameterRanges:
 
     def _random_configs(
         self, random_state: RandomState, num_configs: int
-    ) -> List[Configuration]:
+    ) -> list[Configuration]:
         return [self._random_config(random_state) for _ in range(num_configs)]
 
-    def random_configs(self, random_state, num_configs: int) -> List[Configuration]:
+    def random_configs(self, random_state, num_configs: int) -> list[Configuration]:
         """Draws random configurations
 
         :param random_state: Random state
@@ -220,7 +221,7 @@ class HyperparameterRanges:
             for config in self._random_configs(random_state, num_configs)
         ]
 
-    def get_ndarray_bounds(self) -> List[Tuple[float, float]]:
+    def get_ndarray_bounds(self) -> list[tuple[float, float]]:
         """
         :return: List of ``(lower, upper)`` bounds for each dimension in
             encoded vector representation.
@@ -237,8 +238,8 @@ class HyperparameterRanges:
         return len(self.config_space)
 
     def filter_for_last_pos_value(
-        self, configs: List[Configuration]
-    ) -> List[Configuration]:
+        self, configs: list[Configuration]
+    ) -> list[Configuration]:
         """
         If ``is_attribute_fixed``, ``configs`` is filtered by removing
         entries whose ``name_last_pos attribute`` value is different from
@@ -258,9 +259,9 @@ class HyperparameterRanges:
     def config_to_tuple(
         self,
         config: Configuration,
-        keys: Optional[List[str]] = None,
+        keys: list[str] | None = None,
         skip_last: bool = False,
-    ) -> Tuple[Hyperparameter, ...]:
+    ) -> tuple[Hyperparameter, ...]:
         """
         :param config: Configuration
         :param keys: Overrides ``_internal_keys``
@@ -277,8 +278,8 @@ class HyperparameterRanges:
 
     def tuple_to_config(
         self,
-        config_tpl: Tuple[Hyperparameter, ...],
-        keys: Optional[List[str]] = None,
+        config_tpl: tuple[Hyperparameter, ...],
+        keys: list[str] | None = None,
         skip_last: bool = False,
     ) -> Configuration:
         """Reverse of :meth:`config_to_tuple`.
@@ -299,7 +300,7 @@ class HyperparameterRanges:
     def config_to_match_string(
         self,
         config: Configuration,
-        keys: Optional[List[str]] = None,
+        keys: list[str] | None = None,
         skip_last: bool = False,
     ) -> str:
         """

--- a/syne_tune/optimizer/schedulers/searchers/utils/hp_ranges_factory.py
+++ b/syne_tune/optimizer/schedulers/searchers/utils/hp_ranges_factory.py
@@ -1,4 +1,3 @@
-from typing import Dict, Optional, List
 import logging
 
 from syne_tune.optimizer.schedulers.searchers.utils.hp_ranges import (
@@ -12,11 +11,11 @@ logger = logging.getLogger(__name__)
 
 
 def make_hyperparameter_ranges(
-    config_space: Dict,
-    name_last_pos: Optional[str] = None,
+    config_space: dict,
+    name_last_pos: str | None = None,
     value_for_last_pos=None,
-    active_config_space: Optional[Dict] = None,
-    prefix_keys: Optional[List[str]] = None,
+    active_config_space: dict | None = None,
+    prefix_keys: list[str] | None = None,
 ) -> HyperparameterRanges:
     """Default method to create :class:`HyperparameterRanges` from ``config_space``
 

--- a/syne_tune/optimizer/schedulers/searchers/utils/hp_ranges_impl.py
+++ b/syne_tune/optimizer/schedulers/searchers/utils/hp_ranges_impl.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Dict, List, Any, Optional, Union
+from typing import Any
 import numpy as np
 
 from syne_tune.config_space import (
@@ -43,7 +43,7 @@ class HyperparameterRange:
     def ndarray_size(self) -> int:
         return 1
 
-    def get_ndarray_bounds(self) -> List[Tuple[float, float]]:
+    def get_ndarray_bounds(self) -> list[tuple[float, float]]:
         raise NotImplementedError
 
 
@@ -151,7 +151,7 @@ class HyperparameterRangeContinuous(HyperparameterRange):
             )
         return False
 
-    def get_ndarray_bounds(self) -> List[Tuple[float, float]]:
+    def get_ndarray_bounds(self) -> list[tuple[float, float]]:
         return self._ndarray_bounds
 
 
@@ -232,7 +232,7 @@ class HyperparameterRangeInteger(HyperparameterRange):
             )
         return False
 
-    def get_ndarray_bounds(self) -> List[Tuple[float, float]]:
+    def get_ndarray_bounds(self) -> list[tuple[float, float]]:
         return self._continuous_range.get_ndarray_bounds()
 
 
@@ -288,7 +288,7 @@ class HyperparameterRangeFiniteRange(HyperparameterRange):
     def scaling(self) -> Scaling:
         return self._scaling
 
-    def _map_from_int(self, x: int) -> Union[float, int]:
+    def _map_from_int(self, x: int) -> float | int:
         y = x * self._step_internal + self._lower_internal
         y = np.clip(self._scaling.from_internal(y), self.lower_bound, self.upper_bound)
         if not self.cast_int:
@@ -296,7 +296,7 @@ class HyperparameterRangeFiniteRange(HyperparameterRange):
         else:
             return int(np.round(y))
 
-    def _map_to_int(self, y: Union[float, int]) -> int:
+    def _map_to_int(self, y: float | int) -> int:
         if self._step_internal == 0:
             return 0
         else:
@@ -334,7 +334,7 @@ class HyperparameterRangeFiniteRange(HyperparameterRange):
             )
         return False
 
-    def get_ndarray_bounds(self) -> List[Tuple[float, float]]:
+    def get_ndarray_bounds(self) -> list[tuple[float, float]]:
         return self._range_int.get_ndarray_bounds()
 
 
@@ -346,7 +346,7 @@ class HyperparameterRangeCategorical(HyperparameterRange):
     :param choices: Values parameter can take
     """
 
-    def __init__(self, name: str, choices: Tuple[Any, ...]):
+    def __init__(self, name: str, choices: tuple[Any, ...]):
         super().__init__(name)
         self._assert_choices(choices)
         self.choices = list(choices)
@@ -360,7 +360,7 @@ class HyperparameterRangeCategorical(HyperparameterRange):
         ), f"value = {value} has type {type(value)}, must be str, int, or float"
 
     @staticmethod
-    def _assert_choices(choices: Tuple[Any, ...]):
+    def _assert_choices(choices: tuple[Any, ...]):
         assert len(choices) > 0
         HyperparameterRangeCategorical._assert_value_type(choices[0])
         value_type = type(choices[0])
@@ -370,8 +370,8 @@ class HyperparameterRangeCategorical(HyperparameterRange):
 
     @staticmethod
     def _assert_choices_and_active_choices(
-        choices: Tuple[Any, ...], active_choices: Optional[Tuple[Any, ...]] = None
-    ) -> Optional[int]:
+        choices: tuple[Any, ...], active_choices: tuple[Any, ...] | None = None
+    ) -> int | None:
         HyperparameterRangeCategorical._assert_choices(choices)
         firstpos = None
         if active_choices is not None:
@@ -414,8 +414,8 @@ class HyperparameterRangeCategoricalNonBinary(HyperparameterRangeCategorical):
     def __init__(
         self,
         name: str,
-        choices: Tuple[Any, ...],
-        active_choices: Tuple[Any, ...] = None,
+        choices: tuple[Any, ...],
+        active_choices: tuple[Any, ...] = None,
     ):
         super().__init__(name, choices)
         if active_choices is None:
@@ -454,7 +454,7 @@ class HyperparameterRangeCategoricalNonBinary(HyperparameterRangeCategorical):
         assert len(cand_ndarray) == self.num_choices, (cand_ndarray, self)
         return self.choices[int(np.argmax(cand_ndarray))]
 
-    def get_ndarray_bounds(self) -> List[Tuple[float, float]]:
+    def get_ndarray_bounds(self) -> list[tuple[float, float]]:
         return self._ndarray_bounds
 
 
@@ -471,8 +471,8 @@ class HyperparameterRangeCategoricalBinary(HyperparameterRangeCategorical):
     def __init__(
         self,
         name: str,
-        choices: Tuple[Any, ...],
-        active_choices: Tuple[Any, ...] = None,
+        choices: tuple[Any, ...],
+        active_choices: tuple[Any, ...] = None,
     ):
         assert len(choices) == 2, (
             f"len(choices) = {len(choices)}, must be 2. Use "
@@ -514,7 +514,7 @@ class HyperparameterRangeCategoricalBinary(HyperparameterRangeCategorical):
         assert len(cand_ndarray) == 1
         return self.choices[self._range_int.from_ndarray(cand_ndarray)]
 
-    def get_ndarray_bounds(self) -> List[Tuple[float, float]]:
+    def get_ndarray_bounds(self) -> list[tuple[float, float]]:
         return self._range_int.get_ndarray_bounds()
 
 
@@ -532,8 +532,8 @@ class HyperparameterRangeOrdinalEqual(HyperparameterRangeCategorical):
     def __init__(
         self,
         name: str,
-        choices: Tuple[Any, ...],
-        active_choices: Optional[Tuple[Any, ...]] = None,
+        choices: tuple[Any, ...],
+        active_choices: tuple[Any, ...] | None = None,
     ):
         super().__init__(name, choices)
         active_lower_bound = self._assert_choices_and_active_choices(
@@ -562,7 +562,7 @@ class HyperparameterRangeOrdinalEqual(HyperparameterRangeCategorical):
         assert len(cand_ndarray) == 1
         return self.choices[self._range_int.from_ndarray(cand_ndarray)]
 
-    def get_ndarray_bounds(self) -> List[Tuple[float, float]]:
+    def get_ndarray_bounds(self) -> list[tuple[float, float]]:
         return self._range_int.get_ndarray_bounds()
 
     def __eq__(self, other) -> bool:
@@ -588,9 +588,9 @@ class HyperparameterRangeOrdinalNearestNeighbor(HyperparameterRangeCategorical):
     def __init__(
         self,
         name: str,
-        choices: Tuple[Any, ...],
+        choices: tuple[Any, ...],
         log_scale: bool = False,
-        active_choices: Optional[Tuple[Any, ...]] = None,
+        active_choices: tuple[Any, ...] | None = None,
     ):
         assert len(choices) > 1, "Use HyperparameterRangeOrdinalEqual"
         super().__init__(name, choices)
@@ -606,8 +606,8 @@ class HyperparameterRangeOrdinalNearestNeighbor(HyperparameterRangeCategorical):
         )
 
     def _get_active_bounds(
-        self, active_choices: Optional[Tuple[Any, ...]]
-    ) -> Tuple[Optional[float], Optional[float]]:
+        self, active_choices: tuple[Any, ...] | None
+    ) -> tuple[float | None, float | None]:
         if active_choices is None:
             return None, None
         else:
@@ -650,7 +650,7 @@ class HyperparameterRangeOrdinalNearestNeighbor(HyperparameterRangeCategorical):
         assert len(cand_ndarray) == 1
         return self._domain_int.cast_int(self._range_int.from_ndarray(cand_ndarray))
 
-    def get_ndarray_bounds(self) -> List[Tuple[float, float]]:
+    def get_ndarray_bounds(self) -> list[tuple[float, float]]:
         return self._range_int.get_ndarray_bounds()
 
     def __eq__(self, other) -> bool:
@@ -677,11 +677,11 @@ class HyperparameterRangesImpl(HyperparameterRanges):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         name_last_pos: str = None,
         value_for_last_pos=None,
-        active_config_space: Dict[str, Any] = None,
-        prefix_keys: Optional[List[str]] = None,
+        active_config_space: dict[str, Any] = None,
+        prefix_keys: list[str] | None = None,
     ):
         super().__init__(
             config_space,
@@ -783,10 +783,10 @@ class HyperparameterRangesImpl(HyperparameterRanges):
         return self.tuple_to_config(tuple(hps))
 
     @property
-    def encoded_ranges(self) -> Dict[str, Tuple[int, int]]:
+    def encoded_ranges(self) -> dict[str, tuple[int, int]]:
         return self._encoded_ranges
 
-    def get_ndarray_bounds(self) -> List[Tuple[float, float]]:
+    def get_ndarray_bounds(self) -> list[tuple[float, float]]:
         bounds = [
             x for hp_range in self._hp_ranges for x in hp_range.get_ndarray_bounds()
         ]
@@ -810,7 +810,7 @@ class HyperparameterRangesImpl(HyperparameterRanges):
 
 def decode_extended_features(
     features_ext: np.ndarray,
-    resource_attr_range: Tuple[int, int],
+    resource_attr_range: tuple[int, int],
 ) -> (np.ndarray, np.ndarray):
     """
     Given matrix of features from extended configs, corresponding to

--- a/syne_tune/optimizer/schedulers/searchers/utils/warmstarting.py
+++ b/syne_tune/optimizer/schedulers/searchers/utils/warmstarting.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from syne_tune.optimizer.schedulers.searchers.utils.hp_ranges_factory import (
     make_hyperparameter_ranges,
 )
@@ -79,7 +77,7 @@ def create_hp_ranges_for_warmstarting(**kwargs) -> HyperparameterRanges:
 
 def create_filter_observed_data_for_warmstarting(
     **kwargs,
-) -> Optional[ConfigurationFilter]:
+) -> ConfigurationFilter | None:
     """
     See :class:`GPFIFOSearcher` for details on transfer_learning_task_attr',
     'transfer_learning_active_task' as optional fields in ``kwargs``.

--- a/syne_tune/optimizer/schedulers/single_fidelity_scheduler.py
+++ b/syne_tune/optimizer/schedulers/single_fidelity_scheduler.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any, Union, List
+from typing import Any
 import logging
 
 from syne_tune.backend.trial_status import Trial
@@ -41,10 +41,10 @@ class SingleFidelityScheduler(TrialScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        metrics: List[str],
-        do_minimize: Optional[bool] = True,
-        searcher: Optional[Union[str, BaseSearcher]] = "random_search",
+        config_space: dict[str, Any],
+        metrics: list[str],
+        do_minimize: bool | None = True,
+        searcher: str | BaseSearcher | None = "random_search",
         random_seed: int = None,
         searcher_kwargs: dict = None,
     ):
@@ -63,7 +63,7 @@ class SingleFidelityScheduler(TrialScheduler):
         else:
             self.searcher = searcher
 
-    def suggest(self) -> Optional[TrialSuggestion]:
+    def suggest(self) -> TrialSuggestion | None:
 
         config = self.searcher.suggest()
         if config is not None:
@@ -77,7 +77,7 @@ class SingleFidelityScheduler(TrialScheduler):
         self.searcher.on_trial_error(trial.trial_id)
         logger.warning(f"trial_id {trial.trial_id}: Evaluation failed!")
 
-    def on_trial_result(self, trial: Trial, result: Dict[str, Any]) -> str:
+    def on_trial_result(self, trial: Trial, result: dict[str, Any]) -> str:
         """Called on each intermediate result reported by a trial.
 
         At this point, the trial scheduler can make a decision by returning
@@ -96,7 +96,7 @@ class SingleFidelityScheduler(TrialScheduler):
         self.searcher.on_trial_result(trial.trial_id, config, metric)
         return SchedulerDecision.CONTINUE
 
-    def on_trial_complete(self, trial: Trial, result: Dict[str, Any]):
+    def on_trial_complete(self, trial: Trial, result: dict[str, Any]):
         """Notification for the completion of trial.
 
         Note that :meth:`on_trial_result` is called with the same result before.
@@ -112,7 +112,7 @@ class SingleFidelityScheduler(TrialScheduler):
         ]
         self.searcher.on_trial_complete(trial.trial_id, config, metric)
 
-    def metadata(self) -> Dict[str, Any]:
+    def metadata(self) -> dict[str, Any]:
         """
         :return: Metadata for the scheduler
         """
@@ -125,7 +125,7 @@ class SingleFidelityScheduler(TrialScheduler):
         metadata["metric_mode"] = self.metric_mode()
         return metadata
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return self.metrics
 
     def metric_mode(self) -> str:

--- a/syne_tune/optimizer/schedulers/single_objective_scheduler.py
+++ b/syne_tune/optimizer/schedulers/single_objective_scheduler.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any, Union
+from typing import Any
 import logging
 
 from syne_tune.optimizer.schedulers.searchers.single_objective_searcher import (
@@ -30,10 +30,10 @@ class SingleObjectiveScheduler(SingleFidelityScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        do_minimize: Optional[bool] = True,
-        searcher: Optional[Union[str, SingleObjectiveBaseSearcher]] = "random_search",
+        do_minimize: bool | None = True,
+        searcher: str | SingleObjectiveBaseSearcher | None = "random_search",
         random_seed: int = None,
         searcher_kwargs: dict = None,
     ):

--- a/syne_tune/optimizer/schedulers/smac_scheduler.py
+++ b/syne_tune/optimizer/schedulers/smac_scheduler.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, List, Dict, Any
+from typing import Any
 
 from ConfigSpace import Configuration
 from smac import Scenario, HyperparameterOptimizationFacade
@@ -20,7 +20,7 @@ from syne_tune.config_space import Domain, Integer, is_log_space, Float
 
 
 def to_smac_configspace(
-    config_space: Dict[str, Domain], random_seed: int
+    config_space: dict[str, Domain], random_seed: int
 ) -> CS.ConfigurationSpace:
     cs = CS.ConfigurationSpace(seed=random_seed)
     for hp_name, hp in config_space.items():
@@ -60,11 +60,11 @@ def to_smac_configspace(
 class SMACScheduler(TrialScheduler):
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        do_minimize: Optional[bool] = True,
+        do_minimize: bool | None = True,
         points_to_evaluate=None,
-        random_seed: Optional[int] = None,
+        random_seed: int | None = None,
     ):
         """
         Wrapper to SMAC3. Requires SMAC3 to be installed, see https://github.com/automl/SMAC3 for instructions.
@@ -110,7 +110,7 @@ class SMACScheduler(TrialScheduler):
         )
         self.trial_info = {}
 
-    def on_trial_complete(self, trial: Trial, result: Dict[str, Any]):
+    def on_trial_complete(self, trial: Trial, result: dict[str, Any]):
         info = self.trial_info[trial.trial_id]
         cost = result[self.metric]
         if not self.do_minimize:
@@ -123,7 +123,7 @@ class SMACScheduler(TrialScheduler):
             ),
         )
 
-    def suggest(self) -> Optional[TrialSuggestion]:
+    def suggest(self) -> TrialSuggestion | None:
         if self.points_to_evaluate:
             config = self.points_to_evaluate.pop()
             info = TrialInfo(
@@ -145,10 +145,10 @@ class SMACScheduler(TrialScheduler):
         # Avoid serialization issues with swig
         return None
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return [self.metric]
 
-    def metadata(self) -> Dict[str, Any]:
+    def metadata(self) -> dict[str, Any]:
         """
         :return: Metadata for the scheduler
         """

--- a/syne_tune/optimizer/schedulers/transfer_learning/__init__.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/__init__.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -24,9 +24,9 @@ class LegacyTransferLearningTaskEvaluations:
             (num_evals, num_seeds, num_fidelities, num_objectives)
     """
 
-    configuration_space: Dict
+    configuration_space: dict
     hyperparameters: pd.DataFrame
-    objectives_names: List[str]
+    objectives_names: list[str]
     objectives_evaluations: np.array
 
     def __post_init__(self):
@@ -56,7 +56,7 @@ class LegacyTransferLearningTaskEvaluations:
 
     def top_k_hyperparameter_configurations(
         self, k: int, mode: str, objective: str
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """
         Returns the best k hyperparameter configurations.
         :param k: The number of top hyperparameters to return.
@@ -83,9 +83,9 @@ class LegacyTransferLearningTaskEvaluations:
 class LegacyTransferLearningMixin:
     def __init__(
         self,
-        config_space: Dict,
-        transfer_learning_evaluations: Dict[str, LegacyTransferLearningTaskEvaluations],
-        metric_names: List[str],
+        config_space: dict,
+        transfer_learning_evaluations: dict[str, LegacyTransferLearningTaskEvaluations],
+        metric_names: list[str],
         **kwargs,
     ):
         """
@@ -104,9 +104,9 @@ class LegacyTransferLearningMixin:
 
     def _check_consistency(
         self,
-        config_space: Dict,
-        transfer_learning_evaluations: Dict[str, LegacyTransferLearningTaskEvaluations],
-        metric_names: List[str],
+        config_space: dict,
+        transfer_learning_evaluations: dict[str, LegacyTransferLearningTaskEvaluations],
+        metric_names: list[str],
     ):
         for task, evals in transfer_learning_evaluations.items():
             for key in config_space.keys():
@@ -119,16 +119,16 @@ class LegacyTransferLearningMixin:
                 f"evaluations objectives {evals.objectives_names}"
             )
 
-    def metric_names(self) -> List[str]:
+    def metric_names(self) -> list[str]:
         return self._metric_names
 
     def top_k_hyperparameter_configurations_per_task(
         self,
-        transfer_learning_evaluations: Dict[str, LegacyTransferLearningTaskEvaluations],
+        transfer_learning_evaluations: dict[str, LegacyTransferLearningTaskEvaluations],
         num_hyperparameters_per_task: int,
         mode: str,
         metric: str,
-    ) -> Dict[str, List[Dict[str, Any]]]:
+    ) -> dict[str, list[dict[str, Any]]]:
         """
         Returns the best hyperparameter configurations for each task.
         :param transfer_learning_evaluations: Set of candidates to choose from.

--- a/syne_tune/optimizer/schedulers/transfer_learning/bounding_box.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/bounding_box.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Dict, Callable, Optional, Any
+from typing import Any
+from collections.abc import Callable
 
 import pandas as pd
 
@@ -71,10 +72,10 @@ class BoundingBox(TransferLearningMixin, SingleObjectiveScheduler):
     def __init__(
         self,
         scheduler_fun: Callable[[dict, str, bool, int], SingleObjectiveScheduler],
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        transfer_learning_evaluations: Dict[str, TransferLearningTaskEvaluations],
-        do_minimize: Optional[bool] = True,
+        transfer_learning_evaluations: dict[str, TransferLearningTaskEvaluations],
+        do_minimize: bool | None = True,
         num_hyperparameters_per_task: int = 1,
         random_seed: int = None,
     ):
@@ -97,11 +98,11 @@ class BoundingBox(TransferLearningMixin, SingleObjectiveScheduler):
 
     def _compute_box(
         self,
-        config_space: Dict[str, Any],
-        transfer_learning_evaluations: Dict[str, TransferLearningTaskEvaluations],
+        config_space: dict[str, Any],
+        transfer_learning_evaluations: dict[str, TransferLearningTaskEvaluations],
         do_minimize: bool,
         num_hyperparameters_per_task: int,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         top_k_per_task = self.top_k_hyperparameter_configurations_per_task(
             transfer_learning_evaluations=transfer_learning_evaluations,
             num_hyperparameters_per_task=num_hyperparameters_per_task,
@@ -136,13 +137,13 @@ class BoundingBox(TransferLearningMixin, SingleObjectiveScheduler):
 
         return new_config_space
 
-    def suggest(self) -> Optional[TrialSuggestion]:
+    def suggest(self) -> TrialSuggestion | None:
         return self.scheduler.suggest()
 
     def on_trial_add(self, trial: Trial):
         self.scheduler.on_trial_add(trial)
 
-    def on_trial_complete(self, trial: Trial, result: Dict[str, Any]):
+    def on_trial_complete(self, trial: Trial, result: dict[str, Any]):
         self.scheduler.on_trial_complete(trial, result)
 
     def on_trial_remove(self, trial: Trial):
@@ -151,7 +152,7 @@ class BoundingBox(TransferLearningMixin, SingleObjectiveScheduler):
     def on_trial_error(self, trial: Trial):
         self.scheduler.on_trial_error(trial)
 
-    def on_trial_result(self, trial: Trial, result: Dict[str, Any]) -> str:
+    def on_trial_result(self, trial: Trial, result: dict[str, Any]) -> str:
         return self.scheduler.on_trial_result(trial, result)
 
     def metric_mode(self) -> str:

--- a/syne_tune/optimizer/schedulers/transfer_learning/quantile_based/normalization_transforms.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/quantile_based/normalization_transforms.py
@@ -1,5 +1,4 @@
 from functools import partial
-from typing import Optional
 
 from scipy import stats
 
@@ -15,7 +14,7 @@ class GaussianTransform:
     """
 
     def __init__(
-        self, y: np.array, random_state: Optional[np.random.RandomState] = None
+        self, y: np.array, random_state: np.random.RandomState | None = None
     ):
         assert y.ndim == 2
         self.dim = y.shape[1]
@@ -25,7 +24,7 @@ class GaussianTransform:
 
     @staticmethod
     def z_transform(
-        series, values_sorted, random_state: Optional[np.random.RandomState] = None
+        series, values_sorted, random_state: np.random.RandomState | None = None
     ):
         """
         :param series: shape (n, dim)
@@ -87,7 +86,7 @@ class StandardTransform:
         return z
 
 
-def from_string(name: str, random_state: Optional[np.random.RandomState] = None):
+def from_string(name: str, random_state: np.random.RandomState | None = None):
     assert name in ["standard", "gaussian"]
     mapping = {
         "standard": StandardTransform,

--- a/syne_tune/optimizer/schedulers/transfer_learning/quantile_based/normalization_transforms.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/quantile_based/normalization_transforms.py
@@ -13,9 +13,7 @@ class GaussianTransform:
      If none use lowest rank of duplicated values.
     """
 
-    def __init__(
-        self, y: np.array, random_state: np.random.RandomState | None = None
-    ):
+    def __init__(self, y: np.array, random_state: np.random.RandomState | None = None):
         assert y.ndim == 2
         self.dim = y.shape[1]
         self.sorted = y.copy()

--- a/syne_tune/optimizer/schedulers/transfer_learning/quantile_based/quantile_based_searcher.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/quantile_based/quantile_based_searcher.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Optional, Any, Tuple
+from typing import Any
 import numpy as np
 import xgboost
 from sklearn.model_selection import train_test_split
@@ -86,9 +86,9 @@ def eval_model(model_pipeline, X, y):
 def subsample(
     X: pd.DataFrame,
     y: np.array,
-    max_samples: Optional[int] = 10000,
+    max_samples: int | None = 10000,
     random_state: np.random.RandomState = None,
-) -> Tuple[pd.DataFrame, np.array]:
+) -> tuple[pd.DataFrame, np.array]:
     """
     Subsample both X and y with `max_samples` elements. If `max_samples` is not set then X and y are returned as such
     and if it is set, the index of X is reset.
@@ -134,8 +134,8 @@ class QuantileBasedSurrogateSearcher(SingleObjectiveBaseSearcher):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
-        transfer_learning_evaluations: Dict[str, TransferLearningTaskEvaluations],
+        config_space: dict[str, Any],
+        transfer_learning_evaluations: dict[str, TransferLearningTaskEvaluations],
         max_fit_samples: int = 100000,
         normalization: str = "gaussian",
         random_seed: int = None,
@@ -167,13 +167,13 @@ class QuantileBasedSurrogateSearcher(SingleObjectiveBaseSearcher):
                 self.mu_pred = self.mu_pred.reshape(-1, 1)
             self.sigma_pred = np.ones_like(self.mu_pred) * sigma_val
 
-    def _update(self, trial_id: str, config: Dict[str, Any], result: Dict[str, Any]):
+    def _update(self, trial_id: str, config: dict[str, Any], result: dict[str, Any]):
         pass
 
-    def clone_from_state(self, state: Dict[str, Any]):
+    def clone_from_state(self, state: dict[str, Any]):
         raise NotImplementedError
 
-    def suggest(self, **kwargs) -> Optional[Dict[str, Any]]:
+    def suggest(self, **kwargs) -> dict[str, Any] | None:
         samples = self.random_state.normal(loc=self.mu_pred, scale=self.sigma_pred)
         candidate = self.X_candidates.loc[np.argmin(samples)]
         return dict(candidate)

--- a/syne_tune/optimizer/schedulers/transfer_learning/transfer_learning_mixin.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/transfer_learning_mixin.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any
 
 from syne_tune.optimizer.schedulers.transfer_learning.transfer_learning_task_evaluation import (
     TransferLearningTaskEvaluations,
@@ -8,8 +8,8 @@ from syne_tune.optimizer.schedulers.transfer_learning.transfer_learning_task_eva
 class TransferLearningMixin:
     def __init__(
         self,
-        config_space: Dict,
-        transfer_learning_evaluations: Dict[str, TransferLearningTaskEvaluations],
+        config_space: dict,
+        transfer_learning_evaluations: dict[str, TransferLearningTaskEvaluations],
         metric: str,
         random_seed: int = None,
         **kwargs,
@@ -31,8 +31,8 @@ class TransferLearningMixin:
 
     def _check_consistency(
         self,
-        config_space: Dict,
-        transfer_learning_evaluations: Dict[str, TransferLearningTaskEvaluations],
+        config_space: dict,
+        transfer_learning_evaluations: dict[str, TransferLearningTaskEvaluations],
     ):
         for task, evals in transfer_learning_evaluations.items():
             for key in config_space.keys():
@@ -47,10 +47,10 @@ class TransferLearningMixin:
 
     def top_k_hyperparameter_configurations_per_task(
         self,
-        transfer_learning_evaluations: Dict[str, TransferLearningTaskEvaluations],
+        transfer_learning_evaluations: dict[str, TransferLearningTaskEvaluations],
         num_hyperparameters_per_task: int,
         do_minimize: bool = False,
-    ) -> Dict[str, List[Dict[str, Any]]]:
+    ) -> dict[str, list[dict[str, Any]]]:
         """
         Returns the best hyperparameter configurations for each task.
         :param transfer_learning_evaluations: Set of candidates to choose from.

--- a/syne_tune/optimizer/schedulers/transfer_learning/transfer_learning_task_evaluation.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/transfer_learning_task_evaluation.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -17,9 +17,9 @@ class TransferLearningTaskEvaluations:
             (num_evals, num_seeds, num_fidelities, num_objectives)
     """
 
-    configuration_space: Dict
+    configuration_space: dict
     hyperparameters: pd.DataFrame
-    objectives_names: List[str]
+    objectives_names: list[str]
     objectives_evaluations: np.array
 
     def __post_init__(self):
@@ -49,7 +49,7 @@ class TransferLearningTaskEvaluations:
 
     def top_k_hyperparameter_configurations(
         self, k: int, objective: str, do_minimize: bool = False
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """
         Returns the best k hyperparameter configurations.
         :param k: The number of top hyperparameters to return.

--- a/syne_tune/optimizer/schedulers/transfer_learning/zero_shot.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/zero_shot.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Optional, Any
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -47,10 +47,10 @@ class ZeroShotTransfer(TransferLearningMixin, SingleObjectiveScheduler):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
-        transfer_learning_evaluations: Dict[str, TransferLearningTaskEvaluations],
-        do_minimize: Optional[bool] = True,
+        transfer_learning_evaluations: dict[str, TransferLearningTaskEvaluations],
+        do_minimize: bool | None = True,
         sort_transfer_learning_evaluations: bool = True,
         use_surrogates: bool = False,
         random_seed: int = None,
@@ -111,10 +111,10 @@ class ZeroShotTransfer(TransferLearningMixin, SingleObjectiveScheduler):
 
     def _create_surrogate_transfer_learning_evaluations(
         self,
-        config_space: Dict[str, Any],
-        transfer_learning_evaluations: Dict[str, TransferLearningTaskEvaluations],
+        config_space: dict[str, Any],
+        transfer_learning_evaluations: dict[str, TransferLearningTaskEvaluations],
         metric: str,
-    ) -> Dict[str, TransferLearningTaskEvaluations]:
+    ) -> dict[str, TransferLearningTaskEvaluations]:
         """
         Creates transfer_learning_evaluations where each configuration is evaluated on each task using surrogate models.
         """
@@ -153,7 +153,7 @@ class ZeroShotTransfer(TransferLearningMixin, SingleObjectiveScheduler):
             )
         return surrogate_transfer_learning_evaluations
 
-    def get_config(self, **kwargs) -> Optional[dict]:
+    def get_config(self, **kwargs) -> dict | None:
         if self._ranks.shape[1] == 0:
             return None
         # Select greedy-best configuration considering all others
@@ -168,7 +168,7 @@ class ZeroShotTransfer(TransferLearningMixin, SingleObjectiveScheduler):
             self._ranks = self._update_ranks()
         return best_config.to_dict()
 
-    def _sample_random_config(self, config_space: Dict[str, Any]) -> Dict[str, Any]:
+    def _sample_random_config(self, config_space: dict[str, Any]) -> dict[str, Any]:
         return {
             k: v.sample(random_state=self.random_state) if isinstance(v, Domain) else v
             for k, v in config_space.items()
@@ -178,6 +178,6 @@ class ZeroShotTransfer(TransferLearningMixin, SingleObjectiveScheduler):
         return self._scores.rank(axis=1)
 
     def _update(
-        self, trial_id: str, config: Dict[str, Any], result: Dict[str, Any]
+        self, trial_id: str, config: dict[str, Any], result: dict[str, Any]
     ) -> None:
         pass

--- a/syne_tune/optimizer/schedulers/utils/simple_profiler.py
+++ b/syne_tune/optimizer/schedulers/utils/simple_profiler.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any
+from typing import Any
 import time
 import logging
 from dataclasses import dataclass
@@ -9,9 +9,9 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class ProfilingBlock:
-    meta: Dict[str, Any]
+    meta: dict[str, Any]
     time_stamp: float
-    durations: Dict[str, List[float]]
+    durations: dict[str, list[float]]
 
 
 class SimpleProfiler:
@@ -36,7 +36,7 @@ class SimpleProfiler:
         self.meta_keys = None
         self.prefix = ""
 
-    def begin_block(self, meta: Dict[str, Any]):
+    def begin_block(self, meta: dict[str, Any]):
         assert not self.start_time, "Timers for these tags still running:\n{}".format(
             self.start_time.keys()
         )
@@ -98,7 +98,7 @@ class SimpleProfiler:
             )
         self.start_time = dict()
 
-    def records_as_dict(self) -> Dict[str, Any]:
+    def records_as_dict(self) -> dict[str, Any]:
         """
         Return records as a dict of lists, can be converted into Pandas
         data-frame by:

--- a/syne_tune/optimizer/schedulers/utils/successive_halving.py
+++ b/syne_tune/optimizer/schedulers/utils/successive_halving.py
@@ -1,4 +1,3 @@
-from typing import Optional, List
 import logging
 import numpy as np
 
@@ -10,12 +9,12 @@ def _is_positive_int(x):
 
 
 def successive_halving_rung_levels(
-    rung_levels: Optional[List[int]],
+    rung_levels: list[int] | None,
     grace_period: int,
-    reduction_factor: Optional[float],
-    rung_increment: Optional[int],
+    reduction_factor: float | None,
+    rung_increment: int | None,
     max_t: int,
-) -> List[int]:
+) -> list[int]:
     """Creates ``rung_levels`` from ``grace_period``, ``reduction_factor``
 
     Note: If ``rung_levels`` is given and ``rung_levels[-1] == max_t``, we strip

--- a/syne_tune/report.py
+++ b/syne_tune/report.py
@@ -4,7 +4,7 @@ import re
 import sys
 from dataclasses import dataclass
 from time import time, perf_counter
-from typing import List, Dict, Any
+from typing import Any
 
 from syne_tune.constants import (
     ST_WORKER_TIME,
@@ -75,7 +75,7 @@ class Reporter:
         _report_logger(**kwargs)
 
     @staticmethod
-    def _check_reported_values(kwargs: Dict[str, Any]):
+    def _check_reported_values(kwargs: dict[str, Any]):
         assert all(
             v is not None for v in kwargs.values()
         ), f"Invalid value in report: kwargs = {kwargs}"
@@ -86,7 +86,7 @@ def _report_logger(**kwargs):
     sys.stdout.flush()
 
 
-def _serialize_report_dict(report_dict: Dict[str, Any]) -> str:
+def _serialize_report_dict(report_dict: dict[str, Any]) -> str:
     """
     :param report_dict: a dictionary of metrics to be serialized
     :return: serialized string of the reported metrics, an exception is raised if the size is too large or
@@ -106,7 +106,7 @@ def _serialize_report_dict(report_dict: Dict[str, Any]) -> str:
         raise e
 
 
-def retrieve(log_lines: List[str]) -> List[Dict[str, float]]:
+def retrieve(log_lines: list[str]) -> list[dict[str, float]]:
     """Retrieves metrics reported with :func:`_report_logger` given log lines.
 
     :param log_lines: Lines in log file to be scanned for metric reports

--- a/syne_tune/results_callback.py
+++ b/syne_tune/results_callback.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional, List
+from typing import Any
 from time import perf_counter
 import copy
 import pandas as pd
@@ -27,7 +27,7 @@ class ExtraResultsComposer:
     functions are not.
     """
 
-    def __call__(self, tuner) -> Optional[Dict[str, Any]]:
+    def __call__(self, tuner) -> dict[str, Any] | None:
         """
         Called in :meth:`StoreResultsCallback.on_trial_result`. The dictionary
         returned is appended (as extra columns) to the results dataframe.
@@ -39,7 +39,7 @@ class ExtraResultsComposer:
         """
         raise NotImplementedError
 
-    def keys(self) -> List[str]:
+    def keys(self) -> list[str]:
         """
         :return: Key names of dictionaries returned in :meth:`__call__`, or
             ``[]`` if nothing is returned
@@ -63,7 +63,7 @@ class StoreResultsCallback(TunerCallback):
     def __init__(
         self,
         add_wallclock_time: bool = True,
-        extra_results_composer: Optional[ExtraResultsComposer] = None,
+        extra_results_composer: ExtraResultsComposer | None = None,
     ):
         self.results = []
         self.csv_file = None
@@ -73,7 +73,7 @@ class StoreResultsCallback(TunerCallback):
         self._start_time_stamp = None
         self._tuner = None
 
-    def _set_time_fields(self, result: Dict[str, Any]):
+    def _set_time_fields(self, result: dict[str, Any]):
         """
         Note that we only add wallclock time to the result if this has not
         already been done (by the backend)
@@ -81,14 +81,14 @@ class StoreResultsCallback(TunerCallback):
         if self._start_time_stamp is not None and ST_TUNER_TIME not in result:
             result[ST_TUNER_TIME] = perf_counter() - self._start_time_stamp
 
-    def _append_extra_results(self, result: Dict[str, Any]):
+    def _append_extra_results(self, result: dict[str, Any]):
         if self._extra_results_composer is not None:
             extra_results = self._extra_results_composer(self._tuner)
             if extra_results is not None:
                 result.update(extra_results)
 
     def on_trial_result(
-        self, trial: Trial, status: str, result: Dict[str, Any], decision: str
+        self, trial: Trial, status: str, result: dict[str, Any], decision: str
     ):
         assert (
             self.save_results_at_frequency is not None

--- a/syne_tune/stopping_criterion.py
+++ b/syne_tune/stopping_criterion.py
@@ -2,7 +2,6 @@ import logging
 import numpy as np
 
 from dataclasses import dataclass
-from typing import Optional, Dict
 
 from syne_tune.tuning_status import TuningStatus
 
@@ -46,9 +45,9 @@ class StoppingCriterion:
     max_cost: float = None
     max_num_trials_finished: int = None
     # minimum value for metrics, any value below this threshold will trigger a stop
-    min_metric_value: Optional[Dict[str, float]] = None
+    min_metric_value: dict[str, float] | None = None
     # maximum value for metrics, any value above this threshold will trigger a stop
-    max_metric_value: Optional[Dict[str, float]] = None
+    max_metric_value: dict[str, float] | None = None
 
     # todo we should have unit-test for all those cases.
     def __call__(self, status: TuningStatus) -> bool:

--- a/syne_tune/stopping_criterions/automatic_termination_criterion.py
+++ b/syne_tune/stopping_criterions/automatic_termination_criterion.py
@@ -1,7 +1,7 @@
 import logging
 import numpy as np
 import torch
-from typing import List, Dict, Any
+from typing import Any
 
 from torch import Tensor
 from botorch.models import SingleTaskGP
@@ -52,7 +52,7 @@ class AutomaticTerminationCriterion(object):
 
     def __init__(
         self,
-        config_space: Dict[str, Any],
+        config_space: dict[str, Any],
         metric: str,
         threshold: float,
         mode: str = "min",
@@ -82,7 +82,7 @@ class AutomaticTerminationCriterion(object):
         else:
             self.multiplier = -1
 
-    def _config_to_feature_matrix(self, configs: List[dict]) -> Tensor:
+    def _config_to_feature_matrix(self, configs: list[dict]) -> Tensor:
         bounds = Tensor(self._hp_ranges.get_ndarray_bounds()).T
         X = Tensor(self._hp_ranges.to_ndarray_matrix(configs))
         return normalize(X, bounds)

--- a/syne_tune/tuner.py
+++ b/syne_tune/tuner.py
@@ -680,9 +680,7 @@ class Tuner:
         """
         return StoreResultsCallback()
 
-    def best_config(
-        self, metric: str | int | None = 0
-    ) -> tuple[int, dict[str, Any]]:
+    def best_config(self, metric: str | int | None = 0) -> tuple[int, dict[str, Any]]:
         """
         :param metric: Indicates which metric to use, can be the index or a name of the metric.
             default to 0 - first metric defined in the Scheduler

--- a/syne_tune/tuner_callback.py
+++ b/syne_tune/tuner_callback.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 
 from syne_tune.backend.trial_status import Trial
 from syne_tune.backend.trial_backend import (
@@ -56,7 +56,7 @@ class TunerCallback:
         """
         pass
 
-    def on_trial_complete(self, trial: Trial, result: Dict[str, Any]):
+    def on_trial_complete(self, trial: Trial, result: dict[str, Any]):
         """Called when a trial completes (``Status.completed``)
 
         The arguments here also have been passed to ``scheduler.on_trial_complete``,
@@ -68,7 +68,7 @@ class TunerCallback:
         pass
 
     def on_trial_result(
-        self, trial: Trial, status: str, result: Dict[str, Any], decision: str
+        self, trial: Trial, status: str, result: dict[str, Any], decision: str
     ):
         """Called when a new result (reported by a trial) is observed
 

--- a/syne_tune/tuning_status.py
+++ b/syne_tune/tuning_status.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Union, Set, Optional, Dict, Any
+from typing import Any
 import numbers
 import logging
 import time
@@ -30,7 +30,7 @@ class MetricsStatistics:
         self.last_metrics = dict()
         self.is_numeric = dict()
 
-    def add(self, metrics: Dict[str, Any]):
+    def add(self, metrics: dict[str, Any]):
         for metric_name, current_metric in metrics.items():
             if metric_name in self.is_numeric:
                 if self.is_numeric[metric_name] != isinstance(
@@ -67,7 +67,7 @@ class TuningStatus:
     """
 
     # TODO: ``metric_names`` not used for anything. Remove?
-    def __init__(self, metric_names: List[str]):
+    def __init__(self, metric_names: list[str]):
         self.metric_names = metric_names
         self.start_time = time.perf_counter()
 
@@ -138,7 +138,7 @@ class TuningStatus:
         """
         return len(self.last_trial_status_seen)
 
-    def _num_trials(self, status: Union[str, Set[str]]):
+    def _num_trials(self, status: str | set[str]):
         if isinstance(status, str):
             status = set([status])
         elif not isinstance(status, set):
@@ -251,8 +251,8 @@ class TuningStatus:
 
 
 def print_best_metric_found(
-    tuning_status: TuningStatus, metric_names: List[str], mode: Optional[str] = None
-) -> Optional[Tuple[int, float]]:
+    tuning_status: TuningStatus, metric_names: list[str], mode: str | None = None
+) -> tuple[int, float] | None:
     """Prints trial status summary and the best metric found.
 
     :param tuning_status: Current tuning status

--- a/syne_tune/util.py
+++ b/syne_tune/util.py
@@ -8,8 +8,8 @@ from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from time import perf_counter
-from typing import Optional, Dict, Any, Iterable
-from typing import Tuple, Union, List
+from typing import Any
+from collections.abc import Iterable
 
 import numpy as np
 
@@ -43,7 +43,7 @@ class RegularCallback:
 
 
 def experiment_path(
-    tuner_name: Optional[str] = None, local_path: Optional[str] = None
+    tuner_name: str | None = None, local_path: str | None = None
 ) -> Path:
     """
     Return the path of an experiment which is used both by :class:`~syne_tune.Tuner`
@@ -69,7 +69,7 @@ def experiment_path(
     return result_path
 
 
-def name_from_base(base: Optional[str], max_length: int = 63) -> str:
+def name_from_base(base: str | None, max_length: int = 63) -> str:
     """Append a timestamp to the provided string.
 
     This function assures that the total length of the resulting string is
@@ -143,7 +143,7 @@ def catchtime(name: str) -> float:
         print(f"Time for {name}: {perf_counter() - start:.4f} secs")
 
 
-def is_increasing(lst: List[Union[float, int]]) -> bool:
+def is_increasing(lst: list[float | int]) -> bool:
     """
     :param lst: List of float or int entries
     :return: Is ``lst`` strictly increasing?
@@ -151,7 +151,7 @@ def is_increasing(lst: List[Union[float, int]]) -> bool:
     return all(x < y for x, y in zip(lst, lst[1:]))
 
 
-def is_positive_integer(lst: List[int]) -> bool:
+def is_positive_integer(lst: list[int]) -> bool:
     """
     :param lst: List of int entries
     :return: Are all entries of ``lst`` of type ``int`` and positive?
@@ -168,8 +168,8 @@ def is_integer(lst: list) -> bool:
 
 
 def dump_json_with_numpy(
-    x: dict, filename: Optional[Union[str, Path]] = None
-) -> Optional[str]:
+    x: dict, filename: str | Path | None = None
+) -> str | None:
     """
     Serializes dictionary ``x`` in JSON, taking into account NumPy specific
     value types such as ``n.p.int64``.
@@ -192,7 +192,7 @@ def dump_json_with_numpy(
         return None
 
 
-def dict_get(params: Dict[str, Any], key: str, default: Any) -> Any:
+def dict_get(params: dict[str, Any], key: str, default: Any) -> Any:
     """
     Returns ``params[key]`` if this exists and is not None, and ``default`` otherwise.
     Note that this is not the same as ``params.get(key, default)``. Namely, if ``params[key]``
@@ -208,10 +208,10 @@ def dict_get(params: Dict[str, Any], key: str, default: Any) -> Any:
 
 
 def recursive_merge(
-    a: Dict[str, Any],
-    b: Dict[str, Any],
-    stop_keys: Optional[List[str]] = None,
-) -> Dict[str, Any]:
+    a: dict[str, Any],
+    b: dict[str, Any],
+    stop_keys: list[str] | None = None,
+) -> dict[str, Any]:
     """
     Merge dictionaries ``a`` and ``b``, where ``b`` takes precedence. We
     typically use this to modify a dictionary ``a``, so ``b`` is smaller
@@ -252,7 +252,7 @@ def recursive_merge(
         return a
 
 
-def find_first_of_type(a: Iterable[Any], typ) -> Optional[Any]:
+def find_first_of_type(a: Iterable[Any], typ) -> Any | None:
     try:
         return next(x for x in a if isinstance(x, typ))
     except StopIteration:
@@ -260,8 +260,8 @@ def find_first_of_type(a: Iterable[Any], typ) -> Optional[Any]:
 
 
 def metric_name_mode(
-    metric_names: List[str], metric_mode: Union[str, List[str]], metric: Union[str, int]
-) -> Tuple[str, str]:
+    metric_names: list[str], metric_mode: str | list[str], metric: str | int
+) -> tuple[str, str]:
     """
     Retrieve the metric mode given a metric queried by either index or name.
     :param metric_names: metrics names defined in a scheduler

--- a/syne_tune/util.py
+++ b/syne_tune/util.py
@@ -167,9 +167,7 @@ def is_integer(lst: list) -> bool:
     return all(x == int(x) for x in lst)
 
 
-def dump_json_with_numpy(
-    x: dict, filename: str | Path | None = None
-) -> str | None:
+def dump_json_with_numpy(x: dict, filename: str | Path | None = None) -> str | None:
     """
     Serializes dictionary ``x`` in JSON, taking into account NumPy specific
     value types such as ``n.p.int64``.

--- a/syne_tune/utils/checkpoint.py
+++ b/syne_tune/utils/checkpoint.py
@@ -1,4 +1,5 @@
-from typing import Callable, Any, Optional, Dict
+from typing import Any
+from collections.abc import Callable
 import argparse
 import os
 
@@ -17,7 +18,7 @@ def add_checkpointing_to_argparse(parser: argparse.ArgumentParser):
 
 
 def resume_from_checkpointed_model(
-    config: Dict[str, Any], load_model_fn: Callable[[str], int]
+    config: dict[str, Any], load_model_fn: Callable[[str], int]
 ) -> int:
     """
     Checks whether there is a checkpoint to be resumed from. If so, the
@@ -49,7 +50,7 @@ def resume_from_checkpointed_model(
 
 
 def checkpoint_model_at_rung_level(
-    config: Dict[str, Any], save_model_fn: Callable[[str, int], Any], resource: int
+    config: dict[str, Any], save_model_fn: Callable[[str, int], Any], resource: int
 ):
     """
     If checkpointing is supported, checks whether a checkpoint is to be
@@ -86,8 +87,8 @@ MUTABLE_STATE_PREFIX = "st_mutable_"
 
 
 def pytorch_load_save_functions(
-    state_dict_objects: Dict[str, Any],
-    mutable_state: Optional[dict] = None,
+    state_dict_objects: dict[str, Any],
+    mutable_state: dict | None = None,
     fname: str = "checkpoint.json",
 ):
     """

--- a/syne_tune/utils/config_as_json.py
+++ b/syne_tune/utils/config_as_json.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 import argparse
 import json
 
@@ -14,7 +14,7 @@ def add_config_json_to_argparse(parser: argparse.ArgumentParser):
     parser.add_argument(f"--{ST_CONFIG_JSON_FNAME_ARG}", type=str)
 
 
-def load_config_json(args: Dict[str, Any]) -> Dict[str, Any]:
+def load_config_json(args: dict[str, Any]) -> dict[str, Any]:
     """
     Loads configuration from JSON file and returns the union with ``args``.
 

--- a/syne_tune/utils/convert_domain.py
+++ b/syne_tune/utils/convert_domain.py
@@ -1,7 +1,7 @@
 # This file has been taken from Ray. The reason for reusing the file is to be able to support the same API when
 # defining search space while avoiding to have Ray as a required dependency. We may want to add functionality in the
 # future.
-from typing import Dict, Any, Union, Optional, List
+from typing import Any
 from numbers import Real
 import numpy as np
 import logging
@@ -24,7 +24,7 @@ from syne_tune.util import is_integer
 logger = logging.getLogger(__name__)
 
 
-def fit_to_regular_grid(x: np.ndarray) -> Dict[str, float]:
+def fit_to_regular_grid(x: np.ndarray) -> dict[str, float]:
     r"""
     Computes the least squares fit of :math:`a * j + b` to ``x[j]``, where
     :math:`j = 0,\dots, n-1`. Returns the LS estimate of ``a``, ``b``, and the
@@ -61,7 +61,7 @@ def _is_choice_domain(domain: Domain) -> bool:
     return isinstance(domain, Categorical)
 
 
-def convert_choice_domain(domain: Categorical, name: Optional[str] = None) -> Domain:
+def convert_choice_domain(domain: Categorical, name: str | None = None) -> Domain:
     """
     If the choice domain ``domain`` has more than 2 numerical values, it is
     converted to :func:`~syne_tune.config_space.finrange`,
@@ -133,7 +133,7 @@ UPPER_LOWER_RATIO_THRESHOLD = 100
 
 
 def convert_linear_to_log_domain(
-    domain: Union[Float, Integer], name: Optional[str] = None
+    domain: Float | Integer, name: str | None = None
 ) -> Domain:
     if is_log_space(domain) or domain.lower < POSITIVE_EPS:
         return domain
@@ -149,7 +149,7 @@ def convert_linear_to_log_domain(
     return result
 
 
-def convert_domain(domain: Domain, name: Optional[str] = None) -> Domain:
+def convert_domain(domain: Domain, name: str | None = None) -> Domain:
     """
     If one of the following rules apply, ``domain`` is converted and returned,
     otherwise it is returned as is.
@@ -179,10 +179,10 @@ def convert_domain(domain: Domain, name: Optional[str] = None) -> Domain:
 
 
 def streamline_config_space(
-    config_space: Dict[str, Any],
-    exclude_names: Optional[List[str]] = None,
+    config_space: dict[str, Any],
+    exclude_names: list[str] | None = None,
     verbose: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Given a configuration space ``config_space``, this function returns a new
     configuration space where some domains may have been replaced by approximately

--- a/tst/blackbox_repository/test_data_consistency.py
+++ b/tst/blackbox_repository/test_data_consistency.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Optional, List
 import pytest
 import numpy as np
 
@@ -20,8 +19,8 @@ class BenchmarkDefinition:
     blackbox_name: str
     dataset_name: str
     max_resource_attr: str
-    surrogate: Optional[str] = None
-    surrogate_kwargs: Optional[dict] = None
+    surrogate: str | None = None
+    surrogate_kwargs: dict | None = None
 
 
 def fcnet_benchmark(dataset_name):
@@ -108,7 +107,7 @@ def create_blackbox(benchmark: BenchmarkDefinition):
     return blackbox
 
 
-def _assert_strictly_increasing(elapsed_times: List[float], error_prefix: str):
+def _assert_strictly_increasing(elapsed_times: list[float], error_prefix: str):
     error_msg_parts = []
     for pos, (et1, et2) in enumerate(zip(elapsed_times[:-1], elapsed_times[1:])):
         if et1 >= et2:
@@ -120,7 +119,7 @@ def _assert_strictly_increasing(elapsed_times: List[float], error_prefix: str):
     assert not error_msg, error_msg
 
 
-def _assert_no_extreme_deviations(elapsed_times: List[float], error_prefix: str):
+def _assert_no_extreme_deviations(elapsed_times: list[float], error_prefix: str):
     pairs = list(zip(elapsed_times[:-1], elapsed_times[1:]))
     epoch_times = [et2 - et1 for et1, et2 in pairs]
     median_val = np.median(epoch_times)

--- a/tst/test_experiment_path.py
+++ b/tst/test_experiment_path.py
@@ -1,6 +1,5 @@
 import os
 from pathlib import Path
-from typing import Dict
 
 import pytest
 
@@ -34,7 +33,7 @@ from syne_tune.util import experiment_path
     ],
 )
 def test_experiment_path(
-    tuner_name: str, local_path: str, env: Dict, expected_path: str
+    tuner_name: str, local_path: str, env: dict, expected_path: str
 ):
     try:
         env_prev = os.environ.copy()

--- a/tst/trial_backend/test_fetch_results.py
+++ b/tst/trial_backend/test_fetch_results.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Optional, Any
+from typing import Any
 
 from syne_tune.backend.trial_backend import TrialBackend
 from syne_tune.backend.trial_status import TrialResult, Status
@@ -17,7 +17,7 @@ class DeterministicBackend(TrialBackend):
         self.timestamp = 0
 
     def generate_event(
-        self, trial_id: int, metrics: List[Dict], status: Optional[str] = None
+        self, trial_id: int, metrics: list[dict], status: str | None = None
     ):
         for m in metrics:
             m[ST_WORKER_TIMESTAMP] = self.timestamp
@@ -37,25 +37,25 @@ class DeterministicBackend(TrialBackend):
                 training_end_time=None,
             )
 
-    def _all_trial_results(self, trial_ids: List[int]) -> List[TrialResult]:
+    def _all_trial_results(self, trial_ids: list[int]) -> list[TrialResult]:
         return [self.trialid_to_results[trial_id] for trial_id in trial_ids]
 
     def _resume_trial(self, trial_id: int):
         pass
 
-    def _pause_trial(self, trial_id: int, result: Dict[str, Any]):
+    def _pause_trial(self, trial_id: int, result: dict[str, Any]):
         pass
 
-    def _stop_trial(self, trial_id: int, result: Dict[str, Any]):
+    def _stop_trial(self, trial_id: int, result: dict[str, Any]):
         pass
 
-    def _schedule(self, trial_id: int, config: Dict):
+    def _schedule(self, trial_id: int, config: dict):
         pass
 
-    def stdout(self, trial_id: int) -> List[str]:
+    def stdout(self, trial_id: int) -> list[str]:
         return []
 
-    def stderr(self, trial_id: int) -> List[str]:
+    def stderr(self, trial_id: int) -> list[str]:
         return []
 
 

--- a/tst/trial_backend/test_local_trial_backend.py
+++ b/tst/trial_backend/test_local_trial_backend.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Optional, List, Dict, Any
+from typing import Any
 
 import pytest
 
@@ -151,14 +151,14 @@ def test_start_config_previous_checkpoint(caplog):
     assert results == ["nothing", "nothing", "state-0", "state-1"]
 
 
-def _map_gpu(gpu: int, gpus_to_use: Optional[List[int]]) -> int:
+def _map_gpu(gpu: int, gpus_to_use: list[int] | None) -> int:
     return gpu if gpus_to_use is None else gpus_to_use[gpu]
 
 
 def _assert_cuda_visible_devices(
-    env: Dict[str, Any],
-    gpus_to_use: Optional[List[int]],
-    visible_devices: List[int],
+    env: dict[str, Any],
+    gpus_to_use: list[int] | None,
+    visible_devices: list[int],
 ):
     cuda_visible_devices = ",".join(
         str(_map_gpu(gpu, gpus_to_use)) for gpu in visible_devices

--- a/tst/trial_backend/test_simulator_trial_backend.py
+++ b/tst/trial_backend/test_simulator_trial_backend.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 import math
 import pytest
 
@@ -25,7 +25,7 @@ from syne_tune.optimizer.schedulers.asha import AsynchronousSuccessiveHalving
 from syne_tune.optimizer.scheduler import SchedulerDecision
 
 
-def _compare_results(res_local: Dict[str, Any], res_simul: Dict[str, Any], num: int):
+def _compare_results(res_local: dict[str, Any], res_simul: dict[str, Any], num: int):
     for key in (ST_TRIAL_ID, ST_DECISION, "epoch", "mean_loss"):
         rloc = res_local[key]
         rsim = res_simul[key]

--- a/tst/util_test.py
+++ b/tst/util_test.py
@@ -1,4 +1,3 @@
-from typing import Optional, Tuple
 import tempfile
 import time
 
@@ -33,7 +32,7 @@ from examples.training_scripts.height_example.blackbox_height import (
 class TestPredictor(SKLearnPredictor):
     def predict(
         self, X: np.ndarray, return_std: bool = True
-    ) -> Tuple[np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray]:
         nexamples = X.shape[0]
         return np.ones(nexamples), np.ones(nexamples)
 
@@ -73,7 +72,7 @@ def wait_until_all_trials_completed(backend):
 def run_experiment_with_height(
     make_scheduler: callable,
     simulated: bool,
-    config_space: Optional[dict] = None,
+    config_space: dict | None = None,
     **kwargs,
 ):
     random_seed = 382378624


### PR DESCRIPTION
Removes type imports which will deprecate in the future, like List, Dict, Set, Tuple and replaces them with native types. Changed imports of Callable, Iterator and Iterable to import from collections.abc. 

Replaced Optional and Union, as described [here](https://peps.python.org/pep-0604/)

Used this [article](https://medium.com/@anuraagkhare_39064/typing-module-deprecated-in-python-what-you-need-to-know-d4348b694141) as linked in the issue.

Closes [#880](https://github.com/syne-tune/syne-tune/issues/880).

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
