### PR TITLE
fix: bump minimal python version to 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.8",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "numpy>=1.26.0, <3.0.0",
     "dill>=0.3.6",


### PR DESCRIPTION
uv fails on installation, see issue.

Closes #1038 .

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
