### PR TITLE
fix: add environment marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ extra = [
     "huggingface_hub",
     "transformers",]
 vllm = [
-    "vllm",
+    "vllm; sys_platform != 'darwin'",
 ]
 
 [project.urls]


### PR DESCRIPTION
add an environment marker to `pyproject.toml `and `vllm`, since `uv sync` currently fails on Mac os due to vllm not being supported.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
