### PR TITLE
fix: infer noise level

### DIFF
--- a/benchmarking/baselines.py
+++ b/benchmarking/baselines.py
@@ -32,6 +32,7 @@ class Methods:
     TPE = "TPE"
     REA = "REA"
     BOTorch = "BOTorch"
+    BOTorch_fix_noise = "BOTorch_fix_noise"
     CQR = "CQR"
     BOHB = "BOHB"
 
@@ -80,7 +81,15 @@ methods = {
         metric=method_arguments.metric,
         do_minimize=method_arguments.mode == "min",
         random_seed=method_arguments.random_seed,
-        searcher_kwargs={"points_to_evaluate": method_arguments.points_to_evaluate},
+        searcher_kwargs={"points_to_evaluate": method_arguments.points_to_evaluate, 'noise_level': None},
+    ),
+    Methods.BOTorch_fix_noise: lambda method_arguments: SingleObjectiveScheduler(
+        config_space=method_arguments.config_space,
+        searcher="botorch",
+        metric=method_arguments.metric,
+        do_minimize=method_arguments.mode == "min",
+        random_seed=method_arguments.random_seed,
+        searcher_kwargs={"points_to_evaluate": method_arguments.points_to_evaluate, 'noise_level': 0},
     ),
     Methods.REA: lambda method_arguments: SingleObjectiveScheduler(
         config_space=method_arguments.config_space,

--- a/benchmarking/baselines.py
+++ b/benchmarking/baselines.py
@@ -81,15 +81,9 @@ methods = {
         metric=method_arguments.metric,
         do_minimize=method_arguments.mode == "min",
         random_seed=method_arguments.random_seed,
-        searcher_kwargs={"points_to_evaluate": method_arguments.points_to_evaluate, 'noise_level': None},
-    ),
-    Methods.BOTorch_fix_noise: lambda method_arguments: SingleObjectiveScheduler(
-        config_space=method_arguments.config_space,
-        searcher="botorch",
-        metric=method_arguments.metric,
-        do_minimize=method_arguments.mode == "min",
-        random_seed=method_arguments.random_seed,
-        searcher_kwargs={"points_to_evaluate": method_arguments.points_to_evaluate, 'noise_level': 0},
+        searcher_kwargs={
+            "points_to_evaluate": method_arguments.points_to_evaluate,
+        },
     ),
     Methods.REA: lambda method_arguments: SingleObjectiveScheduler(
         config_space=method_arguments.config_space,

--- a/benchmarking/baselines.py
+++ b/benchmarking/baselines.py
@@ -32,7 +32,6 @@ class Methods:
     TPE = "TPE"
     REA = "REA"
     BOTorch = "BOTorch"
-    BOTorch_fix_noise = "BOTorch_fix_noise"
     CQR = "CQR"
     BOHB = "BOHB"
 
@@ -81,9 +80,7 @@ methods = {
         metric=method_arguments.metric,
         do_minimize=method_arguments.mode == "min",
         random_seed=method_arguments.random_seed,
-        searcher_kwargs={
-            "points_to_evaluate": method_arguments.points_to_evaluate,
-        },
+        searcher_kwargs={"points_to_evaluate": method_arguments.points_to_evaluate},
     ),
     Methods.REA: lambda method_arguments: SingleObjectiveScheduler(
         config_space=method_arguments.config_space,

--- a/syne_tune/optimizer/schedulers/multiobjective/expected_hyper_volume_improvement.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/expected_hyper_volume_improvement.py
@@ -58,7 +58,6 @@ class ExpectedHyperVolumeImprovement(BaseSearcher):
     :param input_warping: Whether to apply input warping when fitting the GP.
         Defaults to ``True``
     :param double_precision: Whether to use double precision when fitting the GP.
-    :param noise_level: Standard deviation of Gaussian noise added to observations for numerical stability.
     :param num_raw_samples: Number of raw samples to use for initialization
         when optimizing the acquisition function. Defaults to 200
     :param num_restarts: Number of restarts to use when optimizing the
@@ -83,7 +82,6 @@ class ExpectedHyperVolumeImprovement(BaseSearcher):
         max_num_observations: int | None = 200,
         input_warping: bool = False,
         double_precision: bool = True,
-        noise_level: float = 1e-8,
         num_raw_samples: int = 200,
         num_restarts: int = 20,
         mc_samples: int = 128,
@@ -106,7 +104,6 @@ class ExpectedHyperVolumeImprovement(BaseSearcher):
         self.trial_observations = dict()
         self._hp_ranges = make_hyperparameter_ranges(config_space)
         self.double_precision = double_precision
-        self.noise_level = noise_level
         self.num_raw_samples = num_raw_samples
         self.num_restarts = num_restarts
         self.mc_samples = mc_samples
@@ -274,10 +271,9 @@ class ExpectedHyperVolumeImprovement(BaseSearcher):
         models = []
         for i in range(Y_tensor.shape[-1]):
             train_y = Y_tensor[..., i : i + 1]
-            noise_y = torch.full_like(train_y, self.noise_level)
 
             models.append(
-                SingleTaskGP(X_tensor, train_y, noise_y, input_transform=warp_tf)
+                SingleTaskGP(X_tensor, train_y, input_transform=warp_tf)
             )
         model = ModelListGP(*models)
         return model

--- a/syne_tune/optimizer/schedulers/multiobjective/expected_hyper_volume_improvement.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/expected_hyper_volume_improvement.py
@@ -272,9 +272,7 @@ class ExpectedHyperVolumeImprovement(BaseSearcher):
         for i in range(Y_tensor.shape[-1]):
             train_y = Y_tensor[..., i : i + 1]
 
-            models.append(
-                SingleTaskGP(X_tensor, train_y, input_transform=warp_tf)
-            )
+            models.append(SingleTaskGP(X_tensor, train_y, input_transform=warp_tf))
         model = ModelListGP(*models)
         return model
 

--- a/syne_tune/optimizer/schedulers/searchers/botorch/botorch_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/botorch/botorch_searcher.py
@@ -74,7 +74,7 @@ class BoTorchSearcher(SingleObjectiveBaseSearcher):
         max_num_observations: int | None = 200,
         input_warping: bool = False,
         double_precision: bool = True,
-        noise_level: float = 0,
+        noise_level: float | None = None,
         num_restarts: int = 20,
         optimization_strategy: str = "gradient",
         num_raw_samples: int = 200,
@@ -239,15 +239,20 @@ class BoTorchSearcher(SingleObjectiveBaseSearcher):
             X_tensor = X_tensor.double()
             Y_tensor = Y_tensor.double()
 
-        Y_noise = self.noise_level * randn_like(Y_tensor)
-
         if self.input_warping:
             warp_tf = Warp(indices=list(range(X_tensor.shape[-1])))
         else:
             warp_tf = None
-        return SingleTaskGP(
-            X_tensor, Y_tensor, train_Yvar=Y_noise, input_transform=warp_tf
-        )
+
+        if self.noise_level is None:
+            return SingleTaskGP(
+                X_tensor, Y_tensor, input_transform=warp_tf
+            )
+        else:
+            Y_noise = self.noise_level * randn_like(Y_tensor)
+            return SingleTaskGP(
+                X_tensor, Y_tensor, train_Yvar=Y_noise, input_transform=warp_tf
+            )
 
     def _config_to_feature_matrix(self, configs: list[dict]) -> Tensor:
         bounds = Tensor(self._hp_ranges.get_ndarray_bounds()).T

--- a/syne_tune/optimizer/schedulers/searchers/botorch/botorch_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/botorch/botorch_searcher.py
@@ -11,7 +11,7 @@ from syne_tune.optimizer.schedulers.searchers.utils import (
 )
 
 
-from torch import Tensor, random, randn_like, rand
+from torch import Tensor, random, rand
 from botorch.models import SingleTaskGP
 from botorch.fit import fit_gpytorch_mll
 from botorch.models.transforms import Warp

--- a/syne_tune/optimizer/schedulers/searchers/botorch/botorch_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/botorch/botorch_searcher.py
@@ -51,7 +51,6 @@ class BoTorchSearcher(SingleObjectiveBaseSearcher):
     :param input_warping: Whether to apply input warping when fitting the GP.
         Defaults to ``True``
     :param double_precision: Whether to use double precision when fitting the GP.
-    :param noise_level: Standard deviation of Gaussian noise added to observations for numerical stability.
     :param num_raw_samples: Number of raw samples to use for initialization
         when optimizing the acquisition function. Defaults to 200
     :param num_restarts: Number of restarts to use when optimizing the
@@ -74,7 +73,6 @@ class BoTorchSearcher(SingleObjectiveBaseSearcher):
         max_num_observations: int | None = 200,
         input_warping: bool = False,
         double_precision: bool = True,
-        noise_level: float | None = None,
         num_restarts: int = 20,
         optimization_strategy: str = "gradient",
         num_raw_samples: int = 200,
@@ -89,7 +87,6 @@ class BoTorchSearcher(SingleObjectiveBaseSearcher):
         self.max_num_observations = max_num_observations
         self.double_precision = double_precision
         self.input_warping = input_warping
-        self.noise_level = noise_level
         self.trial_configs = dict()
         self.pending_trials = set()
         self.trial_observations = dict()
@@ -244,15 +241,9 @@ class BoTorchSearcher(SingleObjectiveBaseSearcher):
         else:
             warp_tf = None
 
-        if self.noise_level is None:
-            return SingleTaskGP(
-                X_tensor, Y_tensor, input_transform=warp_tf
-            )
-        else:
-            Y_noise = self.noise_level * randn_like(Y_tensor)
-            return SingleTaskGP(
-                X_tensor, Y_tensor, train_Yvar=Y_noise, input_transform=warp_tf
-            )
+        return SingleTaskGP(
+            X_tensor, Y_tensor, input_transform=warp_tf
+        )
 
     def _config_to_feature_matrix(self, configs: list[dict]) -> Tensor:
         bounds = Tensor(self._hp_ranges.get_ndarray_bounds()).T

--- a/syne_tune/optimizer/schedulers/searchers/botorch/botorch_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/botorch/botorch_searcher.py
@@ -241,9 +241,7 @@ class BoTorchSearcher(SingleObjectiveBaseSearcher):
         else:
             warp_tf = None
 
-        return SingleTaskGP(
-            X_tensor, Y_tensor, input_transform=warp_tf
-        )
+        return SingleTaskGP(X_tensor, Y_tensor, input_transform=warp_tf)
 
     def _config_to_feature_matrix(self, configs: list[dict]) -> Tensor:
         bounds = Tensor(self._hp_ranges.get_ndarray_bounds()).T


### PR DESCRIPTION
Adding additional noise leads to a fixed noise level for the GP (see [here](https://botorch.readthedocs.io/en/stable/models.html#module-botorch.models.gp_regression)). If we don't pass it, we let BOTorch infer the noise level automatically. 

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
