### PR TITLE
refactor: add benchmarking dependencies to pyproject.toml

### DIFF
--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -8,7 +8,7 @@ This repository shows an example of how to run a full evaluation: launching tuni
 
 Setup an environment by doing
 ```bash
-pip install -r benchmarking/requirements.txt
+pip install -e .[benchmarking,extra]
 ```
 
 Then run
@@ -40,7 +40,6 @@ sp --download YOURJOBNAME
 
 Note the path where the data is downloaded, you can then plot results with: 
 ```bash
-pip install pyparfor
 python benchmarking/results_analysis/show_results.py --path "~/slurmpilot/jobs/synetune/bench-2025-02-20-16-00-38/results" 
 ```
 after adapting `--path` to where the slurmpilot data was downloaded.

--- a/benchmarking/node_setup.sh
+++ b/benchmarking/node_setup.sh
@@ -1,1 +1,1 @@
-pip install -r requirements.txt
+pip install -e .[benchmarking,extra]

--- a/benchmarking/requirements.txt
+++ b/benchmarking/requirements.txt
@@ -1,8 +1,1 @@
-  numpy>=1.26.0, <3.0.0
-  coolname
-  pandas
-  huggingface-hub
-  scikit-learn
-  dill
-  syne-tune[blackbox-repository]
-  syne-tune[gpsearchers]
+-e .[benchmarking,extra]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
 ]
 requires-python = ">=3.9"
 dependencies = [
@@ -62,8 +62,13 @@ extra = [
     "botorch>=0.7.2",
     # moo
     "pymoo>=0.6.0",
-    "huggingface_hub",
-    "transformers",]
+    "transformers",
+]
+benchmarking = [
+    "slurmpilot",
+    "pyparfor",
+    "matplotlib",
+]
 vllm = [
     "vllm",
 ]


### PR DESCRIPTION
Moved benchmarking dependencies into `pyproject.toml`. I also updated the readme and requirements.txt in the benchmarking directory.

Also removed redundant` huggingface_hub` import in `pyproject.toml`

Correctly mentioned python version as 3.9, since we updated this.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
