### PR TITLE
fix: fix import error in method_styles.py

### DIFF
--- a/benchmarking/results_analysis/method_styles.py
+++ b/benchmarking/results_analysis/method_styles.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib import cm
 
 rs_color = "black"
 gp_color = "tab:orange"
@@ -20,7 +19,7 @@ multifidelity_style2 = "dashdot"
 show_seeds = False
 marker_ours = "*"
 
-cmap = cm.get_cmap("viridis")
+cmap = plt.get_cmap("viridis")
 method_styles = {}
 
 

--- a/benchmarking/results_analysis/method_styles.py
+++ b/benchmarking/results_analysis/method_styles.py
@@ -51,15 +51,40 @@ plot_range = {
 }
 
 if __name__ == "__main__":
-    x = np.linspace(0, 1)
-    for i, (method, method_style) in enumerate(method_styles.items()):
+    method_styles = {
+        "Method A": {
+            "color": "tab:blue",
+            "linestyle": "solid",
+            "marker": "o",
+        },
+        "Method B": {
+            "color": "tab:orange",
+            "linestyle": "dashed",
+            "marker": "s",
+        },
+        "Method C": {
+            "color": "tab:green",
+            "linestyle": "dashdot",
+            "marker": "^",
+        },
+    }
+
+    x = np.linspace(0, 1, 100)
+
+    for i, (method, style) in enumerate(method_styles.items()):
         plt.plot(
             x,
             np.ones_like(x) * i,
             label=method,
-            color=method_style.color,
-            linestyle=method_style.linestyle,
-            marker=method_style.marker,
+            color=style["color"],
+            linestyle=style["linestyle"],
+            marker=style["marker"],
+            markevery=10,
         )
+
+    plt.xlabel("x")
+    plt.ylabel("Method")
+    plt.title("Method styles test")
     plt.legend()
+    plt.tight_layout()
     plt.show()

--- a/benchmarking/results_analysis/method_styles.py
+++ b/benchmarking/results_analysis/method_styles.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -19,7 +20,7 @@ multifidelity_style2 = "dashdot"
 show_seeds = False
 marker_ours = "*"
 
-cmap = plt.get_cmap("viridis")
+cmap = mpl.colormaps["viridis"]
 method_styles = {}
 
 


### PR DESCRIPTION
Currently throws an error, since `matplotlib.cm.get_cmap() `was deprecated in Matplotlib 3.7 and now is called via `matplotlib.colormap()`

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
